### PR TITLE
fix: changelog hook now diffs against base branch to detect stale entries

### DIFF
--- a/.claude/hooks/update-changelog-before-pr.py
+++ b/.claude/hooks/update-changelog-before-pr.py
@@ -40,8 +40,30 @@ def get_branch_commits():
         return []
 
 
+def check_changelog_modified_on_branch():
+    """Check if CHANGELOG.md was modified on the current branch vs base."""
+    try:
+        cwd = os.environ.get("CLAUDE_PROJECT_DIR", ".")
+        # Check against develop first, fall back to main
+        for base in ["origin/develop", "origin/main"]:
+            check = subprocess.run(
+                ["git", "rev-parse", "--verify", base],
+                capture_output=True, text=True, cwd=cwd
+            )
+            if check.returncode == 0:
+                result = subprocess.run(
+                    ["git", "diff", "--name-only", f"{base}...HEAD", "--", "CHANGELOG.md"],
+                    capture_output=True, text=True, cwd=cwd
+                )
+                if result.returncode == 0:
+                    return bool(result.stdout.strip()), base
+        return None, None  # Could not determine
+    except Exception:
+        return None, None
+
+
 def check_changelog_has_unreleased_entries():
-    """Check if CHANGELOG.md has meaningful entries under [Unreleased]."""
+    """Check if CHANGELOG.md has meaningful NEW entries under [Unreleased]."""
     try:
         changelog_path = os.path.join(
             os.environ.get("CLAUDE_PROJECT_DIR", "."),
@@ -65,10 +87,24 @@ def check_changelog_has_unreleased_entries():
         entries = [line.strip() for line in unreleased_body.split('\n')
                    if line.strip().startswith('- ')]
 
-        if entries:
-            return True, f"{len(entries)} entries found under [Unreleased]"
+        if not entries:
+            return False, "[Unreleased] section has no entries"
 
-        return False, "[Unreleased] section has no entries"
+        # Entries exist — but are they new on this branch or stale?
+        modified, base = check_changelog_modified_on_branch()
+        if modified is None:
+            # Can't determine — trust the entries exist
+            return True, f"{len(entries)} entries found under [Unreleased]"
+        elif modified:
+            return True, f"{len(entries)} entries found under [Unreleased] (modified on this branch)"
+        else:
+            # Entries exist but CHANGELOG.md wasn't modified on this branch — stale!
+            return False, (
+                f"[Unreleased] has {len(entries)} entries, but CHANGELOG.md was NOT "
+                f"modified on this branch (compared to {base}). "
+                f"These are stale entries from a previous release. "
+                f"Add a new entry for your changes"
+            )
     except (PermissionError, OSError) as e:
         return None, f"Cannot read CHANGELOG.md: {e}"
     except Exception as e:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Hookify nudge scope** — `/obsidian-setup` now writes the claudeception-compress nudge rule to `~/.claude/` (global) instead of the project's `.claude/` directory, so the nudge triggers in any project where claudeception runs. Also fixes the existence check to look for the `.local.md` rule file instead of grepping `settings.json`.
+- **Changelog PR hook now detects stale entries** — The `update-changelog-before-pr` hook now diffs CHANGELOG.md against the base branch instead of just checking for any entries under `[Unreleased]`. Stale entries from previous releases no longer cause false passes.
 
 ## [1.5.0] - 2026-04-05
 


### PR DESCRIPTION
## Summary

- **Changelog diff check** — The `update-changelog-before-pr` hook now diffs `CHANGELOG.md` against the base branch (`origin/develop` or `origin/main`) instead of just checking for any entries under `[Unreleased]`. Stale entries from previous releases no longer cause false passes.
- Adds `check_changelog_modified_on_branch()` helper that uses `git diff --name-only base...HEAD -- CHANGELOG.md`

## Test plan

- [ ] On a feature branch with no CHANGELOG changes: `gh pr create` should be blocked with "stale entries" message
- [ ] On a feature branch with new CHANGELOG entries: `gh pr create` should pass with "(modified on this branch)"
- [ ] On a branch where git base detection fails: falls back to trusting entry existence (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)