### PR TITLE
docs: add changelog entry for hookify nudge scope fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Hookify nudge scope** — `/obsidian-setup` now writes the claudeception-compress nudge rule to `~/.claude/` (global) instead of the project's `.claude/` directory, so the nudge triggers in any project where claudeception runs. Also fixes the existence check to look for the `.local.md` rule file instead of grepping `settings.json`.
+
 ## [1.5.0] - 2026-04-05
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds missing `[Unreleased]` changelog entry for the hookify nudge global scope fix (PR #7)

## Test plan

- [ ] Verify CHANGELOG.md has the entry under `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)