### PR TITLE
feat: add highlights summary to standup notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Standup highlights summary** — `/standup` now generates a highlights summary and key open items section at the top of standup notes for quick scanning.
+
+### Fixed
+
+- **Python 3.9 compatibility** — Added `from __future__ import annotations` to `obsidian_utils.py` so `X | None` type hints (PEP 604) work on macOS system Python 3.9.6. Previously caused `TypeError` at import time, breaking all hooks.
+- **SessionEnd hook cancellation** — Removed in-hook AI summarization (`claude -p` subprocess) from `obsidian_session_log.py`. SessionEnd hooks are fire-and-forget; the slow subprocess was killed when Claude Code's process tree exited. Summarization is now fully deferred to `/recall`.
+
 ## [1.5.1] - 2026-04-05
 
 ### Fixed

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -2,8 +2,10 @@
 """
 obsidian_session_log.py -- SessionEnd hook for obsidian-brain plugin.
 
-Reads the session transcript, writes a raw fallback note to the Obsidian vault,
-then attempts AI summarization to upgrade it. Always exits 0.
+Reads the session transcript and writes a raw note to the Obsidian vault.
+AI summarization is deferred to /recall (SessionEnd hooks are fire-and-forget;
+slow subprocess calls like `claude -p` get killed when the process tree exits).
+Always exits 0.
 """
 
 import datetime
@@ -23,7 +25,6 @@ from obsidian_utils import (  # noqa: E402
     extract_session_metadata,
     extract_tool_uses,
     extract_user_messages,
-    generate_summary,
     is_resumed_session,
     load_config,
     make_filename,
@@ -123,7 +124,6 @@ def _run() -> None:
         return
 
     sessions_folder = config.get("sessions_folder", "claude-sessions")
-    summary_model = config.get("summary_model", "haiku")
     min_messages = config.get("min_messages", 3)
     min_duration = config.get("min_duration_minutes", 2)
 
@@ -169,23 +169,7 @@ def _run() -> None:
     if not write_vault_note(vault_path, sessions_folder, filename, raw_content):
         print("[obsidian-brain] failed to write raw note, aborting", file=sys.stderr)
         return
-    print("[obsidian-brain] raw note written, attempting summarization...", file=sys.stderr)
-
-    # 10. Attempt AI summarization with 15s timeout
-    summary = generate_summary(
-        user_msgs, assistant_msgs, metadata,
-        model=summary_model, timeout=15,
-    )
-
-    # 11. If summary succeeds, overwrite with summarized version
-    if summary:
-        summarized_content = _build_note(session_id, metadata, summary, resumed=resumed)
-        if write_vault_note(vault_path, sessions_folder, filename, summarized_content):
-            print("[obsidian-brain] upgraded to AI summary", file=sys.stderr)
-        else:
-            print("[obsidian-brain] summary write failed, raw note preserved", file=sys.stderr)
-    else:
-        print("[obsidian-brain] summarization failed/timed out, raw note preserved", file=sys.stderr)
+    print("[obsidian-brain] raw note written (summarization deferred to /recall)", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -10,6 +10,8 @@ Extracted from the validated spike (spike_session_log.py) with these changes:
 Every public function catches its own errors and logs to stderr.
 """
 
+from __future__ import annotations
+
 import datetime
 import hashlib
 import json

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -238,7 +238,7 @@ Rules:
 - Decisions and errors should be deduplicated across sessions in the same project.
 - Open items should be listed as checkboxes (`- [ ]`).
 
-Precede all project sections with a header block:
+Precede all project sections with a header block that includes a highlights summary and consolidated open items:
 
 ```markdown
 # Standup: $START_DATE to $END_DATE
@@ -246,9 +246,22 @@ Precede all project sections with a header block:
 **Range:** $START_DATE → $END_DATE
 **Projects covered:** $PROJECT_COUNT
 **Sessions:** $SESSION_COUNT | **Insights:** $INSIGHT_COUNT
+
+### Highlights
+- **$PROJECT_A** — 1-2 sentence summary of what was accomplished this period
+- **$PROJECT_B** — 1-2 sentence summary of what was accomplished this period
+
+### Key Open Items
+- [ ] $PROJECT_A: $MOST_IMPORTANT_OPEN_ITEM
+- [ ] $PROJECT_B: $MOST_IMPORTANT_OPEN_ITEM
 ```
 
-If `IS_RANGE` is false (single day), use `# Standup: $DATE` and omit the "Range:" line.
+Rules for the header sections:
+- **Highlights:** Include only projects with substantive work (skip vault-import-only or config-tweak sessions). Write 1-2 sentences per project summarizing the outcome, not the process. Order by impact/significance, not alphabetically.
+- **Key Open Items:** Consolidate the most important open items across all projects (max ~5-7 items). Prefix each with the project name. These are the items that should drive next week's work. Skip low-priority or already-in-progress items.
+- Both sections are written in the saved note AND presented in the conversation output.
+
+If `IS_RANGE` is false (single day), use `# Standup: $DATE` and omit the "Range:" line. For single-day standups, the Highlights section may be omitted if only 1-2 sessions occurred.
 
 ### Step 10 — Build frontmatter
 

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -248,8 +248,8 @@ Precede all project sections with a header block that includes a highlights summ
 **Sessions:** $SESSION_COUNT | **Insights:** $INSIGHT_COUNT
 
 ### Highlights
-- **$PROJECT_A** — 1-2 sentence summary of what was accomplished this period
-- **$PROJECT_B** — 1-2 sentence summary of what was accomplished this period
+- **$PROJECT_A** — 1-2 sentences summarizing what was accomplished this period
+- **$PROJECT_B** — 1-2 sentences summarizing what was accomplished this period
 
 ### Key Open Items
 - [ ] $PROJECT_A: $MOST_IMPORTANT_OPEN_ITEM


### PR DESCRIPTION
## Summary
- Standup notes now include a `### Highlights` section with per-project outcome summaries
- Adds `### Key Open Items` section consolidating the most important actionable items across all projects
- Both sections are written to the saved note AND presented in conversation output
- **Fix: Python 3.9 compatibility** — Added `from __future__ import annotations` to `obsidian_utils.py` so `X | None` type hints work on macOS system Python 3.9.6 (previously caused `TypeError` breaking all hooks)
- **Fix: SessionEnd hook cancellation** — Removed in-hook AI summarization (`claude -p` subprocess) from `obsidian_session_log.py`. SessionEnd hooks are fire-and-forget; the subprocess was killed on exit. Summarization fully deferred to `/recall`

## Test plan
- [ ] Run `/standup` or `/standup weekly` and verify highlights + key open items appear at the top of the generated note
- [ ] Verify single-day standups with 1-2 sessions can omit highlights per the new rule
- [ ] Verify `python3 -c "import sys; sys.path.insert(0, 'hooks'); import obsidian_utils"` works on Python 3.9
- [ ] Verify SessionEnd hook writes raw note and exits quickly (no summarization attempt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)