### PR TITLE
feat: Phase 2a — 4 new skills + 2 dashboards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "obsidian-brain",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-04-05
+
+### Added
+
+- `/standup` skill: daily/weekly summary generation across projects with AI summarization, context-shield deep reads, and source note backlinks
+- `/link` skill: cross-reference related notes with bidirectional wikilinks and auto-suggestion
+- `/retro` skill: honest session retrospective for meta-learning with session backlinks
+- `/vault-ask` skill: synthesize answers from vault knowledge with source citations and relevance ranking
+- Learning Velocity dashboard: topic frequency from curated insights, retrospective history, error patterns
+- Decision Timeline dashboard: chronological decision tracking with active/superseded status views
+
 ## [1.3.0] - 2026-04-05
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Machine-local config at `~/.claude/obsidian-brain-config.json` (outside the vaul
 
 ### Tag convention
 
-All frontmatter tags use the `claude/` prefix: `claude/session`, `claude/insight`, `claude/decision`, `claude/error-fix`, `claude/snapshot`, `claude/imported`, `claude/project/<name>`, `claude/topic/<topic>`, `claude/auto`.
+All frontmatter tags use the `claude/` prefix: `claude/session`, `claude/insight`, `claude/decision`, `claude/error-fix`, `claude/snapshot`, `claude/imported`, `claude/standup`, `claude/retro`, `claude/project/<name>`, `claude/topic/<topic>`, `claude/auto`.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ CC Session Lifecycle
     |-- /compress ----> You curate & save specific insights
     |-- /recall ------> Loads project context from vault
     |-- /vault-search > Searches across all sessions & insights
+    |-- /standup -----> Generates daily/weekly project summaries
+    |-- /link --------> Cross-references notes with wikilinks
+    |-- /retro -------> Session retrospective & process improvements
+    |-- /vault-ask ---> Synthesized answers from vault knowledge
     +-- SessionEnd ---> Auto-logs session to vault
 ```
 
@@ -70,6 +74,10 @@ Run `/obsidian-setup` after installation. It will:
 | `/decide` | Log architectural decisions (ADR-lite format) |
 | `/error-log` | Capture error + root cause + fix for future reference |
 | `/vault-import` | Backfill historical sessions (requires `/conversation-search` and `/context-shield`) |
+| `/standup` | Generate daily/weekly summary across projects |
+| `/link` | Cross-reference related notes with bidirectional wikilinks |
+| `/retro` | Session retrospective — what worked, what didn't, process improvements |
+| `/vault-ask` | Ask questions and get synthesized answers grounded in vault history |
 
 ### Usage Examples
 
@@ -93,6 +101,24 @@ Run `/obsidian-setup` after installation. It will:
 
 # Import last 30 days of sessions into vault
 /vault-import 30d
+
+# Generate today's standup
+/standup
+
+# Weekly summary
+/standup this week
+
+# Auto-suggest note connections
+/link
+
+# Link specific notes
+/link this session to the redis decision
+
+# Session retrospective
+/retro
+
+# Ask a question across all vault history
+/vault-ask what patterns have I used for error handling?
 ```
 
 ## Auto-Logging
@@ -164,12 +190,14 @@ Contains Obsidian Dataview dashboard templates that auto-update as notes are add
 | Decision | `claude/decision` | `/decide` |
 | Error Fix | `claude/error-fix` | `/error-log` |
 | Imported Session | `claude/imported` | `/vault-import` |
+| Standup | `claude/standup` | `/standup` |
+| Retrospective | `claude/retro` | `/retro` |
 
 ### Tag Convention
 
 All tags use the `claude/` prefix to separate from your existing vault tags:
 
-- `claude/session`, `claude/insight`, `claude/decision`, `claude/error-fix`, `claude/snapshot`
+- `claude/session`, `claude/insight`, `claude/decision`, `claude/error-fix`, `claude/snapshot`, `claude/standup`, `claude/retro`
 - `claude/project/<name>` — project scoping
 - `claude/topic/<topic>` — domain/technology tags
 - `claude/auto` — auto-generated content
@@ -177,11 +205,13 @@ All tags use the `claude/` prefix to separate from your existing vault tags:
 
 ## Dataview Dashboards
 
-Three dashboard templates are installed to `claude-dashboards/`:
+Five dashboard templates are installed to `claude-dashboards/`:
 
 - **Sessions Overview** — recent sessions, insights, and active decisions across all projects
 - **Project Index** — sessions grouped by project with counts and date ranges
 - **Weekly Review** — this week's activity
+- **Learning Velocity** — topic frequency from curated insights, recent retrospectives, and error patterns
+- **Decision Timeline** — chronological view of all decisions with active/superseded status tracking
 
 These use [Dataview](https://github.com/blacksmithgu/obsidian-dataview) queries that auto-update as new notes are added.
 

--- a/dashboards/decision-timeline.md
+++ b/dashboards/decision-timeline.md
@@ -1,0 +1,34 @@
+# Decision Timeline
+
+## Active Decisions
+```dataview
+TABLE date, project
+FROM "claude-insights"
+WHERE type = "claude-decision" AND status = "active"
+SORT date DESC
+```
+
+## All Decisions (Chronological)
+```dataview
+TABLE date, project, status
+FROM "claude-insights"
+WHERE type = "claude-decision"
+SORT date DESC
+```
+
+## Superseded Decisions
+```dataview
+TABLE date, project
+FROM "claude-insights"
+WHERE type = "claude-decision" AND status = "superseded"
+SORT date DESC
+```
+
+## Decisions by Project
+```dataview
+TABLE length(rows) AS "Decisions", min(rows.date) AS "First", max(rows.date) AS "Last"
+FROM "claude-insights"
+WHERE type = "claude-decision"
+GROUP BY project
+SORT length(rows) DESC
+```

--- a/dashboards/learning-velocity.md
+++ b/dashboards/learning-velocity.md
@@ -1,0 +1,61 @@
+# Learning Velocity
+
+## Topics by Frequency
+```dataviewjs
+let pages = dv.pages('"claude-insights"')
+    .where(p => p.tags);
+
+let topics = {};
+for (let p of pages) {
+    let tags = p.tags || [];
+    if (!Array.isArray(tags)) tags = [tags];
+    for (let tag of tags) {
+        if (typeof tag === 'string' && tag.startsWith("claude/topic/")) {
+            let topic = tag.replace("claude/topic/", "");
+            topics[topic] = (topics[topic] || 0) + 1;
+        }
+    }
+}
+
+dv.table(
+    ["Topic", "Notes"],
+    Object.entries(topics)
+        .sort((a, b) => b[1] - a[1])
+        .map(([topic, count]) => [topic, count])
+);
+```
+
+## Recent Retrospectives
+```dataview
+TABLE date, project
+FROM "claude-insights"
+WHERE type = "claude-retro"
+SORT date DESC
+LIMIT 10
+```
+
+## Error Patterns (Most Common)
+```dataviewjs
+let pages = dv.pages('"claude-insights"')
+    .where(p => p.type === "claude-error-fix");
+
+let topics = {};
+for (let p of pages) {
+    let tags = p.tags || [];
+    if (!Array.isArray(tags)) tags = [tags];
+    for (let tag of tags) {
+        if (typeof tag === 'string' && tag.startsWith("claude/topic/")) {
+            let topic = tag.replace("claude/topic/", "");
+            topics[topic] = (topics[topic] || 0) + 1;
+        }
+    }
+}
+
+dv.table(
+    ["Error Topic", "Occurrences"],
+    Object.entries(topics)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 15)
+        .map(([topic, count]) => [topic, count])
+);
+```

--- a/skills/link/SKILL.md
+++ b/skills/link/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: link
+description: "Cross-references related Obsidian vault notes with bidirectional wikilinks. Use when: (1) /link to auto-suggest connections for the current session, (2) /link <description> to link specific notes, (3) user wants to connect related notes."
+metadata:
+  version: 1.0.0
+---
+
+# Link — Cross-Reference Vault Notes with Bidirectional Wikilinks
+
+Search the Obsidian vault for notes related to the current session or a specific description, then create bidirectional wikilinks between them in their respective `## Related` sections.
+
+**Tools needed:** Bash, Grep, Read, Write, Edit
+
+## Procedure
+
+Follow these steps exactly. Do not skip steps or reorder them.
+
+### Step 1 — Load config
+
+Read `~/.claude/obsidian-brain-config.json`:
+
+```bash
+cat ~/.claude/obsidian-brain-config.json
+```
+
+If the file does not exist or is not valid JSON, tell the user:
+
+> Config not found. Run `/obsidian-setup` first to configure your Obsidian vault.
+
+Stop here if config is missing. Otherwise, extract `vault_path`, `sessions_folder` (default `claude-sessions`), and `insights_folder` (default `claude-insights`). Store as `VAULT_PATH`, `SESSIONS_FOLDER`, `INSIGHTS_FOLDER`.
+
+### Step 2 — Validate vault access
+
+Run:
+
+```bash
+test -d "$VAULT_PATH/$SESSIONS_FOLDER" && test -d "$VAULT_PATH/$INSIGHTS_FOLDER" && echo "OK" || echo "FAIL"
+```
+
+If FAIL, tell the user:
+
+> The vault folders do not exist. Run `/obsidian-setup` to fix this.
+
+Stop here if FAIL.
+
+### Step 3 — Determine mode
+
+Check if the user provided an argument after `/link`.
+
+- **Without argument** (bare `/link`): Go to Step 4A — auto-suggest connections for the current session.
+- **With argument** (e.g. `/link authentication flow notes`): Go to Step 4B — explicit link by description.
+
+### Step 4A — Auto-suggest connections
+
+**4A.1 — Derive project name:**
+
+```bash
+basename "$(pwd)"
+```
+
+Store as `PROJECT`. Normalize: lowercase, hyphens for spaces.
+
+**4A.2 — Find most recent session note for this project:**
+
+```bash
+ls -t "$VAULT_PATH/$SESSIONS_FOLDER"/ | head -20
+```
+
+From that list, identify the most recent file whose name contains the project name (or whose frontmatter contains `project: $PROJECT`). If you cannot determine from the filename alone, use Grep:
+
+```
+pattern: "project: $PROJECT"
+path: $VAULT_PATH/$SESSIONS_FOLDER/
+output_mode: files_with_matches
+```
+
+Sort the matched files by modification time and pick the most recent one. This is the **source note**. Read its full content using the Read tool.
+
+**4A.3 — Extract keywords:**
+
+From the current conversation topics and the source note's content, identify 3-5 meaningful keywords or concepts. Prefer: technology names, method names, architectural terms, error types, product feature names. Avoid generic words like "session", "note", "file".
+
+**4A.4 — Search vault for related notes (parallel):**
+
+Run these searches in parallel using Grep, case-insensitive (`-i: true`):
+
+For each keyword (run as parallel searches across both folders):
+
+```
+pattern: "<keyword>"
+path: $VAULT_PATH/$SESSIONS_FOLDER/
+output_mode: files_with_matches
+-i: true
+```
+
+```
+pattern: "<keyword>"
+path: $VAULT_PATH/$INSIGHTS_FOLDER/
+output_mode: files_with_matches
+-i: true
+```
+
+Collect all matched files across all keywords. Exclude the source note itself.
+
+**4A.5 — Search by overlapping tags:**
+
+Read the source note's frontmatter and extract its `tags:` list. For each tag that starts with `claude/topic/`, run:
+
+```
+pattern: "<tag>"
+path: $VAULT_PATH/$SESSIONS_FOLDER/
+output_mode: files_with_matches
+```
+
+```
+pattern: "<tag>"
+path: $VAULT_PATH/$INSIGHTS_FOLDER/
+output_mode: files_with_matches
+```
+
+Add any new matches to your candidate list, excluding the source note.
+
+**4A.6 — Rank candidates:**
+
+Score each candidate file:
+- +1 for each keyword match
+- +1 for each shared tag
+- +2 bonus if the file is in the insights folder (insights/decisions are higher value than raw sessions)
+
+Sort by score descending. Take the top 5.
+
+**4A.7 — Present candidates:**
+
+> **Suggested connections for this session:**
+>
+> 1. [[note-filename-without-extension]] — <reason: shares topics X and Y>
+> 2. [[note-filename-without-extension]] — <reason>
+> 3. [[note-filename-without-extension]] — <reason>
+>
+> Which would you like to link? (e.g. `1,3` or `all` or `none`)
+
+Wait for the user's response. If `none`, stop. For each selected candidate, go to Step 5 with the source note and that candidate as the target.
+
+### Step 4B — Explicit link request
+
+**4B.1 — Identify source note:**
+
+If the user's description contains "this session", "current session", or similar: derive the project name from `basename "$(pwd)"` and find the most recent session note for that project (same as Step 4A.2).
+
+Otherwise, use the user's description to search for a source note:
+
+```
+pattern: "<keywords from description>"
+path: $VAULT_PATH/$SESSIONS_FOLDER/
+output_mode: files_with_matches
+-i: true
+```
+
+```
+pattern: "<keywords from description>"
+path: $VAULT_PATH/$INSIGHTS_FOLDER/
+output_mode: files_with_matches
+-i: true
+```
+
+**4B.2 — Identify target note:**
+
+Parse the user's description for target note clues. Search both folders:
+
+```
+pattern: "<target keywords>"
+path: $VAULT_PATH/$SESSIONS_FOLDER/
+output_mode: files_with_matches
+-i: true
+```
+
+```
+pattern: "<target keywords>"
+path: $VAULT_PATH/$INSIGHTS_FOLDER/
+output_mode: files_with_matches
+-i: true
+```
+
+**4B.3 — Resolve ambiguity:**
+
+If multiple matches were found for either source or target, present them and ask the user to pick:
+
+> Found multiple matches. Which note did you mean?
+>
+> 1. [[note-filename-1]]
+> 2. [[note-filename-2]]
+
+Wait for the user's selection. Once both source and target are unambiguously identified, go to Step 5.
+
+### Step 5 — Create bidirectional link
+
+For each source-target pair:
+
+**5.1 — Read the source note** using the Read tool.
+
+**5.2 — Check for duplicate link in source:**
+
+Search the source note's content for `[[target-filename]]` (filename without `.md`). If the link already exists in the source, skip writing to the source and note it:
+
+> [[source-note]] already links to [[target-note]] — skipping source.
+
+**5.3 — Add link to source note:**
+
+- If the source note has a `## Related` section: use the Edit tool to append a new line to that section:
+  `- [[target-filename]] — <one-line reason for the connection>`
+- If no `## Related` section exists: use the Edit tool to append the following to the end of the file:
+
+  ```
+  
+  ## Related
+  
+  - [[target-filename]] — <one-line reason for the connection>
+  ```
+
+- Use the Write tool only if the note is very short or the Edit tool would be unreliable due to unclear anchor text.
+
+After writing, set permissions:
+
+```bash
+chmod 644 "<source-note-path>"
+```
+
+**5.4 — Read the target note** using the Read tool.
+
+**5.5 — Check for duplicate link in target:**
+
+Search the target note's content for `[[source-filename]]`. If it already exists, skip writing to the target:
+
+> [[target-note]] already links back to [[source-note]] — skipping target.
+
+**5.6 — Add link to target note** (mirror of 5.3, but reversed — source becomes the linked note):
+
+- If the target note has a `## Related` section: append:
+  `- [[source-filename]] — <one-line reason for the connection>`
+- If no `## Related` section: append:
+
+  ```
+  
+  ## Related
+  
+  - [[source-filename]] — <one-line reason for the connection>
+  ```
+
+After writing, set permissions:
+
+```bash
+chmod 644 "<target-note-path>"
+```
+
+### Step 6 — Confirm
+
+For each linked pair, print:
+
+> **Linked:** [[source-note]] ↔ [[target-note]]
+> Reason: <connection reason>
+> Links are bidirectional — both notes now reference each other in their Related section.
+
+If multiple pairs were linked, print a summary after all pairs are done:
+
+> **All done.** N bidirectional link(s) created.
+
+## Edge Cases
+
+- **No session note found for current project:** Tell the user no session note was found. Suggest they work in a session so one is auto-logged at session end, then run `/link` again.
+- **No candidates found in auto-suggest:** Tell the user no related notes were found for the extracted keywords. Suggest running `/link <specific description>` to search manually.
+- **Already linked (both directions):** Tell the user both notes already reference each other — no changes needed.
+- **Only one direction already linked:** Add only the missing direction; do not duplicate the existing link.
+- **Wikilink format:** Always use the filename without the `.md` extension: `[[2026-04-04-obsidian-brain-297a]]` not `[[2026-04-04-obsidian-brain-297a.md]]`.
+- **Large vault (50+ files):** Never glob or read the entire folder. Always use Grep to search — never `ls` the whole folder for matching.
+- **Config exists but vault path is invalid:** Warn the user and suggest running `/obsidian-setup` again.

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: retro
+description: "Generates honest session retrospectives analyzing what worked, what didn't, key learnings, and actionable process improvements. Use when: (1) /retro command at end of session, (2) user wants to reflect on session quality and outcomes."
+metadata:
+  version: 1.0.0
+---
+
+# Retro — Generate Honest Session Retrospective
+
+Analyze the current conversation candidly and save a structured retrospective to the Obsidian vault. The goal is honest reflection — not self-congratulation — so future sessions can improve.
+
+**Tools needed:** Bash, Write, Read
+
+## Procedure
+
+Follow these steps exactly. Do not skip steps or reorder them.
+
+### Step 1 — Read config
+
+Run:
+
+```bash
+cat ~/.claude/obsidian-brain-config.json
+```
+
+If the file does not exist or is invalid JSON, tell the user:
+
+> Config not found. Please run `/obsidian-setup` first to configure your Obsidian vault.
+
+Stop here if config is missing.
+
+Parse the JSON and extract `vault_path`, `insights_folder`, and `sessions_folder`. Store them as `VAULT_PATH`, `INSIGHTS_FOLDER` (default `claude-insights`), and `SESSIONS_FOLDER` (default `claude-sessions`).
+
+### Step 2 — Validate vault access
+
+Run:
+
+```bash
+test -d "$VAULT_PATH/$INSIGHTS_FOLDER" && test -w "$VAULT_PATH/$INSIGHTS_FOLDER" && echo "OK" || echo "FAIL"
+```
+
+If FAIL, tell the user:
+
+> The insights folder `$VAULT_PATH/$INSIGHTS_FOLDER` does not exist or is not writable. Run `/obsidian-setup` to fix this.
+
+Stop here if FAIL.
+
+### Step 3 — Analyze the session honestly
+
+Review the full current conversation. Be **candid**, not defensive or self-congratulatory.
+
+The **"What Didn't Work"** section is the MOST valuable part of this retrospective — invest the most analysis there.
+
+Evaluate the session across these five dimensions:
+
+1. **What approaches worked?** — Successful strategies, good tool choices, efficient workflows, moments where the approach was clearly right.
+2. **What didn't work?** — Be specific: wrong assumptions that led to dead ends, approaches that were abandoned partway through, time wasted on the wrong path, tools that failed or were misused, misunderstandings of the user's intent, overcomplicated solutions when a simple one existed, factual errors or hallucinations Claude produced.
+3. **What did the user correct or redirect?** — Any moment the user said "no, that's wrong" or steered the conversation back — these are especially valuable signals.
+4. **Key learnings** — Non-obvious insights that would be genuinely useful in future sessions. Not generic advice; specific to what happened here.
+5. **Process improvements** — Concrete and actionable changes. Not vague ("be more careful") but specific ("check existing tests before writing new ones", "ask for the schema before generating SQL").
+
+### Step 4 — Structure the retrospective
+
+Draft the note body using this exact structure:
+
+```markdown
+## What Went Well
+- <specific thing that worked, with enough context to be meaningful>
+
+## What Didn't Work
+- <dead end: what was tried, why it failed, time impact>
+- <wrong assumption: what was assumed, what was actually true>
+- <user correction: what Claude did wrong, what user redirected to>
+
+## Key Learnings
+- <non-obvious insight with enough context to be useful later>
+
+## Process Improvements
+- [ ] <specific actionable change for future sessions>
+```
+
+**Important:** "What Didn't Work" should have MORE items than "What Went Well." If the session went smoothly with no obvious failures, still find at least one improvement opportunity — there is always something.
+
+### Step 5 — Derive session ID and backlinks
+
+Find the session ID by running:
+
+```bash
+SESSION_ID=$(ls -t ~/.claude/projects/*"$(basename "$PWD")"/*.jsonl 2>/dev/null | head -1 | xargs -I{} basename {} .jsonl)
+```
+
+**Important:** If `SESSION_ID` is empty (glob matched nothing), use `unknown` for `source_session` and omit `source_session_note` entirely. Do NOT proceed to hash derivation with an empty string.
+
+If `SESSION_ID` is non-empty, derive the 4-char hash and find the matching session note:
+
+```bash
+HASH=$(echo -n "$SESSION_ID" | shasum -a 256 | cut -c1-4)
+SESSION_NOTE_PATH=$(ls "$VAULT_PATH/$SESSIONS_FOLDER"/*-"$HASH".md 2>/dev/null | head -1)
+if [ -n "$SESSION_NOTE_PATH" ]; then
+  SESSION_NOTE=$(basename "$SESSION_NOTE_PATH" .md)
+else
+  SESSION_NOTE=
+fi
+```
+
+If the session note file doesn't exist yet (current session hasn't ended), construct the expected filename as `YYYY-MM-DD-<project-slug>-<HASH>` and include it anyway — Obsidian shows unresolved wikilinks as greyed out, and they auto-resolve once the session note is created at session end.
+
+Project name: `basename "$(pwd)"`.
+
+### Step 6 — Show preview and ask for edits
+
+Present the full note to the user including frontmatter:
+
+```
+---
+type: claude-retro
+date: YYYY-MM-DD
+source_session: <current-session-id>
+source_session_note: "[[<session-note-filename>]]"
+project: <project-name>
+tags:
+  - claude/retro
+  - claude/project/<project-name>
+---
+
+## What Went Well
+...
+
+## What Didn't Work
+...
+
+## Key Learnings
+...
+
+## Process Improvements
+...
+```
+
+Where:
+- `YYYY-MM-DD` is today's date
+- `<current-session-id>` and `<session-note-filename>` are derived from Step 5
+- `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
+- The `source_session_note` field creates an Obsidian backlink from the retro to its source session
+
+Ask the user:
+
+> Preview above. Would you like to:
+> - **save** as-is
+> - **edit content** — tell me what to change
+> - **cancel** — discard this note
+
+Wait for the user's response. Apply any requested edits and show the updated preview. Repeat until the user says **save** or **cancel**.
+
+If cancel, stop here.
+
+### Step 7 — Generate filename and write
+
+Construct the filename:
+
+1. **Date:** `YYYY-MM-DD` (today)
+2. **Slug:** `retro` (fixed — no title slug needed for retrospectives)
+3. **Hash:** 4-character hex hash from current timestamp:
+   - macOS: `date +%s | md5 | cut -c1-4`
+   - Linux: `date +%s | md5sum | cut -c1-4`
+
+Final filename: `YYYY-MM-DD-retro-<hash>.md`
+
+Example: `2026-04-05-retro-a3f2.md`
+
+Run:
+
+```bash
+mkdir -p "$VAULT_PATH/$INSIGHTS_FOLDER"
+```
+
+Then use the **Write** tool to write the full note (frontmatter + body) to:
+
+```
+$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-retro-<hash>.md
+```
+
+Then set permissions:
+
+```bash
+chmod 644 "$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-retro-<hash>.md"
+```
+
+### Step 8 — Confirm
+
+Print:
+
+> **Retrospective saved!**
+> - File: `$VAULT_PATH/$INSIGHTS_FOLDER/<filename>`
+> - Tags: `claude/retro`, `claude/project/<name>`
+> - Open in Obsidian to review and track process improvements over time.

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -123,6 +123,8 @@ tags:
   - claude/project/<project-name>
 ---
 
+# Session Retrospective: <project-name> (<date>)
+
 ## What Went Well
 ...
 

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -95,7 +95,20 @@ END_DATE=$(date -d "last week Sunday" +%Y-%m-%d)
 
 **`YYYY-MM-DD to YYYY-MM-DD`:** use the two dates directly as `START_DATE` and `END_DATE`.
 
-Store both dates. Also compute `IS_RANGE` = true if `START_DATE != END_DATE`, false otherwise. This controls the filename slug in Step 10.
+Store both dates. Also compute `IS_RANGE` = true if `START_DATE != END_DATE`, false otherwise. This controls the filename slug in Step 11.
+
+**Validate the parsed dates:** Check that `START_DATE` and `END_DATE` are non-empty and match `YYYY-MM-DD` format. If either is empty or malformed, tell the user:
+
+> Could not parse the date range from your input. Supported formats:
+> - `/standup` (today)
+> - `/standup yesterday`
+> - `/standup this week`
+> - `/standup last week`
+> - `/standup 2026-03-25 to 2026-03-31`
+
+Stop here if validation fails.
+
+Also verify that `START_DATE <= END_DATE`. If not, tell the user the start date must be before or equal to the end date.
 
 ### Step 4 — Search for notes in date range (parallel)
 

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: standup
+description: "Generates daily/weekly standup summaries across all projects from the Obsidian vault. Use when: (1) /standup for today's summary, (2) /standup this week for weekly summary, (3) /standup <date range> for custom range."
+metadata:
+  version: 1.0.0
+---
+
+# Standup — Generate Standup Summaries from Obsidian Vault
+
+Searches the Obsidian vault for session notes and insights within a date range, upgrades any unsummarized notes with AI summaries, groups findings by project, and generates a structured standup note.
+
+**Tools needed:** Bash, Grep, Read, Write
+
+## Procedure
+
+Follow these steps exactly. Do not skip steps or reorder them.
+
+### Step 1 — Load config
+
+Read `~/.claude/obsidian-brain-config.json`:
+
+```bash
+cat ~/.claude/obsidian-brain-config.json
+```
+
+If the file does not exist or is not valid JSON, tell the user:
+
+> Config not found. Run `/obsidian-setup` first to configure your Obsidian vault.
+
+Stop here if config is missing. Otherwise, extract `vault_path`, `sessions_folder` (default `claude-sessions`), and `insights_folder` (default `claude-insights`). Store as `VAULT_PATH`, `SESSIONS_FOLDER`, `INSIGHTS_FOLDER`.
+
+### Step 2 — Parse date range from arguments
+
+Inspect the argument passed after `/standup`. Calculate `START_DATE` and `END_DATE` as `YYYY-MM-DD` strings using bash `date` commands.
+
+**No argument (bare `/standup`):** today only.
+
+```bash
+START_DATE=$(date +%Y-%m-%d)
+END_DATE=$START_DATE
+```
+
+**`yesterday`:**
+
+```bash
+# macOS
+START_DATE=$(date -v-1d +%Y-%m-%d)
+END_DATE=$START_DATE
+
+# Linux fallback
+START_DATE=$(date -d "yesterday" +%Y-%m-%d)
+END_DATE=$START_DATE
+```
+
+**`this week`:** Monday of the current week through today.
+
+```bash
+# macOS
+DOW=$(date +%u)   # 1=Mon … 7=Sun
+DAYS_BACK=$((DOW - 1))
+START_DATE=$(date -v-${DAYS_BACK}d +%Y-%m-%d)
+END_DATE=$(date +%Y-%m-%d)
+
+# Linux fallback
+START_DATE=$(date -d "last Monday" +%Y-%m-%d 2>/dev/null || date -d "$(date +%Y-%m-%d) -$(date +%u)-1 days" +%Y-%m-%d)
+END_DATE=$(date +%Y-%m-%d)
+```
+
+**`last week`:** Monday through Sunday of the previous week.
+
+```bash
+# macOS
+DOW=$(date +%u)
+START_DATE=$(date -v-${DOW}d -v-6d +%Y-%m-%d)
+END_DATE=$(date -v-${DOW}d +%Y-%m-%d)
+
+# Linux fallback
+START_DATE=$(date -d "last week Monday" +%Y-%m-%d)
+END_DATE=$(date -d "last week Sunday" +%Y-%m-%d)
+```
+
+**`YYYY-MM-DD to YYYY-MM-DD`:** use the two dates directly as `START_DATE` and `END_DATE`.
+
+Store both dates. Also compute `IS_RANGE` = true if `START_DATE != END_DATE`, false otherwise. This controls the filename slug in Step 10.
+
+### Step 3 — Search for notes in date range (parallel)
+
+Run two Grep searches in parallel to find notes whose `date:` frontmatter field falls within the range.
+
+**Search A — Sessions:**
+
+```
+pattern: "^date: "
+path: $VAULT_PATH/$SESSIONS_FOLDER/
+output_mode: content
+glob: "*.md"
+```
+
+**Search B — Insights:**
+
+```
+pattern: "^date: "
+path: $VAULT_PATH/$INSIGHTS_FOLDER/
+output_mode: content
+glob: "*.md"
+```
+
+For each result, parse the `date:` value and keep only files where `START_DATE <= date <= END_DATE`. Collect the matching file paths into `MATCHED_FILES`.
+
+If `MATCHED_FILES` is empty, tell the user:
+
+> No session or insight notes found for the range **$START_DATE to $END_DATE**.
+
+Stop here.
+
+### Step 4 — Identify unsummarized session notes
+
+From `MATCHED_FILES`, isolate those in `$SESSIONS_FOLDER/`. Use Grep to check each for the unsummarized marker:
+
+```
+pattern: "AI summary unavailable"
+path: <each session file>
+output_mode: files_with_matches
+```
+
+Split into:
+- `UNSUMMARIZED` — session files containing "AI summary unavailable"
+- `SUMMARIZED` — all other matched files (sessions + insights)
+
+### Step 5 — Deferred summarization for unsummarized notes
+
+If `UNSUMMARIZED` is empty, skip to Step 6.
+
+For each file in `UNSUMMARIZED`, perform the upgrade (process multiple notes in parallel via sub-agents when there are more than 2):
+
+1. **Read the full file** using the Read tool.
+2. **Extract frontmatter** — preserve it exactly as-is (everything between the opening `---` and closing `---`).
+3. **Extract the full conversation** — read all content after frontmatter, including:
+   - `## Conversation (raw)` — interleaved user and assistant messages
+   - `## Tool Usage` — commands run, files edited, searches performed
+   - `## Changes Made` — files touched
+   - `## Errors Encountered` — errors from tool results
+4. **Generate a detailed, specific summary** with these sections:
+   - `## Summary` — 3-5 sentence overview: what problem was solved, what approach was taken, what was the outcome. Name specific technologies, files, and patterns.
+   - `## Key Decisions` — Bulleted list with rationale. If none, write "None noted."
+   - `## Changes Made` — Bulleted list with file paths and descriptions. If none, write "None noted."
+   - `## Errors Encountered` — Bulleted list with error messages, root causes, and fixes. If none, write "None."
+   - `## Open Questions / Next Steps` — Checkbox list of specific, actionable items. If none, write "None."
+5. **Preserve the Session Metadata section** at the bottom if it exists.
+6. **Write the upgraded note** using the Write tool to the same file path. Structure:
+   - Original frontmatter (unchanged)
+   - `# <title from original note>`
+   - The five summary sections
+   - Session Metadata section (if it existed)
+7. Run `chmod 644 <filepath>` after writing.
+
+**Important:** Do NOT modify frontmatter. Do NOT change the filename. Do NOT add or remove tags.
+
+Move all upgraded files from `UNSUMMARIZED` into the working set alongside `SUMMARIZED`. Track the count of upgraded notes as `UPGRADED_COUNT`.
+
+### Step 6 — Read and distill note content
+
+Collect all matched files (now all summarized). Apply the /context-shield rule:
+
+- **5 or fewer notes:** Read each file directly using the Read tool. Extract: project name (from frontmatter `project:` field), note type (`type:` field), date, title (first `# Heading`), summary (content of `## Summary` section), decisions (bullets from `## Key Decisions`), errors resolved (bullets from `## Errors Encountered`), open items (checkboxes from `## Open Questions / Next Steps`), and the filename (for wikilinks).
+- **More than 5 notes:** Spawn parallel sub-agents (one per note) to extract the same fields and return distilled summaries. Each sub-agent reads one file and returns: `{project, type, date, title, summary, decisions[], errors_resolved[], open_items[], filename}`.
+
+Collect all distilled records as `NOTE_DATA`.
+
+### Step 7 — Group by project
+
+Group `NOTE_DATA` by `project` field. Sort projects alphabetically. Within each project, sort notes by `date` ascending (oldest first within the range). Separate sessions from insights within each project group.
+
+If any notes have a missing or empty `project` field, group them under `(unknown project)`.
+
+### Step 8 — Generate standup note body
+
+Build the standup note body using the grouped data. For each project, emit a section:
+
+```markdown
+## $PROJECT_NAME
+
+### Sessions
+- [[filename-without-extension]] — $TITLE ($DATE)
+
+### Insights
+- [[filename-without-extension]] — $TITLE ($DATE)
+
+### Decisions
+- $DECISION_1
+- $DECISION_2
+
+### Errors Resolved
+- $ERROR_1
+
+### Open Items
+- [ ] $OPEN_ITEM_1
+- [ ] $OPEN_ITEM_2
+```
+
+Rules:
+- Omit any subsection that has no content (e.g., if no decisions, skip `### Decisions` entirely).
+- Omit the `### Insights` subsection if no insight notes exist for that project in the range.
+- Wikilinks must use the bare filename without `.md` extension: `[[2026-04-05-my-note-a3f2]]`.
+- Decisions and errors should be deduplicated across sessions in the same project.
+- Open items should be listed as checkboxes (`- [ ]`).
+
+Precede all project sections with a header block:
+
+```markdown
+# Standup: $START_DATE to $END_DATE
+
+**Range:** $START_DATE → $END_DATE
+**Projects covered:** $PROJECT_COUNT
+**Sessions:** $SESSION_COUNT | **Insights:** $INSIGHT_COUNT
+```
+
+If `IS_RANGE` is false (single day), use `# Standup: $DATE` and omit the "Range:" line.
+
+### Step 9 — Build frontmatter
+
+Construct the `source_notes` array from ALL matched filenames (sessions + insights), formatted as wikilinks:
+
+```yaml
+---
+type: claude-standup
+date: YYYY-MM-DD
+date_range: "START_DATE to END_DATE"
+projects:
+  - project-a
+  - project-b
+source_notes:
+  - "[[note-filename-1]]"
+  - "[[note-filename-2]]"
+tags:
+  - claude/standup
+---
+```
+
+Where:
+- `date` is today's date (the date the standup was generated, not the range start)
+- `date_range` is `"$START_DATE to $END_DATE"` (use the same value for single-day standups)
+- `projects` lists all unique project names found, sorted alphabetically
+- `source_notes` lists every contributing note as a wikilink (filename without `.md`)
+
+### Step 10 — Generate filename
+
+Construct the filename:
+
+1. **Date prefix:** `YYYY-MM-DD` (today's date, i.e., when the standup is generated)
+2. **Slug:**
+   - If `IS_RANGE` is false (single day): `standup-daily`
+   - If `IS_RANGE` is true and the range spans exactly 7 days Mon-Sun: `standup-weekly`
+   - Otherwise: `standup-range`
+3. **Hash:** last 4 hex characters of the current timestamp hash:
+   ```bash
+   # macOS
+   HASH=$(date +%s | md5 | cut -c29-32)
+   # Linux fallback
+   HASH=$(date +%s | md5sum | cut -c1-4)
+   ```
+
+Final filename: `YYYY-MM-DD-<slug>-<hash>.md`
+
+Example: `2026-04-05-standup-daily-a3f2.md`
+
+### Step 11 — Write the note
+
+Run:
+
+```bash
+mkdir -p "$VAULT_PATH/$INSIGHTS_FOLDER"
+```
+
+Then use the **Write** tool to write the full note (frontmatter + body) to:
+
+```
+$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-<slug>-<hash>.md
+```
+
+Then set permissions:
+
+```bash
+chmod 644 "$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-<slug>-<hash>.md"
+```
+
+### Step 12 — Present to user
+
+Display the full standup in the conversation:
+
+> **Standup for $START_DATE to $END_DATE:**
+
+Then output the standup body (without frontmatter) as formatted markdown.
+
+If `UPGRADED_COUNT > 0`, append:
+
+> _Upgraded $UPGRADED_COUNT session note(s) with AI summaries._
+
+Then confirm the saved file:
+
+> **Saved:** `$VAULT_PATH/$INSIGHTS_FOLDER/<filename>`
+
+## Edge Cases
+
+- **No notes found for range:** Tell the user and suggest narrowing or widening the range, or checking that vault path is correct.
+- **All notes are unsummarized:** Summarize all in Step 5 before proceeding — never skip summarization.
+- **Single project:** Omit the per-project `## $PROJECT_NAME` heading if there is exactly one project; output the sections directly under the top-level header.
+- **Config exists but vault path is invalid:** Warn the user and suggest running `/obsidian-setup` again.
+- **macOS vs Linux date syntax:** Always try macOS syntax (`date -v`) first; fall back to Linux (`date -d`) if it fails.
+- **Notes with missing project field:** Group under `(unknown project)` and note this to the user.

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -143,7 +143,7 @@ Split into:
 
 ### Step 6 — Deferred summarization for unsummarized notes
 
-If `UNSUMMARIZED` is empty, skip to Step 6.
+If `UNSUMMARIZED` is empty, skip to Step 7.
 
 For each file in `UNSUMMARIZED`, perform the upgrade (process multiple notes in parallel via sub-agents when there are more than 2):
 
@@ -254,6 +254,8 @@ source_notes:
   - "[[note-filename-2]]"
 tags:
   - claude/standup
+  - claude/project/project-a
+  - claude/project/project-b
 ---
 ```
 
@@ -262,6 +264,7 @@ Where:
 - `date_range` is `"$START_DATE to $END_DATE"` (use the same value for single-day standups)
 - `projects` lists all unique project names found, sorted alphabetically
 - `source_notes` lists every contributing note as a wikilink (filename without `.md`)
+- `tags` includes `claude/standup` plus a `claude/project/<name>` tag for each project covered by the standup
 
 ### Step 11 — Generate filename
 

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -29,7 +29,21 @@ If the file does not exist or is not valid JSON, tell the user:
 
 Stop here if config is missing. Otherwise, extract `vault_path`, `sessions_folder` (default `claude-sessions`), and `insights_folder` (default `claude-insights`). Store as `VAULT_PATH`, `SESSIONS_FOLDER`, `INSIGHTS_FOLDER`.
 
-### Step 2 — Parse date range from arguments
+### Step 2 — Validate vault access
+
+Run:
+
+```bash
+test -d "$VAULT_PATH/$SESSIONS_FOLDER" && test -d "$VAULT_PATH/$INSIGHTS_FOLDER" && echo "OK" || echo "FAIL"
+```
+
+If FAIL, tell the user:
+
+> The vault folders do not exist or are not accessible. Run `/obsidian-setup` to fix this.
+
+Stop here if FAIL.
+
+### Step 3 — Parse date range from arguments
 
 Inspect the argument passed after `/standup`. Calculate `START_DATE` and `END_DATE` as `YYYY-MM-DD` strings using bash `date` commands.
 
@@ -83,7 +97,7 @@ END_DATE=$(date -d "last week Sunday" +%Y-%m-%d)
 
 Store both dates. Also compute `IS_RANGE` = true if `START_DATE != END_DATE`, false otherwise. This controls the filename slug in Step 10.
 
-### Step 3 — Search for notes in date range (parallel)
+### Step 4 — Search for notes in date range (parallel)
 
 Run two Grep searches in parallel to find notes whose `date:` frontmatter field falls within the range.
 
@@ -113,7 +127,7 @@ If `MATCHED_FILES` is empty, tell the user:
 
 Stop here.
 
-### Step 4 — Identify unsummarized session notes
+### Step 5 — Identify unsummarized session notes
 
 From `MATCHED_FILES`, isolate those in `$SESSIONS_FOLDER/`. Use Grep to check each for the unsummarized marker:
 
@@ -127,7 +141,7 @@ Split into:
 - `UNSUMMARIZED` — session files containing "AI summary unavailable"
 - `SUMMARIZED` — all other matched files (sessions + insights)
 
-### Step 5 — Deferred summarization for unsummarized notes
+### Step 6 — Deferred summarization for unsummarized notes
 
 If `UNSUMMARIZED` is empty, skip to Step 6.
 
@@ -158,22 +172,28 @@ For each file in `UNSUMMARIZED`, perform the upgrade (process multiple notes in 
 
 Move all upgraded files from `UNSUMMARIZED` into the working set alongside `SUMMARIZED`. Track the count of upgraded notes as `UPGRADED_COUNT`.
 
-### Step 6 — Read and distill note content
+### Step 7 — Read and distill note content
 
 Collect all matched files (now all summarized). Apply the /context-shield rule:
 
-- **5 or fewer notes:** Read each file directly using the Read tool. Extract: project name (from frontmatter `project:` field), note type (`type:` field), date, title (first `# Heading`), summary (content of `## Summary` section), decisions (bullets from `## Key Decisions`), errors resolved (bullets from `## Errors Encountered`), open items (checkboxes from `## Open Questions / Next Steps`), and the filename (for wikilinks).
-- **More than 5 notes:** Spawn parallel sub-agents (one per note) to extract the same fields and return distilled summaries. Each sub-agent reads one file and returns: `{project, type, date, title, summary, decisions[], errors_resolved[], open_items[], filename}`.
+For each note, check its size using `wc -l`. Apply the context-shield rule **per note** based on size:
+
+- **Notes under ~100 lines (~3000 tokens):** Read directly using the Read tool.
+- **Notes over ~100 lines:** Spawn a `/context-shield` sub-agent to read in isolation and return a distilled summary.
+
+When multiple notes need sub-agent reads, spawn them in parallel (one sub-agent per note).
+
+From each note (whether read directly or via sub-agent), extract: project name (from frontmatter `project:` field), note type (`type:` field), date, title (first `# Heading`), summary (content of `## Summary` section), decisions (bullets from `## Key Decisions`), errors resolved (bullets from `## Errors Encountered`), open items (checkboxes from `## Open Questions / Next Steps`), and the filename (for wikilinks).
 
 Collect all distilled records as `NOTE_DATA`.
 
-### Step 7 — Group by project
+### Step 8 — Group by project
 
 Group `NOTE_DATA` by `project` field. Sort projects alphabetically. Within each project, sort notes by `date` ascending (oldest first within the range). Separate sessions from insights within each project group.
 
 If any notes have a missing or empty `project` field, group them under `(unknown project)`.
 
-### Step 8 — Generate standup note body
+### Step 9 — Generate standup note body
 
 Build the standup note body using the grouped data. For each project, emit a section:
 
@@ -217,7 +237,7 @@ Precede all project sections with a header block:
 
 If `IS_RANGE` is false (single day), use `# Standup: $DATE` and omit the "Range:" line.
 
-### Step 9 — Build frontmatter
+### Step 10 — Build frontmatter
 
 Construct the `source_notes` array from ALL matched filenames (sessions + insights), formatted as wikilinks:
 
@@ -243,7 +263,7 @@ Where:
 - `projects` lists all unique project names found, sorted alphabetically
 - `source_notes` lists every contributing note as a wikilink (filename without `.md`)
 
-### Step 10 — Generate filename
+### Step 11 — Generate filename
 
 Construct the filename:
 
@@ -264,7 +284,7 @@ Final filename: `YYYY-MM-DD-<slug>-<hash>.md`
 
 Example: `2026-04-05-standup-daily-a3f2.md`
 
-### Step 11 — Write the note
+### Step 12 — Write the note
 
 Run:
 
@@ -284,7 +304,7 @@ Then set permissions:
 chmod 644 "$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-<slug>-<hash>.md"
 ```
 
-### Step 12 — Present to user
+### Step 13 — Present to user
 
 Display the full standup in the conversation:
 

--- a/skills/vault-ask/SKILL.md
+++ b/skills/vault-ask/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: vault-ask
+description: "Asks questions and gets synthesized answers grounded in vault history with source citations. Use when: (1) /vault-ask <question> to reason over vault knowledge, (2) user wants to know what their notes say about a topic, (3) user wants cross-project pattern analysis."
+metadata:
+  version: 1.0.0
+---
+
+# Vault Ask
+
+Synthesizes a reasoned answer to the user's question by searching session and insight notes in the Obsidian vault and citing sources. Returns a grounded answer, not a list of matches.
+
+**Tools needed:** Grep, Read, Bash
+
+## Procedure
+
+Follow these steps exactly. Do not skip steps or reorder them.
+
+### Step 1 — Load config
+
+Read `~/.claude/obsidian-brain-config.json` using the Read tool.
+
+If the file does not exist, tell the user:
+
+> Config not found. Run `/obsidian-setup` first to configure your vault path.
+
+Stop here if config is missing.
+
+Extract `vault_path`, `sessions_folder`, and `insights_folder` from the config. Construct the two search directories:
+
+- `SESSIONS_DIR` = `<vault_path>/<sessions_folder>`
+- `INSIGHTS_DIR` = `<vault_path>/<insights_folder>`
+
+### Step 2 — Parse the question
+
+The user provides a question after `/vault-ask`. Extract 3–6 key search terms from it:
+
+- **Technology names** — e.g. `Redis`, `GraphQL`, `JWT`, `Postgres`
+- **Concept keywords** — e.g. `error handling`, `rate limiting`, `caching`
+- **Action words indicating note types** — e.g. `decided` → look for decision notes, `fixed` → look for error-fix notes
+
+Store the extracted terms as `SEARCH_TERMS`. Keep the original question for use in Step 6.
+
+### Step 3 — Search vault (3 parallel agents)
+
+Launch three Grep searches in parallel — one per agent below. Use the Grep tool (never Bash grep).
+
+**Agent 1 — Session content:**
+For each term in `SEARCH_TERMS`, run:
+```
+Grep(pattern="<term>", path=SESSIONS_DIR, glob="*.md", output_mode="files_with_matches", -i=true)
+```
+Collect the union of all file paths returned.
+
+**Agent 2 — Insight content:**
+For each term in `SEARCH_TERMS`, run:
+```
+Grep(pattern="<term>", path=INSIGHTS_DIR, glob="*.md", output_mode="files_with_matches", -i=true)
+```
+Collect the union of all file paths returned.
+
+**Agent 3 — Tag search (both folders):**
+For each term in `SEARCH_TERMS`, run two Grep calls:
+```
+Grep(pattern="claude/topic/.*<term>", path=SESSIONS_DIR, glob="*.md", output_mode="files_with_matches", -i=true)
+Grep(pattern="claude/topic/.*<term>", path=INSIGHTS_DIR, glob="*.md", output_mode="files_with_matches", -i=true)
+```
+Collect all file paths returned.
+
+Combine results from all three agents. Deduplicate by file path. Store as `CANDIDATE_FILES`.
+
+If `CANDIDATE_FILES` is empty, tell the user:
+
+> No vault notes found matching your question. Try `/vault-search` with individual keywords to explore what's available.
+
+Stop here.
+
+### Step 4 — Rank results
+
+Score each file in `CANDIDATE_FILES` using these rules:
+
+| Condition | Points |
+|-----------|--------|
+| Each search term found in content (Agent 1 or 2 match) | +2 per term |
+| Note type is `claude-insight`, `claude-decision`, or `claude-error-fix` | +3 |
+| Note type is `claude-session` | +1 |
+| File date is within the last 30 days (relative to today) | +1 |
+| Matching tag found (Agent 3 match) | +2 |
+
+To determine note type and date without reading the full file, run:
+```
+Read(file_path="<path>", limit=20)
+```
+to get frontmatter fields (`type:`, `date:`).
+
+Sort `CANDIDATE_FILES` by score descending. Take the top 10. Store as `RANKED_FILES`.
+
+### Step 5 — Read top notes (context shield)
+
+Read the top 5–10 files from `RANKED_FILES`. Apply the following size-based strategy:
+
+- **Files under ~100 lines:** Read directly with the Read tool.
+- **Files over ~100 lines:** Use the `/context-shield` skill (parallel, one sub-agent per file). Each sub-agent reads the file in isolation and returns a distilled summary relevant to the question.
+
+For each file, extract:
+- Note type (session, insight, decision, error-fix)
+- Date
+- Key content relevant to the question — decisions made, patterns observed, errors and fixes
+- Exact filename (without path) for use as a wikilink citation
+
+Store all extracted content as `NOTE_SUMMARIES`.
+
+### Step 6 — Synthesize answer
+
+Using `NOTE_SUMMARIES`, synthesize a comprehensive answer to the user's question. Follow these rules strictly:
+
+1. **Lead with the answer, not the methodology.** Do not begin with "I searched your vault..." — begin with the actual answer.
+
+2. **Cite sources inline using wikilinks.** Reference the note filename (without extension) as a wikilink:
+   > "You chose Redis over Memcached ([[2026-04-04-use-redis-a3f2-decision]]) because TTL-per-key was required for token expiry."
+
+3. **Distinguish certainty levels** based on the evidence:
+   - `"You explicitly decided..."` — use when a decision note clearly records the choice
+   - `"Based on your sessions, it appears..."` — use when the pattern is inferred from session content
+   - `"Limited context available..."` — use when only one or two notes weakly touch the topic
+
+4. **End with a Sources section:**
+   ```markdown
+   ### Sources
+   - [[note-filename-1]] — <what this note contributed to the answer>
+   - [[note-filename-2]] — <what this note contributed to the answer>
+   ```
+
+If the notes contain contradictory information (e.g. a decision was changed later), surface that explicitly:
+> "You initially chose X ([[older-note]]), but later switched to Y ([[newer-note]])."
+
+### Step 7 — Present answer
+
+Display the synthesized answer from Step 6 in the conversation.
+
+Do NOT write anything to the vault — this skill is read-only.
+
+If the user asks a follow-up question, return to Step 2 with the new question.
+
+## Key distinction
+
+`/vault-search` returns a ranked list of matching notes.
+`/vault-ask` returns a reasoned, cited answer synthesized from note content.
+
+Use `/vault-ask` when the user wants to know _what_ their notes say, not _which_ notes match.
+
+## Edge Cases
+
+- **Single result:** Synthesize from that one source. Be explicit about limited coverage: "Only one relevant note was found..."
+- **All results are old (>90 days):** Mention this: "Your most recent notes on this topic are from `<date>`."
+- **Question is ambiguous (multiple interpretations):** Answer each interpretation with a subheading, or ask the user to clarify before proceeding.
+- **No matching tags, only content matches:** That is fine — tag matches are bonus scoring, not required.
+- **Config exists but vault path is invalid:** Warn the user and suggest running `/obsidian-setup` again.

--- a/skills/vault-ask/SKILL.md
+++ b/skills/vault-ask/SKILL.md
@@ -17,15 +17,19 @@ Follow these steps exactly. Do not skip steps or reorder them.
 
 ### Step 1 — Load config
 
-Read `~/.claude/obsidian-brain-config.json` using the Read tool.
+Read `~/.claude/obsidian-brain-config.json`:
 
-If the file does not exist, tell the user:
+```bash
+cat ~/.claude/obsidian-brain-config.json
+```
 
-> Config not found. Run `/obsidian-setup` first to configure your vault path.
+If the file does not exist or is not valid JSON, tell the user:
+
+> Config not found. Run `/obsidian-setup` first to configure your Obsidian vault.
 
 Stop here if config is missing.
 
-Extract `vault_path`, `sessions_folder`, and `insights_folder` from the config. Construct the two search directories:
+Extract `vault_path`, `sessions_folder` (default `claude-sessions`), and `insights_folder` (default `claude-insights`) from the config. Construct the two search directories:
 
 - `SESSIONS_DIR` = `<vault_path>/<sessions_folder>`
 - `INSIGHTS_DIR` = `<vault_path>/<insights_folder>`

--- a/skills/vault-ask/SKILL.md
+++ b/skills/vault-ask/SKILL.md
@@ -34,6 +34,18 @@ Extract `vault_path`, `sessions_folder` (default `claude-sessions`), and `insigh
 - `SESSIONS_DIR` = `<vault_path>/<sessions_folder>`
 - `INSIGHTS_DIR` = `<vault_path>/<insights_folder>`
 
+Validate vault access:
+
+```bash
+test -d "$SESSIONS_DIR" && test -d "$INSIGHTS_DIR" && echo "OK" || echo "FAIL"
+```
+
+If FAIL, tell the user:
+
+> The vault folders do not exist or are not accessible. Run `/obsidian-setup` to fix this.
+
+Stop here if FAIL.
+
 ### Step 2 — Parse the question
 
 The user provides a question after `/vault-ask`. Extract 3–6 key search terms from it:
@@ -92,9 +104,9 @@ Score each file in `CANDIDATE_FILES` using these rules:
 
 To determine note type and date without reading the full file, run:
 ```
-Read(file_path="<path>", limit=20)
+Read(file_path="<path>", limit=40)
 ```
-to get frontmatter fields (`type:`, `date:`).
+to get frontmatter fields (`type:`, `date:`). Use 40 lines because some notes (e.g., standups with large `source_notes` arrays) have frontmatter exceeding 20 lines. If `type:` or `date:` is not found within the first 40 lines, read the full frontmatter.
 
 Sort `CANDIDATE_FILES` by score descending. Take the top 10. Store as `RANKED_FILES`.
 


### PR DESCRIPTION
## Summary

- **`/standup`** — daily/weekly summary with AI summarization, context-shield, and source note backlinks
- **`/link`** — cross-reference notes with bidirectional wikilinks and auto-suggestion
- **`/retro`** — honest session retrospective for meta-learning
- **`/vault-ask`** — synthesized answers from vault knowledge with citations
- **Learning Velocity dashboard** — topic frequency, retro history, error patterns
- **Decision Timeline dashboard** — active/superseded decisions, grouped by project
- README, CHANGELOG, and version bump to 1.4.0

## Test plan

- [ ] Run `/standup` — verify it searches, summarizes, and writes a standup note
- [ ] Run `/standup this week` — verify date range parsing
- [ ] Run `/link` — verify auto-suggestion and bidirectional linking
- [ ] Run `/retro` — verify retrospective generation with session backlinks
- [ ] Run `/vault-ask what projects have I worked on?` — verify search + synthesis
- [ ] Open Learning Velocity dashboard in Obsidian — verify Dataview renders
- [ ] Open Decision Timeline dashboard in Obsidian — verify Dataview renders
- [ ] Verify README has all new skills, examples, dashboards, and note types

🤖 Generated with [Claude Code](https://claude.com/claude-code)