### PR TITLE
feat: Phase 2b — claudeception-to-compress bridge

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "obsidian-brain",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "obsidian-brain",
-  "version": "1.5.0",
+  "version": "1.4.0",
   "description": "Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-04-05
+
+### Added
+
+- **Claudeception-to-Compress bridge** — `/compress` now detects `/claudeception` output in the conversation and surfaces extracted skills/knowledge as top-priority insight candidates. Uses layered detection: high-confidence structured markers (skill validator output, skill file paths) first, broad phrase scanning as fallback. Claudeception candidates are labeled `[from claudeception]` or `[possibly from claudeception]` and pre-selected by default.
+- **Hookify nudge via `/obsidian-setup`** — New idempotent step in `/obsidian-setup` configures a hookify nudge that reminds users to run `/compress` after claudeception produces output. Existing users can re-run `/obsidian-setup` to pick up the nudge.
+
+### Changed
+
+- **`/obsidian-setup` is now idempotent** — Detects existing installations and offers upgrade/reconfigure/cancel. In upgrade mode, preserves existing config and user-customized dashboards while adding new features (dashboards, hookify nudges). Safe to re-run anytime.
+
 ## [1.4.0] - 2026-04-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Claudeception-to-Compress bridge** — `/compress` now detects `/claudeception` output in the conversation and surfaces extracted skills/knowledge as top-priority insight candidates. Uses layered detection: high-confidence structured markers (skill validator output, skill file paths) first, broad phrase scanning as fallback. Claudeception candidates are labeled `[from claudeception]` or `[possibly from claudeception]` and pre-selected by default.
+- **Claudeception-to-Compress bridge** — `/compress` now detects `/claudeception` output in the conversation and surfaces extracted skills/knowledge as top-priority insight candidates. Uses layered detection: high-confidence structured markers (skill validator output, skill file paths) first, broad phrase scanning as fallback. Claudeception candidates are labeled `[from claudeception]` or `[possibly from claudeception]` and included when the user selects `all`.
 - **Hookify nudge via `/obsidian-setup`** — New idempotent step in `/obsidian-setup` configures a hookify nudge that reminds users to run `/compress` after claudeception produces output. Existing users can re-run `/obsidian-setup` to pick up the nudge.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.5.0] - 2026-04-05
-
 ### Added
 
 - **Claudeception-to-Compress bridge** — `/compress` now detects `/claudeception` output in the conversation and surfaces extracted skills/knowledge as top-priority insight candidates. Uses layered detection: high-confidence structured markers (skill validator output, skill file paths) first, broad phrase scanning as fallback. Claudeception candidates are labeled `[from claudeception]` or `[possibly from claudeception]` and pre-selected by default.

--- a/scripts/git-flow-finish.sh
+++ b/scripts/git-flow-finish.sh
@@ -414,8 +414,22 @@ else
     log_skip "bump-version.sh not found — skip version bump"
   fi
 
-  # Stage version file changes (avoid git add -A which could stage unintended files)
-  git add .claude-plugin/plugin.json package.json pyproject.toml Cargo.toml version.txt 2>/dev/null || true
+  # Ensure [Unreleased] header exists in CHANGELOG.md
+  if [[ -f CHANGELOG.md ]]; then
+    if ! grep -q '## \[Unreleased\]' CHANGELOG.md; then
+      # Add [Unreleased] header at the top (after the file header)
+      sed -i '' '/^## \[/i\
+## [Unreleased]\
+' CHANGELOG.md
+      log_ok "Added [Unreleased] header to CHANGELOG.md"
+    else
+      # Ensure [Unreleased] section is empty (no leftover entries)
+      log_ok "[Unreleased] header already exists in CHANGELOG.md"
+    fi
+  fi
+
+  # Stage version file changes and CHANGELOG (avoid git add -A which could stage unintended files)
+  git add .claude-plugin/plugin.json package.json pyproject.toml Cargo.toml version.txt CHANGELOG.md 2>/dev/null || true
   if ! git diff --cached --quiet; then
     git commit -m "$(cat <<EOF
 chore(develop): bump version for next development cycle

--- a/scripts/git-flow-finish.sh
+++ b/scripts/git-flow-finish.sh
@@ -417,13 +417,20 @@ else
   # Ensure [Unreleased] header exists in CHANGELOG.md
   if [[ -f CHANGELOG.md ]]; then
     if ! grep -q '## \[Unreleased\]' CHANGELOG.md; then
-      # Add [Unreleased] header at the top (after the file header)
-      sed -i '' '/^## \[/i\
-## [Unreleased]\
-' CHANGELOG.md
+      # Add [Unreleased] header once before the first version header, portably
+      changelog_tmp="$(mktemp)"
+      awk '
+        BEGIN { inserted = 0 }
+        /^## \[/ && !inserted {
+          print "## [Unreleased]"
+          print ""
+          inserted = 1
+        }
+        { print }
+      ' CHANGELOG.md > "$changelog_tmp"
+      mv "$changelog_tmp" CHANGELOG.md
       log_ok "Added [Unreleased] header to CHANGELOG.md"
     else
-      # Ensure [Unreleased] section is empty (no leftover entries)
       log_ok "[Unreleased] header already exists in CHANGELOG.md"
     fi
   fi

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -108,7 +108,7 @@ Analyze the full conversation and identify 3-5 additional candidate insights (be
 
 If no claudeception output was detected, present only the standard candidates (same as before — no labels).
 
-Claudeception candidates are **pre-selected by default** — if the user says `all`, they are included. If the user picks specific numbers, normal selection applies.
+When the user says `all`, all candidates (including claudeception ones) are saved. When the user picks specific numbers, only those are saved — standard selection behavior.
 
 Wait for the user to pick. For each selected insight, draft the note content and continue to Step 5. Process selected insights one at a time.
 

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -64,7 +64,30 @@ Skip to Step 5.
 
 ### Step 4B — Multi-insight suggestion
 
-Analyze the full conversation and identify 3-5 candidate insights. Each candidate should be one of these types:
+**First, check for claudeception output** using layered detection:
+
+**Layer 1 — High-confidence structured markers** (check first):
+
+Scan the current conversation for these patterns. If found, extract the skill/knowledge name and a one-line summary:
+
+- The `MANDATORY SKILL EVALUATION REQUIRED` banner (from the claudeception activator hook)
+- `Result: PASS` or `Result: FAIL` (from the claudeception skill validator)
+- Skill file paths matching `~/.claude/skills/*/SKILL.md` or `.claude/skills/*/SKILL.md`
+
+If any Layer 1 markers are found, create a candidate for each and label it `[from claudeception]`.
+
+**Layer 2 — Broad phrase scanning** (fallback, only if Layer 1 found nothing):
+
+Scan the conversation for these phrases:
+- "created skill", "new skill at", "skill file written"
+- "extracted knowledge", "pattern identified", "reusable insight"
+- Output from a `/claudeception` invocation
+
+If any Layer 2 phrases are found, create a candidate for each and label it `[possibly from claudeception]`.
+
+**Then, perform standard insight discovery:**
+
+Analyze the full conversation and identify 3-5 additional candidate insights (beyond any claudeception candidates). Each candidate should be one of these types:
 
 - **Decision** — an architectural or design choice made during the session
 - **Pattern** — a reusable approach, technique, or workflow discovered
@@ -72,16 +95,20 @@ Analyze the full conversation and identify 3-5 candidate insights. Each candidat
 - **Error Fix** — a bug or error diagnosed and resolved
 - **Discovery** — a new finding about a tool, API, library, or system behavior
 
-Present the candidates as a numbered list:
+**Present all candidates** as a numbered list, with claudeception candidates first:
 
 > **Insights found in this session:**
 >
-> 1. [type] Title — one-line summary
-> 2. [type] Title — one-line summary
-> 3. [type] Title — one-line summary
-> ...
+> 1. [from claudeception] [Discovery] Rate limiter pattern — extracted as reusable skill
+> 2. [possibly from claudeception] [Pattern] Retry with exponential backoff — identified across 3 sessions
+> 3. [Decision] Chose Redis for session store — trade-off analysis
+> 4. [Solution] Fixed CORS issue with Safari — root cause in preflight handling
 >
 > Which would you like to save? (e.g. `1,3` or `all`)
+
+If no claudeception output was detected, present only the standard candidates (same as before — no labels).
+
+Claudeception candidates are **pre-selected by default** — if the user says `all`, they are included. If the user picks specific numbers, normal selection applies.
 
 Wait for the user to pick. For each selected insight, draft the note content and continue to Step 5. Process selected insights one at a time.
 

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: obsidian-setup
-description: "First-run configuration for the Obsidian Brain plugin. Sets up vault path, creates folders, copies dashboard templates, and writes config. Use when: (1) first time installing obsidian-brain, (2) changing vault path, (3) /obsidian-setup command."
+description: "First-run configuration and upgrade for the Obsidian Brain plugin. Sets up vault path, creates folders, copies dashboard templates, configures hookify nudges, and writes config. Idempotent — safe to re-run to pick up new features without overwriting existing config or dashboards. Use when: (1) first time installing obsidian-brain, (2) changing vault path, (3) /obsidian-setup command, (4) upgrading to a new version."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # Obsidian Brain Setup
@@ -15,7 +15,39 @@ Configure the obsidian-brain plugin for first use. This skill validates prerequi
 
 Follow these steps exactly. Do not skip steps or reorder them.
 
-### Step 1 — Ask for vault path
+### Step 1 — Check for existing installation
+
+Read `~/.claude/obsidian-brain-config.json`:
+
+```bash
+cat ~/.claude/obsidian-brain-config.json 2>/dev/null
+```
+
+**If the file exists and is valid JSON**, extract `vault_path` and present:
+
+> **Existing obsidian-brain installation detected.**
+> - Vault path: `<vault_path from config>`
+>
+> Would you like to:
+> - **upgrade** — add new features (dashboards, nudges) without touching existing config or dashboards
+> - **reconfigure** — start fresh (will overwrite config and dashboards)
+> - **cancel** — exit setup
+
+If **upgrade**: store `MODE=upgrade`. Use `vault_path` from the existing config. Skip to Step 5 (Create vault folders — `mkdir -p` is already safe). In upgrade mode:
+- Step 5 (Create vault folders): runs normally (`mkdir -p` is idempotent)
+- Step 6 (Install dashboards): only write dashboard files that do NOT already exist (`test -f` before each write)
+- Step 7 (Write config): SKIP entirely — preserve existing config
+- Step 8 (Verify vault access): runs normally
+- Step 9 (Configure claudeception nudge): runs normally (has its own idempotency check)
+- Step 10 (Print success message): show upgrade-specific message
+
+If **reconfigure**: store `MODE=reconfigure`. Proceed to Step 2 (Ask for vault path) as normal — full setup flow.
+
+If **cancel**: stop here.
+
+**If the file does not exist or is invalid JSON**: store `MODE=fresh`. Proceed to Step 2 (Ask for vault path) — first-time setup.
+
+### Step 2 — Ask for vault path
 
 Ask the user:
 
@@ -23,7 +55,7 @@ Ask the user:
 
 Store the response as `VAULT_PATH`. Strip any trailing slash.
 
-### Step 2 — Validate the vault path
+### Step 3 — Validate the vault path
 
 Run:
 
@@ -33,7 +65,7 @@ test -d "$VAULT_PATH" && test -w "$VAULT_PATH" && echo "OK" || echo "FAIL"
 
 If FAIL, tell the user the path does not exist or is not writable and ask them to correct it. Repeat until OK.
 
-### Step 3 — Check claude CLI availability
+### Step 4 — Check claude CLI availability
 
 Run:
 
@@ -47,7 +79,7 @@ If FAIL, warn the user:
 
 Continue regardless — this is a warning, not a blocker.
 
-### Step 4 — Create vault folders
+### Step 5 — Create vault folders
 
 Run:
 
@@ -55,9 +87,18 @@ Run:
 mkdir -p "$VAULT_PATH/claude-sessions" "$VAULT_PATH/claude-insights" "$VAULT_PATH/claude-dashboards"
 ```
 
-### Step 5 — Install dashboard templates
+### Step 6 — Install dashboard templates
 
-Write these three files into the vault. Use the Write tool for each.
+For each dashboard file below, check if it already exists before writing:
+
+```bash
+test -f "$VAULT_PATH/claude-dashboards/<filename>" && echo "EXISTS" || echo "MISSING"
+```
+
+If EXISTS and `MODE=upgrade`, skip this file — preserve user customizations.
+If MISSING (or `MODE=reconfigure`), write the file using the Write tool.
+
+**Dashboard files to install:**
 
 **File: `$VAULT_PATH/claude-dashboards/sessions-overview.md`**
 
@@ -127,15 +168,124 @@ SORT date DESC
 \```
 ```
 
+**File: `$VAULT_PATH/claude-dashboards/learning-velocity.md`**
+
+```markdown
+# Learning Velocity
+
+## Topics by Frequency
+\```dataviewjs
+let pages = dv.pages('"claude-insights"')
+    .where(p => p.tags);
+
+let topics = {};
+for (let p of pages) {
+    let tags = p.tags || [];
+    if (!Array.isArray(tags)) tags = [tags];
+    for (let tag of tags) {
+        if (typeof tag === 'string' && tag.startsWith("claude/topic/")) {
+            let topic = tag.replace("claude/topic/", "");
+            topics[topic] = (topics[topic] || 0) + 1;
+        }
+    }
+}
+
+dv.table(
+    ["Topic", "Notes"],
+    Object.entries(topics)
+        .sort((a, b) => b[1] - a[1])
+        .map(([topic, count]) => [topic, count])
+);
+\```
+
+## Recent Retrospectives
+\```dataview
+TABLE date, project
+FROM "claude-insights"
+WHERE type = "claude-retro"
+SORT date DESC
+LIMIT 10
+\```
+
+## Error Patterns (Most Common)
+\```dataviewjs
+let pages = dv.pages('"claude-insights"')
+    .where(p => p.type === "claude-error-fix");
+
+let topics = {};
+for (let p of pages) {
+    let tags = p.tags || [];
+    if (!Array.isArray(tags)) tags = [tags];
+    for (let tag of tags) {
+        if (typeof tag === 'string' && tag.startsWith("claude/topic/")) {
+            let topic = tag.replace("claude/topic/", "");
+            topics[topic] = (topics[topic] || 0) + 1;
+        }
+    }
+}
+
+dv.table(
+    ["Error Topic", "Occurrences"],
+    Object.entries(topics)
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 15)
+        .map(([topic, count]) => [topic, count])
+);
+\```
+```
+
+**File: `$VAULT_PATH/claude-dashboards/decision-timeline.md`**
+
+```markdown
+# Decision Timeline
+
+## Active Decisions
+\```dataview
+TABLE date, project
+FROM "claude-insights"
+WHERE type = "claude-decision" AND status = "active"
+SORT date DESC
+\```
+
+## All Decisions (Chronological)
+\```dataview
+TABLE date, project, status
+FROM "claude-insights"
+WHERE type = "claude-decision"
+SORT date DESC
+\```
+
+## Superseded Decisions
+\```dataview
+TABLE date, project
+FROM "claude-insights"
+WHERE type = "claude-decision" AND status = "superseded"
+SORT date DESC
+\```
+
+## Decisions by Project
+\```dataview
+TABLE length(rows) AS "Decisions", min(rows.date) AS "First", max(rows.date) AS "Last"
+FROM "claude-insights"
+WHERE type = "claude-decision"
+GROUP BY project
+SORT length(rows) DESC
+\```
+```
+
 **Important:** The backslash before the triple backticks above is an escape for this document only. When writing the actual files, use plain triple backticks (no backslash).
 
-### Step 6 — Write config file
+### Step 7 — Write config file
+
+**If `MODE=upgrade`:** Skip this step — preserve existing config.
+
+**If `MODE=fresh` or `MODE=reconfigure`:**
 
 Write `~/.claude/obsidian-brain-config.json` with this exact structure:
 
 ```json
 {
-  "vault_path": "<VAULT_PATH value from Step 1>",
+  "vault_path": "<VAULT_PATH value from Step 2>",
   "sessions_folder": "claude-sessions",
   "insights_folder": "claude-insights",
   "dashboards_folder": "claude-dashboards",
@@ -148,11 +298,11 @@ Write `~/.claude/obsidian-brain-config.json` with this exact structure:
 }
 ```
 
-Replace `<VAULT_PATH value from Step 1>` with the actual vault path. Ensure the file is valid JSON.
+Replace `<VAULT_PATH value from Step 2>` with the actual vault path. Ensure the file is valid JSON.
 
 First run `mkdir -p ~/.claude` to ensure the directory exists.
 
-### Step 7 — Verify vault access
+### Step 8 — Verify vault access
 
 Run:
 
@@ -163,16 +313,44 @@ echo "test" > "$TESTFILE" && test -f "$TESTFILE" && rm "$TESTFILE" && echo "OK" 
 
 If FAIL, warn that vault writes are not working and ask the user to check permissions.
 
-### Step 8 — Print success message
+### Step 9 — Configure claudeception nudge (idempotent)
 
-Print:
+Check if the claudeception-to-compress nudge is already configured:
+
+```bash
+grep -r "compress" ~/.claude/settings.json 2>/dev/null | grep -q "claudeception" && echo "EXISTS" || echo "MISSING"
+```
+
+If EXISTS, skip this step — the nudge is already configured.
+
+If MISSING, invoke `/hookify` with this instruction:
+
+> Create a rule: After claudeception finishes and produces output (skill creation or knowledge extraction), display a non-blocking nudge message: "Claudeception extracted knowledge from this session. Run `/compress` to save it to your Obsidian vault." The trigger should match the `Result: PASS` marker or skill file path output from claudeception.
+
+This is a soft nudge — a suggestion, not automatic execution.
+
+### Step 10 — Print success message
+
+**If `MODE=upgrade`:**
+
+> **Obsidian Brain upgraded!**
+>
+> - Vault path: `<VAULT_PATH>` (unchanged)
+> - Config: preserved (unchanged)
+> - New dashboards: installed (existing dashboards preserved)
+> - Claudeception nudge: configured
+>
+> Re-run `/obsidian-setup` anytime to pick up new features.
+
+**If `MODE=fresh` or `MODE=reconfigure`:**
 
 > **Obsidian Brain setup complete!**
 >
 > - Vault path: `<VAULT_PATH>`
 > - Config written to: `~/.claude/obsidian-brain-config.json`
 > - Folders created: `claude-sessions/`, `claude-insights/`, `claude-dashboards/`
-> - Dashboards installed: `sessions-overview.md`, `project-index.md`, `weekly-review.md`
+> - Dashboards installed: `sessions-overview.md`, `project-index.md`, `weekly-review.md`, `learning-velocity.md`, `decision-timeline.md`
+> - Claudeception nudge: configured (run `/compress` reminder after knowledge extraction)
 >
 > **Next step — install the Dataview plugin in Obsidian:**
 > 1. Open Obsidian Settings > Community Plugins > Browse

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -96,7 +96,7 @@ test -f "$VAULT_PATH/claude-dashboards/<filename>" && echo "EXISTS" || echo "MIS
 ```
 
 If EXISTS and `MODE=upgrade`, skip this file — preserve user customizations.
-If MISSING (or `MODE=reconfigure`), write the file using the Write tool.
+Otherwise (MISSING, or `MODE=fresh`, or `MODE=reconfigure`), write the file using the Write tool.
 
 **Dashboard files to install:**
 
@@ -318,7 +318,7 @@ If FAIL, warn that vault writes are not working and ask the user to check permis
 Check if the claudeception-to-compress nudge is already configured:
 
 ```bash
-grep -r "compress" ~/.claude/settings.json 2>/dev/null | grep -q "claudeception" && echo "EXISTS" || echo "MISSING"
+grep -q "Run ./compress. to save it to your Obsidian vault" ~/.claude/settings.json 2>/dev/null && echo "EXISTS" || echo "MISSING"
 ```
 
 If EXISTS, skip this step — the nudge is already configured.

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -33,7 +33,7 @@ cat ~/.claude/obsidian-brain-config.json 2>/dev/null
 > - **reconfigure** — start fresh (will overwrite config and dashboards)
 > - **cancel** — exit setup
 
-If **upgrade**: store `MODE=upgrade`. Use `vault_path` from the existing config. Skip to Step 5 (Create vault folders — `mkdir -p` is already safe). In upgrade mode:
+If **upgrade**: store `MODE=upgrade`. Store `VAULT_PATH` from the existing config's `vault_path` field. Also extract `sessions_folder` (default `claude-sessions`), `insights_folder` (default `claude-insights`), and `dashboards_folder` (default `claude-dashboards`). Skip to Step 5 (Create vault folders — `mkdir -p` is already safe). In upgrade mode:
 - Step 5 (Create vault folders): runs normally (`mkdir -p` is idempotent)
 - Step 6 (Install dashboards): only write dashboard files that do NOT already exist (`test -f` before each write)
 - Step 7 (Write config): SKIP entirely — preserve existing config


### PR DESCRIPTION
## Summary

- **Claudeception detection in `/compress`** — Step 4B now scans the conversation for claudeception output using layered detection (high-confidence structured markers first, broad phrase fallback). Extracted skills/knowledge appear as top-priority candidates labeled `[from claudeception]` or `[possibly from claudeception]`.
- **`/obsidian-setup` now idempotent** — Detects existing installations, offers upgrade/reconfigure/cancel. Upgrade mode preserves config and user-customized dashboards. Adds 2 missing Phase 2a dashboards (learning-velocity, decision-timeline) to the install list.
- **Hookify nudge via `/obsidian-setup`** — Idempotent step configures a non-blocking nudge reminding users to run `/compress` after claudeception output.
- Version bump to 1.5.0.

## Test plan

- [ ] Run `/claudeception` in a session that produces a skill, then run `/compress` — verify claudeception output appears as first candidate(s) with `[from claudeception]` label
- [ ] Run `/compress` in a session where claudeception did NOT run — verify standard candidate list appears without any labels
- [ ] Run `/compress <topic>` (single-topic mode) — verify it is unaffected by the change
- [ ] Re-run `/obsidian-setup` — verify upgrade detection, dashboard guards, config preservation
- [ ] Verify hookify nudge appears after claudeception produces output
- [ ] Verify Steps 5-10 of `/compress` are unchanged (save flow, preview, tags, filename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)