### PR TITLE
feat: permission-aware setup + README troubleshooting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .DS_Store
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Permission pre-flight check in `/obsidian-setup`** — Detects restrictive Claude Code permission modes via canary write before attempting out-of-workspace writes. Presents three options: switch mode (`Shift+Tab`), whitelist paths in settings, or continue manually.
+- **Vault path canary** — Tests vault writability in `/obsidian-setup` Step 5 before creating folders, catching cases where `~/.claude/` is writable but the vault is not.
+- **README troubleshooting section** — Covers silent setup failures (permission modes), `python` not found on macOS, and vault path not writable.
+
+### Changed
+
+- **Auto-logging description** — README now accurately reflects deferred summarization (removed reference to in-hook `claude -p` subprocess).
+
 ## [1.5.2] - 2026-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -126,10 +126,9 @@ Run `/obsidian-setup` after installation. It will:
 Sessions are automatically logged to your vault on every session end (via hooks). No manual action needed. The hook:
 
 1. Reads the session transcript
-2. Writes a raw session note immediately (guaranteed)
-3. Attempts `claude -p --model haiku` summarization with 15s timeout (best-effort)
-4. Falls back to raw data extraction if summarization fails
-5. Unsummarized notes are upgraded when `/recall` is invoked
+2. Extracts metadata, user/assistant messages, and tool usage
+3. Writes a raw session note immediately (guaranteed, fast)
+4. Unsummarized notes are upgraded with AI summaries when `/recall` is invoked
 
 **Smart filtering:** Sessions with fewer than 3 user messages or shorter than 2 minutes are skipped.
 
@@ -238,6 +237,42 @@ Machine-local config at `~/.claude/obsidian-brain-config.json`:
 
 - **Obsidian Sync:** Works seamlessly — all vault writes are new markdown files (no conflict risk). Config lives at `~/.claude/` (machine-local, outside the vault).
 - **New machine setup:** Install the plugin, run `/obsidian-setup` with your vault path on that machine.
+
+## Troubleshooting
+
+### Setup fails silently / writes not working
+
+**Symptom:** `/obsidian-setup` appears to complete but config file, vault folders, or dashboards were not created.
+
+**Cause:** Claude Code's permission mode or filesystem sandbox is blocking writes outside the working directory.
+
+**Fix:** Press `Shift+Tab` and switch to "accept edits" mode, then re-run `/obsidian-setup`. For a permanent fix, use `/config` to change `permissions.defaultMode`, or add paths to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json`:
+
+```json
+{
+  "sandbox": {
+    "filesystem": {
+      "allowWrite": ["~/.claude", "~/path/to/vault-parent"]
+    }
+  }
+}
+```
+
+### `python` not found on macOS
+
+**Symptom:** Hook scripts fail with "command not found: python".
+
+**Cause:** macOS ships `python3`, not `python`.
+
+**Fix:** The hooks use `python3` by default. If you see this error, check that `python3` is on your PATH (`which python3`). Install via Xcode Command Line Tools (`xcode-select --install`) or Homebrew (`brew install python`).
+
+### Vault path not writable
+
+**Symptom:** Setup reports the vault path is not writable, or session notes fail to save.
+
+**Cause:** Directory permissions, Obsidian Sync lock files, or cloud sync conflicts.
+
+**Fix:** Check `ls -la` on the vault directory. Ensure your user owns it and has write permission. If using Obsidian Sync or iCloud, ensure the sync agent isn't locking files during writes.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -246,17 +246,19 @@ Machine-local config at `~/.claude/obsidian-brain-config.json`:
 
 **Cause:** Claude Code's permission mode or filesystem sandbox is blocking writes outside the working directory.
 
-**Fix:** Press `Shift+Tab` and switch to "accept edits" mode, then re-run `/obsidian-setup`. For a permanent fix, use `/config` to change `permissions.defaultMode`, or add paths to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json`:
+**Fix:** Press `Shift+Tab` and switch to "accept edits" mode, then re-run `/obsidian-setup`. For a permanent fix, use `/config` to change `permissions.defaultMode`, or add paths to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json`. **Use absolute paths** — `~` is not expanded inside JSON string values:
 
 ```json
 {
   "sandbox": {
     "filesystem": {
-      "allowWrite": ["~/.claude", "~/path/to/vault-parent"]
+      "allowWrite": ["/Users/you/.claude", "/Users/you/Documents/vault-parent"]
     }
   }
 }
 ```
+
+Replace `/Users/you` with your actual home directory (run `echo $HOME` to find it).
 
 ### `python` not found on macOS
 

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -67,23 +67,23 @@ If **FAIL**: present the following message using AskUserQuestion:
 >
 > 1. **Switch permission mode (recommended)** — Press `Shift+Tab` to switch to "accept edits" mode for this session. Or use `/config` to change `permissions.defaultMode` permanently. Then re-run `/obsidian-setup`.
 >
-> 2. **Whitelist paths permanently** — Add `~/.claude` and your vault's parent directory to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json`:
+> 2. **Whitelist paths permanently** — Add `$HOME/.claude` and your vault's parent directory to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json`. **Use absolute paths** — `~` is not expanded inside JSON string values:
 >    ```json
 >    {
 >      "sandbox": {
 >        "filesystem": {
->          "allowWrite": ["~/.claude", "~/path/to/vault-parent"]
+>          "allowWrite": ["/Users/you/.claude", "/Users/you/Documents/vault-parent"]
 >        }
 >      }
 >    }
 >    ```
->    Then re-run `/obsidian-setup`.
+>    Replace `/Users/you` with your actual home directory (run `echo $HOME` to find it). Then re-run `/obsidian-setup`.
 >
 > 3. **I'll handle it myself** — Continue setup and approve or fix writes as they come up.
 
 **Behavior per option:**
 - **Option 1:** Print the instruction, then stop. User changes mode and re-runs `/obsidian-setup`.
-- **Option 2:** Print the JSON snippet (include the vault parent path if already known from Step 1's existing config). Then stop. User edits settings and re-runs.
+- **Option 2:** Print the JSON snippet with absolute paths. In upgrade mode (`MODE=upgrade`), substitute the known vault parent path from the existing config. In fresh mode, show only the `$HOME/.claude` entry with a note that the vault parent must be added after the user provides the vault path. Then stop. User edits settings and re-runs.
 - **Option 3:** Continue with setup as normal. Writes may fail and the user deals with each one.
 
 ### Step 2 — Ask for vault path

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: obsidian-setup
 description: "First-run configuration and upgrade for the Obsidian Brain plugin. Sets up vault path, creates folders, copies dashboard templates, configures hookify nudges, and writes config. Idempotent — safe to re-run to pick up new features without overwriting existing config or dashboards. Use when: (1) first time installing obsidian-brain, (2) changing vault path, (3) /obsidian-setup command, (4) upgrading to a new version."
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Obsidian Brain Setup

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -120,7 +120,19 @@ Continue regardless — this is a warning, not a blocker.
 
 ### Step 5 — Create vault folders
 
-Run:
+First, test that the vault path is writable:
+
+```bash
+echo "test" > "$VAULT_PATH/.obsidian-brain-canary" 2>&1 && rm -f "$VAULT_PATH/.obsidian-brain-canary" && echo "OK" || echo "FAIL"
+```
+
+If **FAIL**, tell the user:
+
+> **Cannot write to your vault at `$VAULT_PATH`.** This is likely a sandbox restriction. Add your vault's parent directory to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json`, or switch to "accept edits" mode (`Shift+Tab`), then re-run `/obsidian-setup`.
+
+Stop here if FAIL.
+
+If **OK**, create the folders:
 
 ```bash
 mkdir -p "$VAULT_PATH/claude-sessions" "$VAULT_PATH/claude-insights" "$VAULT_PATH/claude-dashboards"

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -47,6 +47,45 @@ If **cancel**: stop here.
 
 **If the file does not exist or is invalid JSON**: store `MODE=fresh`. Proceed to Step 2 (Ask for vault path) — first-time setup.
 
+### Step 1.5 — Permission pre-flight check
+
+Before any out-of-workspace writes, test whether Claude Code can write to `~/.claude/`:
+
+```bash
+echo "test" > ~/.claude/.obsidian-brain-canary 2>&1 && rm -f ~/.claude/.obsidian-brain-canary && echo "OK" || echo "FAIL"
+```
+
+If **OK**: proceed silently to Step 2.
+
+If **FAIL**: present the following message using AskUserQuestion:
+
+> **Heads up — setup needs write access outside this project directory.**
+>
+> Obsidian Brain writes config to `~/.claude/` and notes to your Obsidian vault. Your current Claude Code permissions block writes outside the working directory.
+>
+> Choose how to fix this:
+>
+> 1. **Switch permission mode (recommended)** — Press `Shift+Tab` to switch to "accept edits" mode for this session. Or use `/config` to change `permissions.defaultMode` permanently. Then re-run `/obsidian-setup`.
+>
+> 2. **Whitelist paths permanently** — Add `~/.claude` and your vault's parent directory to `sandbox.filesystem.allowWrite` in `~/.claude/settings.json`:
+>    ```json
+>    {
+>      "sandbox": {
+>        "filesystem": {
+>          "allowWrite": ["~/.claude", "~/path/to/vault-parent"]
+>        }
+>      }
+>    }
+>    ```
+>    Then re-run `/obsidian-setup`.
+>
+> 3. **I'll handle it myself** — Continue setup and approve or fix writes as they come up.
+
+**Behavior per option:**
+- **Option 1:** Print the instruction, then stop. User changes mode and re-runs `/obsidian-setup`.
+- **Option 2:** Print the JSON snippet (include the vault parent path if already known from Step 1's existing config). Then stop. User edits settings and re-runs.
+- **Option 3:** Continue with setup as normal. Writes may fail and the user deals with each one.
+
 ### Step 2 — Ask for vault path
 
 Ask the user:


### PR DESCRIPTION
## Summary
- `/obsidian-setup` now detects restrictive permission modes via canary write before any out-of-workspace writes
- Three user options on failure: switch mode (Shift+Tab), whitelist paths in settings, or continue manually
- Vault path canary in Step 5 catches sandbox restrictions on the vault directory
- README troubleshooting section covers 3 common issues
- Auto-logging description updated to reflect deferred summarization (v1.5.2)
- obsidian-setup skill version bumped to 1.2.0

## Test plan
- [ ] Run `/obsidian-setup` in "accept edits" mode — should proceed without showing permission warning
- [ ] Run `/obsidian-setup` in "don't ask" mode — should detect canary failure and present 3 options
- [ ] Select option 3 and verify setup continues
- [ ] Verify README troubleshooting section renders correctly on GitHub
- [ ] Verify auto-logging description no longer mentions `claude -p`

## Spec
docs/superpowers/specs/2026-04-06-obsidian-brain-permission-aware-setup-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)