### PR TITLE
Fix SessionStart hook + add session backlinks to insights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **SessionStart hook output** — Added required `hookEventName: "SessionStart"` field to `obsidian_session_hint.py` JSON output. Claude Code silently drops `hookSpecificOutput` JSON that omits this field, causing the session hint to never appear at startup.
+- **SessionStart hook matcher** — Added explicit `matcher` field to `hooks.json` SessionStart entry for clarity (optional but documents intent).
+
+### Added
+
+- **Session backlinks in insights** — All insight-producing skills (`/compress`, `/error-log`, `/decide`) now derive the current session ID and include a `source_session_note` wikilink in frontmatter, enabling bidirectional navigation between session notes and insights in Obsidian's graph view.
+- **Session ID derivation** — Skills now detect the active session by finding the most recently modified `.jsonl` file in the Claude Code project directory, replacing the broken `$CLAUDE_SESSION_ID` environment variable approach.
+
+### Changed
+
+- **Templates updated** — `insight.md`, `error-fix.md`, and `decision.md` templates now include `source_session` and `source_session_note` frontmatter fields.
+
 ## [1.2.0] - 2026-04-04
 
 ### Added

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -12,6 +12,7 @@
     ],
     "SessionStart": [
       {
+        "matcher": "startup|resume|clear|compact",
         "hooks": [
           {
             "type": "command",

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -69,7 +69,7 @@ def _run() -> None:
         f"Obsidian context: Last session for {project} ({latest['date']}): "
         f"{latest['summary']} Next steps: {latest['next_steps']}"
     )
-    output = {"hookSpecificOutput": {"additionalContext": hint}}
+    output = {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": hint}}
 
     try:
         print(json.dumps(output))

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -128,7 +128,7 @@ Where:
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
   SESSION_NOTE=$(ls $VAULT_PATH/$SESSIONS_FOLDER/*-$HASH.md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
   ```
-  If the session ID can't be derived, use `unknown` for `source_session` and omit the `source_session_note` field entirely. If the session note file doesn't exist yet (current session hasn't ended), still include `source_session` but omit `source_session_note`.
+  If the session ID can't be derived, use `unknown` for `source_session` and omit the `source_session_note` field entirely. If the session note file doesn't exist yet (current session hasn't ended), construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian shows unresolved wikilinks as greyed out, and they auto-resolve once the session note is created at session end.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
 - The `source_session_note` field creates an Obsidian backlink from the insight to its source session, enabling bidirectional navigation in the graph view
 

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -29,7 +29,7 @@ If the file does not exist or is invalid JSON, tell the user:
 
 Stop here if config is missing.
 
-Parse the JSON and extract `vault_path` and `insights_folder`. Store them as `VAULT_PATH` and `INSIGHTS_FOLDER` (default `claude-insights`).
+Parse the JSON and extract `vault_path`, `insights_folder`, and `sessions_folder`. Store them as `VAULT_PATH`, `INSIGHTS_FOLDER` (default `claude-insights`), and `SESSIONS_FOLDER` (default `claude-sessions`).
 
 ### Step 2 — Validate vault access
 
@@ -126,7 +126,7 @@ Where:
   Then derive the 4-char hash and find the matching session note in the vault:
   ```bash
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
-  SESSION_NOTE=$(ls $VAULT_PATH/$SESSIONS_FOLDER/*-$HASH.md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
+  SESSION_NOTE=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
   ```
   If the session ID can't be derived, use `unknown` for `source_session` and omit the `source_session_note` field entirely. If the session note file doesn't exist yet (current session hasn't ended), construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian shows unresolved wikilinks as greyed out, and they auto-resolve once the session note is created at session end.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -123,12 +123,14 @@ Where:
   ```bash
   SESSION_ID=$(ls -t ~/.claude/projects/*"$(basename "$PWD")"/*.jsonl 2>/dev/null | head -1 | xargs -I{} basename {} .jsonl)
   ```
-  Then derive the 4-char hash and find the matching session note in the vault:
+  **Important:** If `SESSION_ID` is empty (glob matched nothing), use `unknown` for `source_session` and omit `source_session_note` entirely. Do NOT proceed to hash derivation with an empty string.
+
+  If `SESSION_ID` is non-empty, derive the 4-char hash and find the matching session note:
   ```bash
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
   SESSION_NOTE=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
   ```
-  If the session ID can't be derived, use `unknown` for `source_session` and omit the `source_session_note` field entirely. If the session note file doesn't exist yet (current session hasn't ended), construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian shows unresolved wikilinks as greyed out, and they auto-resolve once the session note is created at session end.
+  If the session note file doesn't exist yet (current session hasn't ended), construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian shows unresolved wikilinks as greyed out, and they auto-resolve once the session note is created at session end.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
 - The `source_session_note` field creates an Obsidian backlink from the insight to its source session, enabling bidirectional navigation in the graph view
 

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -103,6 +103,7 @@ Present the full note to the user including frontmatter:
 type: claude-insight
 date: YYYY-MM-DD
 source_session: <current-session-id>
+source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
 tags:
   - claude/insight
@@ -118,8 +119,18 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
-- `<current-session-id>` is extracted from the environment variable `CLAUDE_SESSION_ID` if available, otherwise use `unknown`
+- `<current-session-id>` and `<session-note-filename>` are derived together. First, get the session ID by finding the most recently modified `.jsonl` file:
+  ```bash
+  SESSION_ID=$(ls -t ~/.claude/projects/*"$(basename "$PWD")"/*.jsonl 2>/dev/null | head -1 | xargs -I{} basename {} .jsonl)
+  ```
+  Then derive the 4-char hash and find the matching session note in the vault:
+  ```bash
+  HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
+  SESSION_NOTE=$(ls $VAULT_PATH/$SESSIONS_FOLDER/*-$HASH.md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
+  ```
+  If the session ID can't be derived, use `unknown` for `source_session` and omit the `source_session_note` field entirely. If the session note file doesn't exist yet (current session hasn't ended), still include `source_session` but omit `source_session_note`.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
+- The `source_session_note` field creates an Obsidian backlink from the insight to its source session, enabling bidirectional navigation in the graph view
 
 Ask the user:
 

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -128,7 +128,12 @@ Where:
   If `SESSION_ID` is non-empty, derive the 4-char hash and find the matching session note:
   ```bash
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
-  SESSION_NOTE=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
+  SESSION_NOTE_PATH=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1)
+  if [ -n "$SESSION_NOTE_PATH" ]; then
+    SESSION_NOTE=$(basename "$SESSION_NOTE_PATH" .md)
+  else
+    SESSION_NOTE=
+  fi
   ```
   If the session note file doesn't exist yet (current session hasn't ended), construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian shows unresolved wikilinks as greyed out, and they auto-resolve once the session note is created at session end.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -90,6 +90,8 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-decision
 date: YYYY-MM-DD
+source_session: <current-session-id>
+source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
 status: active
 tags:
@@ -128,7 +130,18 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<current-session-id>` and `<session-note-filename>` are derived together. First, get the session ID by finding the most recently modified `.jsonl` file:
+  ```bash
+  SESSION_ID=$(ls -t ~/.claude/projects/*"$(basename "$PWD")"/*.jsonl 2>/dev/null | head -1 | xargs -I{} basename {} .jsonl)
+  ```
+  Then derive the 4-char hash and find the matching session note in the vault:
+  ```bash
+  HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
+  SESSION_NOTE=$(ls $VAULT_PATH/$SESSIONS_FOLDER/*-$HASH.md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
+  ```
+  If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, include `source_session` but omit `source_session_note`.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
+- The `source_session_note` field creates an Obsidian backlink to the source session note
 
 Ask the user:
 

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -139,7 +139,12 @@ Where:
   If `SESSION_ID` is non-empty, derive the 4-char hash and find the matching session note:
   ```bash
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
-  SESSION_NOTE=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
+  SESSION_NOTE_PATH=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1)
+  if [ -n "$SESSION_NOTE_PATH" ]; then
+    SESSION_NOTE=$(basename "$SESSION_NOTE_PATH" .md)
+  else
+    SESSION_NOTE=
+  fi
   ```
   If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -134,12 +134,14 @@ Where:
   ```bash
   SESSION_ID=$(ls -t ~/.claude/projects/*"$(basename "$PWD")"/*.jsonl 2>/dev/null | head -1 | xargs -I{} basename {} .jsonl)
   ```
-  Then derive the 4-char hash and find the matching session note in the vault:
+  **Important:** If `SESSION_ID` is empty (glob matched nothing), use `unknown` for `source_session` and omit `source_session_note` entirely. Do NOT proceed to hash derivation with an empty string.
+
+  If `SESSION_ID` is non-empty, derive the 4-char hash and find the matching session note:
   ```bash
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
   SESSION_NOTE=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
   ```
-  If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
+  If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
 - The `source_session_note` field creates an Obsidian backlink to the source session note
 

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -139,7 +139,7 @@ Where:
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
   SESSION_NOTE=$(ls $VAULT_PATH/$SESSIONS_FOLDER/*-$HASH.md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
   ```
-  If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, include `source_session` but omit `source_session_note`.
+  If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
 - The `source_session_note` field creates an Obsidian backlink to the source session note
 

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -29,7 +29,7 @@ If the file does not exist or is invalid JSON, tell the user:
 
 Stop here if config is missing.
 
-Parse the JSON and extract `vault_path` and `insights_folder`. Store them as `VAULT_PATH` and `INSIGHTS_FOLDER` (default `claude-insights`).
+Parse the JSON and extract `vault_path`, `insights_folder`, and `sessions_folder`. Store them as `VAULT_PATH`, `INSIGHTS_FOLDER` (default `claude-insights`), and `SESSIONS_FOLDER` (default `claude-sessions`).
 
 ### Step 2 — Validate vault access
 
@@ -137,7 +137,7 @@ Where:
   Then derive the 4-char hash and find the matching session note in the vault:
   ```bash
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
-  SESSION_NOTE=$(ls $VAULT_PATH/$SESSIONS_FOLDER/*-$HASH.md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
+  SESSION_NOTE=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
   ```
   If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)

--- a/skills/error-log/SKILL.md
+++ b/skills/error-log/SKILL.md
@@ -88,6 +88,8 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-error-fix
 date: YYYY-MM-DD
+source_session: <current-session-id>
+source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
 tags:
   - claude/error-fix
@@ -117,8 +119,19 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<current-session-id>` and `<session-note-filename>` are derived together. First, get the session ID by finding the most recently modified `.jsonl` file:
+  ```bash
+  SESSION_ID=$(ls -t ~/.claude/projects/*"$(basename "$PWD")"/*.jsonl 2>/dev/null | head -1 | xargs -I{} basename {} .jsonl)
+  ```
+  Then derive the 4-char hash and find the matching session note in the vault:
+  ```bash
+  HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
+  SESSION_NOTE=$(ls $VAULT_PATH/$SESSIONS_FOLDER/*-$HASH.md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
+  ```
+  If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, include `source_session` but omit `source_session_note`.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
 - `<Error Title>` is a short, descriptive title for the error (e.g. "BrokenPipeError when piping subprocess output to head")
+- The `source_session_note` field creates an Obsidian backlink to the source session note
 
 Ask the user:
 

--- a/skills/error-log/SKILL.md
+++ b/skills/error-log/SKILL.md
@@ -29,7 +29,7 @@ If the file does not exist or is invalid JSON, tell the user:
 
 Stop here if config is missing.
 
-Parse the JSON and extract `vault_path` and `insights_folder`. Store them as `VAULT_PATH` and `INSIGHTS_FOLDER` (default `claude-insights`).
+Parse the JSON and extract `vault_path`, `insights_folder`, and `sessions_folder`. Store them as `VAULT_PATH`, `INSIGHTS_FOLDER` (default `claude-insights`), and `SESSIONS_FOLDER` (default `claude-sessions`).
 
 ### Step 2 — Validate vault access
 
@@ -126,7 +126,7 @@ Where:
   Then derive the 4-char hash and find the matching session note in the vault:
   ```bash
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
-  SESSION_NOTE=$(ls $VAULT_PATH/$SESSIONS_FOLDER/*-$HASH.md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
+  SESSION_NOTE=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
   ```
   If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)

--- a/skills/error-log/SKILL.md
+++ b/skills/error-log/SKILL.md
@@ -128,7 +128,7 @@ Where:
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
   SESSION_NOTE=$(ls $VAULT_PATH/$SESSIONS_FOLDER/*-$HASH.md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
   ```
-  If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, include `source_session` but omit `source_session_note`.
+  If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
 - `<Error Title>` is a short, descriptive title for the error (e.g. "BrokenPipeError when piping subprocess output to head")
 - The `source_session_note` field creates an Obsidian backlink to the source session note

--- a/skills/error-log/SKILL.md
+++ b/skills/error-log/SKILL.md
@@ -123,12 +123,14 @@ Where:
   ```bash
   SESSION_ID=$(ls -t ~/.claude/projects/*"$(basename "$PWD")"/*.jsonl 2>/dev/null | head -1 | xargs -I{} basename {} .jsonl)
   ```
-  Then derive the 4-char hash and find the matching session note in the vault:
+  **Important:** If `SESSION_ID` is empty (glob matched nothing), use `unknown` for `source_session` and omit `source_session_note` entirely. Do NOT proceed to hash derivation with an empty string.
+
+  If `SESSION_ID` is non-empty, derive the 4-char hash and find the matching session note:
   ```bash
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
   SESSION_NOTE=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
   ```
-  If the session ID can't be derived, use `unknown` for `source_session` and omit `source_session_note`. If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
+  If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
 - `<Error Title>` is a short, descriptive title for the error (e.g. "BrokenPipeError when piping subprocess output to head")
 - The `source_session_note` field creates an Obsidian backlink to the source session note

--- a/skills/error-log/SKILL.md
+++ b/skills/error-log/SKILL.md
@@ -128,7 +128,12 @@ Where:
   If `SESSION_ID` is non-empty, derive the 4-char hash and find the matching session note:
   ```bash
   HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
-  SESSION_NOTE=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1 | xargs basename 2>/dev/null | sed 's/\.md$//')
+  SESSION_NOTE_PATH=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1)
+  if [ -n "$SESSION_NOTE_PATH" ]; then
+    SESSION_NOTE=$(basename "$SESSION_NOTE_PATH" .md)
+  else
+    SESSION_NOTE=
+  fi
   ```
   If the session note doesn't exist yet, construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian auto-resolves unresolved wikilinks once the target note is created.
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)

--- a/templates/decision.md
+++ b/templates/decision.md
@@ -1,6 +1,8 @@
 ---
 type: claude-decision
 date: {{date}}
+source_session: {{source_session}}
+source_session_note: "[[{{source_session_note}}]]"
 project: {{project}}
 status: active
 tags:

--- a/templates/decision.md
+++ b/templates/decision.md
@@ -2,7 +2,7 @@
 type: claude-decision
 date: {{date}}
 source_session: {{source_session}}
-source_session_note: "[[{{source_session_note}}]]"
+source_session_note: "{{source_session_note}}"
 project: {{project}}
 status: active
 tags:

--- a/templates/error-fix.md
+++ b/templates/error-fix.md
@@ -1,6 +1,8 @@
 ---
 type: claude-error-fix
 date: {{date}}
+source_session: {{source_session}}
+source_session_note: "[[{{source_session_note}}]]"
 project: {{project}}
 tags:
   - claude/error-fix

--- a/templates/error-fix.md
+++ b/templates/error-fix.md
@@ -2,7 +2,7 @@
 type: claude-error-fix
 date: {{date}}
 source_session: {{source_session}}
-source_session_note: "[[{{source_session_note}}]]"
+source_session_note: "{{source_session_note}}"
 project: {{project}}
 tags:
   - claude/error-fix

--- a/templates/insight.md
+++ b/templates/insight.md
@@ -2,6 +2,7 @@
 type: claude-insight
 date: {{date}}
 source_session: {{source_session}}
+source_session_note: "[[{{source_session_note}}]]"
 project: {{project}}
 tags:
   - claude/insight

--- a/templates/insight.md
+++ b/templates/insight.md
@@ -2,7 +2,7 @@
 type: claude-insight
 date: {{date}}
 source_session: {{source_session}}
-source_session_note: "[[{{source_session_note}}]]"
+source_session_note: "{{source_session_note}}"
 project: {{project}}
 tags:
   - claude/insight


### PR DESCRIPTION
## Summary

- **Fix SessionStart hook** — Added required `hookEventName: "SessionStart"` to `obsidian_session_hint.py` JSON output. Claude Code silently drops `hookSpecificOutput` without this field, which caused the session hint to never appear at startup despite the hook running successfully.
- **Add session backlinks** — All insight-producing skills (`/compress`, `/error-log`, `/decide`) now derive the active session ID from the most recently modified `.jsonl` file and include a `source_session_note` wikilink in frontmatter. This enables bidirectional navigation between sessions and insights in Obsidian's graph view.
- **Update templates** — `insight.md`, `error-fix.md`, and `decision.md` templates include `source_session` and `source_session_note` fields.

### Root cause (SessionStart fix)

This bug took 3 debugging sessions to fully resolve:
1. Session 1 incorrectly attributed the failure to a missing `matcher` field in `hooks.json`
2. Session 2 found the real code fix (`hookEventName`) but only deployed to the plugin cache
3. Session 3 discovered `${CLAUDE_PLUGIN_ROOT}` resolves to the marketplace directory, not cache — deployed fix to the correct location

### Session ID derivation

`CLAUDE_SESSION_ID` env var doesn't exist at runtime. The new approach finds the most recently modified `.jsonl` in `~/.claude/projects/*<project>/*.jsonl` and derives the session note filename via `sha256(session_id)[:4]` hash — the same algorithm used by `obsidian_utils.py`.

## Files changed

| File | Change |
|------|--------|
| `hooks/obsidian_session_hint.py` | Added `hookEventName` to output JSON |
| `hooks/hooks.json` | Added explicit `matcher` field (optional, for clarity) |
| `skills/compress/SKILL.md` | Session ID derivation + backlink |
| `skills/error-log/SKILL.md` | Session ID derivation + backlink |
| `skills/decide/SKILL.md` | Session ID derivation + backlink |
| `templates/insight.md` | Added `source_session_note` field |
| `templates/error-fix.md` | Added `source_session` + `source_session_note` fields |
| `templates/decision.md` | Added `source_session` + `source_session_note` fields |
| `CHANGELOG.md` | Documented all changes under `[Unreleased]` |

## Test plan

- [x] Verified SessionStart hook output appears in system reminders at startup
- [x] Verified session ID derivation returns correct UUID for current session
- [x] Verified `sha256(session_id)[:4]` hash matches existing session note filenames
- [x] Verified `/compress` produces `source_session_note` wikilink in frontmatter
- [ ] Verify `/error-log` and `/decide` produce backlinks (manual test needed)
- [ ] Verify Obsidian graph view shows bidirectional links between sessions and insights

🤖 Generated with [Claude Code](https://claude.com/claude-code)