### PR TITLE
feat: open items dashboard + auto-checkoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Cross-project open items dashboard** — New `claude-dashboards/open-items.md` Dataview dashboard installed by `/obsidian-setup`. Shows all unchecked `- [ ]` items from session notes' `## Open Questions / Next Steps` sections, grouped by project, with separate "Recent (7d)" and "Stale (>30d)" views. Scoped to the last 90 days for performance.
-- **`/check-items` skill** — Cross-project sweep that scans all session notes for unchecked items, gathers evidence from recent sessions per project, proposes matches via substring + completion-phrase heuristics, and flips confirmed items from `- [ ]` to `- [x]` in the source notes. Default 14-day evidence window, configurable via `/check-items <Nd>`.
+- **Cross-project open items dashboard** — New `claude-dashboards/open-items.md` Dataview dashboard installed by `/obsidian-setup`. Shows all unchecked `- [ ]` items from session notes' `## Open Questions / Next Steps` sections, grouped by project, with separate "Recent (7d)" and "Items from sessions 30-90 days ago" views plus stats. Scoped to the last 90 days for performance.
+- **`/check-items` skill** — Cross-project sweep that scans all session notes for unchecked items (unbounded), gathers evidence from sessions in the last 14 days per project, proposes matches via substring + completion-phrase heuristics, and flips confirmed items from `- [ ]` to `- [x]` in the source notes. The 14-day window applies only to the evidence pool used for matching; open-item collection itself is unbounded. Configurable via `/check-items <Nd>`.
 - **`/recall` auto-detect** — `/recall` now detects open items from the current project that may have been completed in the most recent loaded session. Proposes candidates with evidence snippets; user confirms before any edits.
 - **`/standup` Closed This Period section** — Standup notes now include a section listing items checked off during the standup window, grouped by project. Detected via file modification time. Omitted if zero items closed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Cross-project open items dashboard** — New `claude-dashboards/open-items.md` Dataview dashboard installed by `/obsidian-setup`. Shows all unchecked `- [ ]` items from session notes' `## Open Questions / Next Steps` sections, grouped by project, with separate "Recent (7d)" and "Stale (>30d)" views. Scoped to the last 90 days for performance.
+- **`/check-items` skill** — Cross-project sweep that scans all session notes for unchecked items, gathers evidence from recent sessions per project, proposes matches via substring + completion-phrase heuristics, and flips confirmed items from `- [ ]` to `- [x]` in the source notes. Default 14-day evidence window, configurable via `/check-items <Nd>`.
+- **`/recall` auto-detect** — `/recall` now detects open items from the current project that may have been completed in the most recent loaded session. Proposes candidates with evidence snippets; user confirms before any edits.
+- **`/standup` Closed This Period section** — Standup notes now include a section listing items checked off during the standup window, grouped by project. Detected via file modification time. Omitted if zero items closed.
+
+### Changed
+
+- **`obsidian-setup` skill** — Now installs the new `open-items.md` dashboard. Skill version bumped to 1.3.0.
+- **`recall` skill** — New Step 7.5 detects completed open items. Skill version bumped to 1.1.0.
+- **`standup` skill** — New "Closed This Period" section. Skill version bumped to 1.1.0.
+
 ## [1.5.3] - 2026-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Run `/obsidian-setup` after installation. It will:
 | `/link` | Cross-reference related notes with bidirectional wikilinks |
 | `/retro` | Session retrospective — what worked, what didn't, process improvements |
 | `/vault-ask` | Ask questions and get synthesized answers grounded in vault history |
+| `/check-items` | Cross-project sweep for completed open items — auto-checks off matches after user confirmation |
 
 ### Usage Examples
 
@@ -119,6 +120,12 @@ Run `/obsidian-setup` after installation. It will:
 
 # Ask a question across all vault history
 /vault-ask what patterns have I used for error handling?
+
+# Sweep open items across all projects (default 14-day evidence window)
+/check-items
+
+# Sweep with a 30-day evidence window
+/check-items 30d
 ```
 
 ## Auto-Logging
@@ -204,13 +211,14 @@ All tags use the `claude/` prefix to separate from your existing vault tags:
 
 ## Dataview Dashboards
 
-Five dashboard templates are installed to `claude-dashboards/`:
+Six dashboard templates are installed to `claude-dashboards/`:
 
 - **Sessions Overview** — recent sessions, insights, and active decisions across all projects
 - **Project Index** — sessions grouped by project with counts and date ranges
 - **Weekly Review** — this week's activity
 - **Learning Velocity** — topic frequency from curated insights, recent retrospectives, and error patterns
 - **Decision Timeline** — chronological view of all decisions with active/superseded status tracking
+- **Open Items** — cross-project view of all unchecked `- [ ]` items from session notes' Open Questions sections, scoped to the last 90 days
 
 These use [Dataview](https://github.com/blacksmithgu/obsidian-dataview) queries that auto-update as new notes are added.
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Stores hand-picked insights you save via `/compress`, `/decide`, and `/error-log
 
 Contains Obsidian Dataview dashboard templates that auto-update as notes are added. These are for browsing your vault visually in Obsidian — they don't get loaded into Claude Code sessions.
 
-**Dashboards included:** Sessions Overview (recent activity across all projects), Project Index (sessions grouped by project), Weekly Review (this week's activity).
+**Dashboards included:** Sessions Overview, Project Index, Weekly Review, Learning Velocity, Decision Timeline, Open Items. See the [Dataview Dashboards](#dataview-dashboards) section below for descriptions.
 
 **Requires:** [Dataview](https://github.com/blacksmithgu/obsidian-dataview) community plugin with JavaScript Queries enabled.
 

--- a/dashboards/open-items.md
+++ b/dashboards/open-items.md
@@ -76,7 +76,9 @@ if (items.length === 0) {
 }
 ```
 
-## Stale (>30 days, still open, within 90-day window)
+## Items from sessions 30-90 days ago
+
+These are unchecked items captured in session notes that are 30-90 days old. The same item may also appear in a more recent session — in that case it will also show in the "Recent" section above. Filter is by source session date, not by item-tracking duration.
 
 ```dataviewjs
 let recentCutoff = dv.date("today").minus(dv.duration("30 days"));

--- a/dashboards/open-items.md
+++ b/dashboards/open-items.md
@@ -2,23 +2,27 @@
 
 Cross-project view of all unchecked `- [ ]` items from session notes' `## Open Questions / Next Steps` sections, scoped to the last 90 days. Items older than 90 days fall off this view — use `/check-items` (unbounded) or `/vault-search` to find them.
 
-## By Project
-
 ```dataviewjs
-let cutoff = dv.date("today").minus(dv.duration("90 days"));
+// Single-pass: scan all sessions in the last 90 days exactly once,
+// build a master list, then render each section from in-memory data.
 
-let pages = dv.pages('"claude-sessions"')
-    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
+const cutoff90 = dv.date("today").minus(dv.duration("90 days"));
+const cutoff30 = dv.date("today").minus(dv.duration("30 days"));
+const cutoff7  = dv.date("today").minus(dv.duration("7 days"));
 
-let allItems = [];
-for (let p of pages) {
-    let content = await dv.io.load(p.file.path);
+const pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff90);
+
+const allItems = [];
+for (const p of pages) {
+    const content = await dv.io.load(p.file.path);
     if (!content) continue;
-    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    // CRLF-tolerant: \r?\n in lookahead, split on /\r?\n/
+    const match = content.match(/## Open Questions[^\r\n]*\r?\n([\s\S]*?)(?=\r?\n## |\r?\n# |$)/);
     if (!match) continue;
-    let lines = match[1].split("\n");
-    for (let line of lines) {
-        let m = line.match(/^- \[ \] (.+)$/);
+    const lines = match[1].split(/\r?\n/);
+    for (const line of lines) {
+        const m = line.match(/^- \[ \] (.+?)\s*$/);
         if (m) {
             allItems.push({
                 project: p.project || "unknown",
@@ -30,122 +34,78 @@ for (let p of pages) {
     }
 }
 
-let byProject = {};
-for (let i of allItems) {
-    if (!byProject[i.project]) byProject[i.project] = [];
-    byProject[i.project].push(i);
-}
-
-let projectNames = Object.keys(byProject).sort();
-for (let project of projectNames) {
-    let items = byProject[project];
-    dv.header(3, project + " (" + items.length + ")");
-    dv.list(items.map(i => i.item + " — " + i.file));
-}
+// ----- By Project -----
+dv.header(2, "By Project");
 
 if (allItems.length === 0) {
     dv.paragraph("No open items in the last 90 days.");
-}
-```
-
-## Recent (last 7 days)
-
-```dataviewjs
-let cutoff = dv.date("today").minus(dv.duration("7 days"));
-
-let pages = dv.pages('"claude-sessions"')
-    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
-
-let items = [];
-for (let p of pages) {
-    let content = await dv.io.load(p.file.path);
-    if (!content) continue;
-    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
-    if (!match) continue;
-    let lines = match[1].split("\n");
-    for (let line of lines) {
-        let m = line.match(/^- \[ \] (.+)$/);
-        if (m) items.push({ project: p.project || "unknown", item: m[1], file: p.file.link });
+} else {
+    const byProject = {};
+    for (const i of allItems) {
+        if (!byProject[i.project]) byProject[i.project] = [];
+        byProject[i.project].push(i);
+    }
+    const projectNames = Object.keys(byProject).sort();
+    for (const project of projectNames) {
+        const items = byProject[project];
+        dv.header(3, project + " (" + items.length + ")");
+        // Render as table to preserve clickable file link
+        dv.table(
+            ["Item", "Source"],
+            items.map(i => [i.item, i.file])
+        );
     }
 }
 
-if (items.length === 0) {
+// ----- Recent (last 7 days) -----
+dv.header(2, "Recent (last 7 days)");
+
+const recent = allItems.filter(i => i.date >= cutoff7);
+if (recent.length === 0) {
     dv.paragraph("No open items from sessions in the last 7 days.");
 } else {
-    dv.list(items.map(i => "**[" + i.project + "]** " + i.item + " — " + i.file));
-}
-```
-
-## Items from sessions 30-90 days ago
-
-These are unchecked items captured in session notes that are 30-90 days old. The same item may also appear in a more recent session — in that case it will also show in the "Recent" section above. Filter is by source session date, not by item-tracking duration.
-
-```dataviewjs
-let recentCutoff = dv.date("today").minus(dv.duration("30 days"));
-let oldCutoff = dv.date("today").minus(dv.duration("90 days"));
-
-let pages = dv.pages('"claude-sessions"')
-    .where(p => p.type === "claude-session" && p.date && p.date < recentCutoff && p.date >= oldCutoff);
-
-let items = [];
-for (let p of pages) {
-    let content = await dv.io.load(p.file.path);
-    if (!content) continue;
-    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
-    if (!match) continue;
-    let lines = match[1].split("\n");
-    for (let line of lines) {
-        let m = line.match(/^- \[ \] (.+)$/);
-        if (m) items.push({ project: p.project || "unknown", item: m[1], date: p.date, file: p.file.link });
-    }
+    dv.table(
+        ["Project", "Item", "Source"],
+        recent.map(i => [i.project, i.item, i.file])
+    );
 }
 
-if (items.length === 0) {
-    dv.paragraph("No stale open items.");
+// ----- Items from sessions 30-90 days ago -----
+dv.header(2, "Items from sessions 30-90 days ago");
+dv.paragraph("These are unchecked items captured in session notes that are 30-90 days old. The same item may also appear in a more recent session — in that case it will also show in the \"Recent\" section above. Filter is by source session date, not by item-tracking duration.");
+
+const stale = allItems
+    .filter(i => i.date < cutoff30)
+    .sort((a, b) => a.date - b.date);
+if (stale.length === 0) {
+    dv.paragraph("No items from sessions 30-90 days ago.");
 } else {
-    items.sort((a, b) => a.date - b.date);
-    dv.list(items.map(i => "**[" + i.project + "]** " + i.item + " (from " + i.date.toFormat("yyyy-MM-dd") + ") — " + i.file));
+    dv.table(
+        ["Project", "Item", "From", "Source"],
+        stale.map(i => [i.project, i.item, i.date.toFormat("yyyy-MM-dd"), i.file])
+    );
 }
-```
 
-## Stats
+// ----- Stats -----
+dv.header(2, "Stats");
 
-```dataviewjs
-let cutoff = dv.date("today").minus(dv.duration("90 days"));
-
-let pages = dv.pages('"claude-sessions"')
-    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
-
-let total = 0;
-let byProject = {};
+const statsByProject = {};
 let oldestDate = null;
-
-for (let p of pages) {
-    let content = await dv.io.load(p.file.path);
-    if (!content) continue;
-    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
-    if (!match) continue;
-    let lines = match[1].split("\n");
-    for (let line of lines) {
-        if (/^- \[ \] /.test(line)) {
-            total++;
-            let project = p.project || "unknown";
-            byProject[project] = (byProject[project] || 0) + 1;
-            if (!oldestDate || p.date < oldestDate) oldestDate = p.date;
-        }
-    }
+for (const i of allItems) {
+    statsByProject[i.project] = (statsByProject[i.project] || 0) + 1;
+    if (!oldestDate || i.date < oldestDate) oldestDate = i.date;
 }
 
-dv.paragraph("**Total open items (last 90 days):** " + total);
-dv.paragraph("**Projects with open items:** " + Object.keys(byProject).length);
+dv.paragraph("**Total open items (last 90 days):** " + allItems.length);
+dv.paragraph("**Projects with open items:** " + Object.keys(statsByProject).length);
 if (oldestDate) {
     dv.paragraph("**Oldest open item from:** " + oldestDate.toFormat("yyyy-MM-dd"));
 }
 
-if (Object.keys(byProject).length > 0) {
+if (Object.keys(statsByProject).length > 0) {
     dv.table(
         ["Project", "Open Items"],
-        Object.entries(byProject).sort((a, b) => b[1] - a[1])
+        Object.entries(statsByProject).sort((a, b) => b[1] - a[1])
     );
 }
 ```

--- a/dashboards/open-items.md
+++ b/dashboards/open-items.md
@@ -1,0 +1,149 @@
+# Open Items — All Projects
+
+Cross-project view of all unchecked `- [ ]` items from session notes' `## Open Questions / Next Steps` sections, scoped to the last 90 days. Items older than 90 days fall off this view — use `/check-items` (unbounded) or `/vault-search` to find them.
+
+## By Project
+
+```dataviewjs
+let cutoff = dv.date("today").minus(dv.duration("90 days"));
+
+let pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
+
+let allItems = [];
+for (let p of pages) {
+    let content = await dv.io.load(p.file.path);
+    if (!content) continue;
+    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    if (!match) continue;
+    let lines = match[1].split("\n");
+    for (let line of lines) {
+        let m = line.match(/^- \[ \] (.+)$/);
+        if (m) {
+            allItems.push({
+                project: p.project || "unknown",
+                item: m[1],
+                date: p.date,
+                file: p.file.link
+            });
+        }
+    }
+}
+
+let byProject = {};
+for (let i of allItems) {
+    if (!byProject[i.project]) byProject[i.project] = [];
+    byProject[i.project].push(i);
+}
+
+let projectNames = Object.keys(byProject).sort();
+for (let project of projectNames) {
+    let items = byProject[project];
+    dv.header(3, project + " (" + items.length + ")");
+    dv.list(items.map(i => i.item + " — " + i.file));
+}
+
+if (allItems.length === 0) {
+    dv.paragraph("No open items in the last 90 days.");
+}
+```
+
+## Recent (last 7 days)
+
+```dataviewjs
+let cutoff = dv.date("today").minus(dv.duration("7 days"));
+
+let pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
+
+let items = [];
+for (let p of pages) {
+    let content = await dv.io.load(p.file.path);
+    if (!content) continue;
+    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    if (!match) continue;
+    let lines = match[1].split("\n");
+    for (let line of lines) {
+        let m = line.match(/^- \[ \] (.+)$/);
+        if (m) items.push({ project: p.project || "unknown", item: m[1], file: p.file.link });
+    }
+}
+
+if (items.length === 0) {
+    dv.paragraph("No open items from sessions in the last 7 days.");
+} else {
+    dv.list(items.map(i => "**[" + i.project + "]** " + i.item + " — " + i.file));
+}
+```
+
+## Stale (>30 days, still open, within 90-day window)
+
+```dataviewjs
+let recentCutoff = dv.date("today").minus(dv.duration("30 days"));
+let oldCutoff = dv.date("today").minus(dv.duration("90 days"));
+
+let pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date < recentCutoff && p.date >= oldCutoff);
+
+let items = [];
+for (let p of pages) {
+    let content = await dv.io.load(p.file.path);
+    if (!content) continue;
+    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    if (!match) continue;
+    let lines = match[1].split("\n");
+    for (let line of lines) {
+        let m = line.match(/^- \[ \] (.+)$/);
+        if (m) items.push({ project: p.project || "unknown", item: m[1], date: p.date, file: p.file.link });
+    }
+}
+
+if (items.length === 0) {
+    dv.paragraph("No stale open items.");
+} else {
+    items.sort((a, b) => a.date - b.date);
+    dv.list(items.map(i => "**[" + i.project + "]** " + i.item + " (from " + i.date.toFormat("yyyy-MM-dd") + ") — " + i.file));
+}
+```
+
+## Stats
+
+```dataviewjs
+let cutoff = dv.date("today").minus(dv.duration("90 days"));
+
+let pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
+
+let total = 0;
+let byProject = {};
+let oldestDate = null;
+
+for (let p of pages) {
+    let content = await dv.io.load(p.file.path);
+    if (!content) continue;
+    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    if (!match) continue;
+    let lines = match[1].split("\n");
+    for (let line of lines) {
+        if (/^- \[ \] /.test(line)) {
+            total++;
+            let project = p.project || "unknown";
+            byProject[project] = (byProject[project] || 0) + 1;
+            if (!oldestDate || p.date < oldestDate) oldestDate = p.date;
+        }
+    }
+}
+
+dv.paragraph("**Total open items (last 90 days):** " + total);
+dv.paragraph("**Projects with open items:** " + Object.keys(byProject).length);
+if (oldestDate) {
+    dv.paragraph("**Oldest open item from:** " + oldestDate.toFormat("yyyy-MM-dd"));
+}
+
+if (Object.keys(byProject).length > 0) {
+    dv.table(
+        ["Project", "Open Items"],
+        Object.entries(byProject).sort((a, b) => b[1] - a[1])
+    );
+}
+```

--- a/skills/check-items/SKILL.md
+++ b/skills/check-items/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: check-items
+description: "Cross-project sweep to detect and check off completed open items in the Obsidian vault. Scans all session notes for unchecked `- [ ]` items, gathers evidence from recent sessions per project, proposes matches, and flips confirmed items to `- [x]`. Use when: (1) /check-items command, (2) /check-items <Nd> for custom scan window (default 14 days), (3) cleaning up the open-items dashboard."
+metadata:
+  version: 1.0.0
+---
+
+# Check Items — Cross-Project Open Item Sweep
+
+Scans all session notes across all projects for unchecked `- [ ]` items in `## Open Questions / Next Steps` sections, gathers evidence from recent sessions per project, proposes completed items, and flips them to `- [x]` after user confirmation.
+
+**Tools needed:** Bash, Grep, Read, Edit
+
+## Procedure
+
+Follow these steps exactly. Do not skip steps or reorder them.
+
+### Step 1 — Load config
+
+Run:
+
+```bash
+cat ~/.claude/obsidian-brain-config.json
+```
+
+If the file does not exist or is not valid JSON, tell the user:
+
+> Config not found. Run `/obsidian-setup` first to configure your Obsidian vault.
+
+Stop here if config is missing. Otherwise extract `vault_path` and `sessions_folder` (default `claude-sessions`). Store as `VAULT_PATH` and `SESSIONS_FOLDER`.
+
+### Step 2 — Validate vault access
+
+Run:
+
+```bash
+test -d "$VAULT_PATH/$SESSIONS_FOLDER" && echo "OK" || echo "FAIL"
+```
+
+If FAIL, tell the user:
+
+> The sessions folder `$VAULT_PATH/$SESSIONS_FOLDER` does not exist. Run `/obsidian-setup` to fix this.
+
+Stop here if FAIL.
+
+### Step 3 — Parse scan window argument
+
+Inspect the argument passed after `/check-items`. Default is `14d` (14 days).
+
+- `/check-items` → `SCAN_DAYS=14`
+- `/check-items 30d` → `SCAN_DAYS=30`
+- `/check-items 7d` → `SCAN_DAYS=7`
+
+If the argument is not in `Nd` format, tell the user the format and use the default.
+
+Compute the cutoff date:
+
+```bash
+SCAN_CUTOFF=$(date -v-${SCAN_DAYS}d +%Y-%m-%d 2>/dev/null || date -d "-${SCAN_DAYS} days" +%Y-%m-%d)
+```
+
+(The first form is macOS, the fallback is Linux.)
+
+### Step 4 — Collect all open items
+
+Use Grep:
+
+```
+pattern: ^- \[ \] 
+path: $VAULT_PATH/$SESSIONS_FOLDER/
+output_mode: content
+-n: true
+```
+
+For each match line, extract the file path. To verify the match is under `## Open Questions / Next Steps` (not some other section), use Grep on the same file:
+
+```
+pattern: ## Open Questions
+path: <each matched file>
+output_mode: content
+-n: true
+```
+
+For each open item match, check that the line number of the `- [ ]` match is greater than the most recent `## Open Questions / Next Steps` line number AND less than the next `## ` heading (if any). Items not in the right section are discarded.
+
+For each valid item, extract:
+- `file_path` (absolute path)
+- `line_number` (where the `- [ ]` appears)
+- `item_text` (the text after `- [ ] `)
+- `project` (from the file's frontmatter `project:` field — read first 20 lines and grep for `^project:`)
+
+Build a map: `{project → [(file_path, line_number, item_text)]}`.
+
+### Step 5 — Skip if zero items
+
+If the map is empty:
+
+```
+No open items found across all projects.
+```
+
+Stop here.
+
+### Step 6 — Determine evidence pool per project
+
+For each project in the map, find the most recent 3 session notes within the scan window. Use Grep to find files matching `project: $PROJECT_NAME`, then filter to those with a date in the frontmatter `>= $SCAN_CUTOFF`. Sort by date descending, take the top 3.
+
+If a project has zero sessions in the scan window, skip its open items (no evidence to match against).
+
+### Step 7 — Read evidence per project
+
+For each project's evidence sessions, use Read to load the file. Extract the `## Summary`, `## Changes Made`, and `## Errors Encountered` sections. Concatenate as `EVIDENCE_TEXT_<project>`.
+
+### Step 8 — Match items to evidence per project
+
+For each open item in a project, run the same matching logic as `/recall` Step 7.5:
+
+- **Tokenize** the item text into words, lowercase, drop common stopwords (`the`, `a`, `an`, `to`, `for`, `in`, `on`, `of`, `and`, `or`, `but`, `is`, `are`, `was`, `were`, `be`).
+- **Substring match:** Count tokens (3+ chars) appearing as substrings in the project's evidence text (lowercased). If count >= 3, candidate.
+- **Distinctive token match:** If the item contains a file path (`/` or `.py`/`.md`/`.json`/`.ts`/`.js`/`.tsx`/`.jsx`), PR/issue ref (`#\d+`, `PR \d+`, `issue \d+`), branch name (`feature/`, `release/`, `hotfix/`), or version (`v?\d+\.\d+\.\d+`), and that token appears in evidence, mark as candidate even if substring count < 3.
+- **Completion phrase boost:** If a completion phrase (`merged`, `shipped`, `fixed`, `released`, `closed`, `removed`, `implemented`, `deleted`, `done`, `completed`) appears within 200 characters of any matched token in evidence, increase confidence.
+
+For each candidate, capture a short evidence snippet (the matching sentence or 60-char window around the match).
+
+### Step 9 — Skip if no candidates
+
+If no candidates across all projects:
+
+```
+Scanned <N> open items across <M> projects. No completion candidates found.
+```
+
+Stop here.
+
+### Step 10 — Present candidates grouped by project
+
+Print:
+
+```
+## obsidian-brain (3 candidates)
+1. [x] Merge feature/standup-highlights branch
+     Evidence: "Merged as PR #10"
+2. [x] Python 3.9 compat fix
+     Evidence: "Released in v1.5.2"
+3. [x] SessionEnd hook fix
+     Evidence: "Released in v1.5.2"
+
+## tiny-vacation-agent (1 candidate)
+4. [x] Add rate limiting to /chat endpoint
+     Evidence: "Added express-rate-limit middleware"
+
+Confirm checkoffs? (e.g. `1,3,4` or `all` or `none`)
+```
+
+Number candidates sequentially across all projects (not per-project) so the user can pick by single number list.
+
+### Step 11 — Wait for user response
+
+Parse the response:
+- `none` or empty → stop, no edits
+- `all` → check off every candidate
+- Comma-separated numbers (e.g. `1,3,4`) → check off only those
+
+### Step 12 — Edit source files for confirmed checkoffs
+
+For each confirmed item, use the Edit tool:
+
+- `file_path`: the source session note path
+- `old_string`: `- [ ] <exact item text>`
+- `new_string`: `- [x] <exact item text>`
+- `replace_all`: false
+
+If the Edit fails because the line is not unique, retry with more context (include the line before and after the target line). If still ambiguous, skip and warn:
+
+```
+⚠️  Could not check off "<item text>" in <basename> — line not unique. Edit manually in Obsidian.
+```
+
+### Step 13 — Report
+
+Print:
+
+```
+✅ Checked off <N> item(s) across <M> project(s).
+
+Closed:
+- **<project A>**: <count> items
+- **<project B>**: <count> items
+
+<X> items remain open in the dashboard. View open-items.md in Obsidian for the live list.
+```
+
+### Step 14 — Edge cases
+
+- **Skipped items due to ambiguity:** Report at the bottom of the output. Don't fail the whole skill.
+- **File modification race:** If a file changed between Read and Edit, the Edit will fail with a "modified since read" error. Re-run `/check-items` — the next pass will pick up the latest state.
+- **Items with markdown formatting:** If `item_text` contains backticks, asterisks, or other markdown, preserve them exactly in the Edit `old_string` and `new_string`.
+- **Items spanning multiple lines:** Only the first line is matched (multi-line list items are uncommon in this codebase). If encountered, skip and warn.

--- a/skills/check-items/SKILL.md
+++ b/skills/check-items/SKILL.md
@@ -187,7 +187,7 @@ Closed:
 - **<project A>**: <count> items
 - **<project B>**: <count> items
 
-<X> items remain open in the dashboard. View open-items.md in Obsidian for the live list.
+<X> items remain open in the dashboard. View open-items.md in Obsidian for the live list. (Note: the dashboard shows items from the last 90 days only; `/check-items` is unbounded, so checkoffs you just made for items older than 90 days won't appear in the dashboard delta.)
 ```
 
 ### Step 14 — Edge cases

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -405,7 +405,9 @@ if (items.length === 0) {
 }
 \```
 
-## Stale (>30 days, still open, within 90-day window)
+## Items from sessions 30-90 days ago
+
+These are unchecked items captured in session notes that are 30-90 days old. The same item may also appear in a more recent session — in that case it will also show in the "Recent" section above. Filter is by source session date, not by item-tracking duration.
 
 \```dataviewjs
 let recentCutoff = dv.date("today").minus(dv.duration("30 days"));

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -324,6 +324,160 @@ SORT length(rows) DESC
 \```
 ```
 
+**File: `$VAULT_PATH/claude-dashboards/open-items.md`**
+
+```markdown
+# Open Items — All Projects
+
+Cross-project view of all unchecked `- [ ]` items from session notes' `## Open Questions / Next Steps` sections, scoped to the last 90 days. Items older than 90 days fall off this view — use `/check-items` (unbounded) or `/vault-search` to find them.
+
+## By Project
+
+\```dataviewjs
+let cutoff = dv.date("today").minus(dv.duration("90 days"));
+
+let pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
+
+let allItems = [];
+for (let p of pages) {
+    let content = await dv.io.load(p.file.path);
+    if (!content) continue;
+    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    if (!match) continue;
+    let lines = match[1].split("\n");
+    for (let line of lines) {
+        let m = line.match(/^- \[ \] (.+)$/);
+        if (m) {
+            allItems.push({
+                project: p.project || "unknown",
+                item: m[1],
+                date: p.date,
+                file: p.file.link
+            });
+        }
+    }
+}
+
+let byProject = {};
+for (let i of allItems) {
+    if (!byProject[i.project]) byProject[i.project] = [];
+    byProject[i.project].push(i);
+}
+
+let projectNames = Object.keys(byProject).sort();
+for (let project of projectNames) {
+    let items = byProject[project];
+    dv.header(3, project + " (" + items.length + ")");
+    dv.list(items.map(i => i.item + " — " + i.file));
+}
+
+if (allItems.length === 0) {
+    dv.paragraph("No open items in the last 90 days.");
+}
+\```
+
+## Recent (last 7 days)
+
+\```dataviewjs
+let cutoff = dv.date("today").minus(dv.duration("7 days"));
+
+let pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
+
+let items = [];
+for (let p of pages) {
+    let content = await dv.io.load(p.file.path);
+    if (!content) continue;
+    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    if (!match) continue;
+    let lines = match[1].split("\n");
+    for (let line of lines) {
+        let m = line.match(/^- \[ \] (.+)$/);
+        if (m) items.push({ project: p.project || "unknown", item: m[1], file: p.file.link });
+    }
+}
+
+if (items.length === 0) {
+    dv.paragraph("No open items from sessions in the last 7 days.");
+} else {
+    dv.list(items.map(i => "**[" + i.project + "]** " + i.item + " — " + i.file));
+}
+\```
+
+## Stale (>30 days, still open, within 90-day window)
+
+\```dataviewjs
+let recentCutoff = dv.date("today").minus(dv.duration("30 days"));
+let oldCutoff = dv.date("today").minus(dv.duration("90 days"));
+
+let pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date < recentCutoff && p.date >= oldCutoff);
+
+let items = [];
+for (let p of pages) {
+    let content = await dv.io.load(p.file.path);
+    if (!content) continue;
+    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    if (!match) continue;
+    let lines = match[1].split("\n");
+    for (let line of lines) {
+        let m = line.match(/^- \[ \] (.+)$/);
+        if (m) items.push({ project: p.project || "unknown", item: m[1], date: p.date, file: p.file.link });
+    }
+}
+
+if (items.length === 0) {
+    dv.paragraph("No stale open items.");
+} else {
+    items.sort((a, b) => a.date - b.date);
+    dv.list(items.map(i => "**[" + i.project + "]** " + i.item + " (from " + i.date.toFormat("yyyy-MM-dd") + ") — " + i.file));
+}
+\```
+
+## Stats
+
+\```dataviewjs
+let cutoff = dv.date("today").minus(dv.duration("90 days"));
+
+let pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
+
+let total = 0;
+let byProject = {};
+let oldestDate = null;
+
+for (let p of pages) {
+    let content = await dv.io.load(p.file.path);
+    if (!content) continue;
+    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    if (!match) continue;
+    let lines = match[1].split("\n");
+    for (let line of lines) {
+        if (/^- \[ \] /.test(line)) {
+            total++;
+            let project = p.project || "unknown";
+            byProject[project] = (byProject[project] || 0) + 1;
+            if (!oldestDate || p.date < oldestDate) oldestDate = p.date;
+        }
+    }
+}
+
+dv.paragraph("**Total open items (last 90 days):** " + total);
+dv.paragraph("**Projects with open items:** " + Object.keys(byProject).length);
+if (oldestDate) {
+    dv.paragraph("**Oldest open item from:** " + oldestDate.toFormat("yyyy-MM-dd"));
+}
+
+if (Object.keys(byProject).length > 0) {
+    dv.table(
+        ["Project", "Open Items"],
+        Object.entries(byProject).sort((a, b) => b[1] - a[1])
+    );
+}
+\```
+```
+
 **Important:** The backslash before the triple backticks above is an escape for this document only. When writing the actual files, use plain triple backticks (no backslash).
 
 ### Step 7 — Write config file
@@ -414,7 +568,7 @@ This is a soft nudge — a non-blocking suggestion, not automatic execution.
 > - Vault path: `<VAULT_PATH>`
 > - Config written to: `~/.claude/obsidian-brain-config.json`
 > - Folders created: `claude-sessions/`, `claude-insights/`, `claude-dashboards/`
-> - Dashboards installed: `sessions-overview.md`, `project-index.md`, `weekly-review.md`, `learning-velocity.md`, `decision-timeline.md`
+> - Dashboards installed: `sessions-overview.md`, `project-index.md`, `weekly-review.md`, `learning-velocity.md`, `decision-timeline.md`, `open-items.md`
 > - Claudeception nudge: configured (run `/compress` reminder after knowledge extraction)
 >
 > **Next step — install the Dataview plugin in Obsidian:**

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: obsidian-setup
 description: "First-run configuration and upgrade for the Obsidian Brain plugin. Sets up vault path, creates folders, copies dashboard templates, configures hookify nudges, and writes config. Idempotent — safe to re-run to pick up new features without overwriting existing config or dashboards. Use when: (1) first time installing obsidian-brain, (2) changing vault path, (3) /obsidian-setup command, (4) upgrading to a new version."
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 # Obsidian Brain Setup

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -331,23 +331,27 @@ SORT length(rows) DESC
 
 Cross-project view of all unchecked `- [ ]` items from session notes' `## Open Questions / Next Steps` sections, scoped to the last 90 days. Items older than 90 days fall off this view — use `/check-items` (unbounded) or `/vault-search` to find them.
 
-## By Project
-
 \```dataviewjs
-let cutoff = dv.date("today").minus(dv.duration("90 days"));
+// Single-pass: scan all sessions in the last 90 days exactly once,
+// build a master list, then render each section from in-memory data.
 
-let pages = dv.pages('"claude-sessions"')
-    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
+const cutoff90 = dv.date("today").minus(dv.duration("90 days"));
+const cutoff30 = dv.date("today").minus(dv.duration("30 days"));
+const cutoff7  = dv.date("today").minus(dv.duration("7 days"));
 
-let allItems = [];
-for (let p of pages) {
-    let content = await dv.io.load(p.file.path);
+const pages = dv.pages('"claude-sessions"')
+    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff90);
+
+const allItems = [];
+for (const p of pages) {
+    const content = await dv.io.load(p.file.path);
     if (!content) continue;
-    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
+    // CRLF-tolerant: \r?\n in lookahead, split on /\r?\n/
+    const match = content.match(/## Open Questions[^\r\n]*\r?\n([\s\S]*?)(?=\r?\n## |\r?\n# |$)/);
     if (!match) continue;
-    let lines = match[1].split("\n");
-    for (let line of lines) {
-        let m = line.match(/^- \[ \] (.+)$/);
+    const lines = match[1].split(/\r?\n/);
+    for (const line of lines) {
+        const m = line.match(/^- \[ \] (.+?)\s*$/);
         if (m) {
             allItems.push({
                 project: p.project || "unknown",
@@ -359,122 +363,78 @@ for (let p of pages) {
     }
 }
 
-let byProject = {};
-for (let i of allItems) {
-    if (!byProject[i.project]) byProject[i.project] = [];
-    byProject[i.project].push(i);
-}
-
-let projectNames = Object.keys(byProject).sort();
-for (let project of projectNames) {
-    let items = byProject[project];
-    dv.header(3, project + " (" + items.length + ")");
-    dv.list(items.map(i => i.item + " — " + i.file));
-}
+// ----- By Project -----
+dv.header(2, "By Project");
 
 if (allItems.length === 0) {
     dv.paragraph("No open items in the last 90 days.");
-}
-\```
-
-## Recent (last 7 days)
-
-\```dataviewjs
-let cutoff = dv.date("today").minus(dv.duration("7 days"));
-
-let pages = dv.pages('"claude-sessions"')
-    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
-
-let items = [];
-for (let p of pages) {
-    let content = await dv.io.load(p.file.path);
-    if (!content) continue;
-    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
-    if (!match) continue;
-    let lines = match[1].split("\n");
-    for (let line of lines) {
-        let m = line.match(/^- \[ \] (.+)$/);
-        if (m) items.push({ project: p.project || "unknown", item: m[1], file: p.file.link });
+} else {
+    const byProject = {};
+    for (const i of allItems) {
+        if (!byProject[i.project]) byProject[i.project] = [];
+        byProject[i.project].push(i);
+    }
+    const projectNames = Object.keys(byProject).sort();
+    for (const project of projectNames) {
+        const items = byProject[project];
+        dv.header(3, project + " (" + items.length + ")");
+        // Render as table to preserve clickable file link
+        dv.table(
+            ["Item", "Source"],
+            items.map(i => [i.item, i.file])
+        );
     }
 }
 
-if (items.length === 0) {
+// ----- Recent (last 7 days) -----
+dv.header(2, "Recent (last 7 days)");
+
+const recent = allItems.filter(i => i.date >= cutoff7);
+if (recent.length === 0) {
     dv.paragraph("No open items from sessions in the last 7 days.");
 } else {
-    dv.list(items.map(i => "**[" + i.project + "]** " + i.item + " — " + i.file));
-}
-\```
-
-## Items from sessions 30-90 days ago
-
-These are unchecked items captured in session notes that are 30-90 days old. The same item may also appear in a more recent session — in that case it will also show in the "Recent" section above. Filter is by source session date, not by item-tracking duration.
-
-\```dataviewjs
-let recentCutoff = dv.date("today").minus(dv.duration("30 days"));
-let oldCutoff = dv.date("today").minus(dv.duration("90 days"));
-
-let pages = dv.pages('"claude-sessions"')
-    .where(p => p.type === "claude-session" && p.date && p.date < recentCutoff && p.date >= oldCutoff);
-
-let items = [];
-for (let p of pages) {
-    let content = await dv.io.load(p.file.path);
-    if (!content) continue;
-    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
-    if (!match) continue;
-    let lines = match[1].split("\n");
-    for (let line of lines) {
-        let m = line.match(/^- \[ \] (.+)$/);
-        if (m) items.push({ project: p.project || "unknown", item: m[1], date: p.date, file: p.file.link });
-    }
+    dv.table(
+        ["Project", "Item", "Source"],
+        recent.map(i => [i.project, i.item, i.file])
+    );
 }
 
-if (items.length === 0) {
-    dv.paragraph("No stale open items.");
+// ----- Items from sessions 30-90 days ago -----
+dv.header(2, "Items from sessions 30-90 days ago");
+dv.paragraph("These are unchecked items captured in session notes that are 30-90 days old. The same item may also appear in a more recent session — in that case it will also show in the \"Recent\" section above. Filter is by source session date, not by item-tracking duration.");
+
+const stale = allItems
+    .filter(i => i.date < cutoff30)
+    .sort((a, b) => a.date - b.date);
+if (stale.length === 0) {
+    dv.paragraph("No items from sessions 30-90 days ago.");
 } else {
-    items.sort((a, b) => a.date - b.date);
-    dv.list(items.map(i => "**[" + i.project + "]** " + i.item + " (from " + i.date.toFormat("yyyy-MM-dd") + ") — " + i.file));
+    dv.table(
+        ["Project", "Item", "From", "Source"],
+        stale.map(i => [i.project, i.item, i.date.toFormat("yyyy-MM-dd"), i.file])
+    );
 }
-\```
 
-## Stats
+// ----- Stats -----
+dv.header(2, "Stats");
 
-\```dataviewjs
-let cutoff = dv.date("today").minus(dv.duration("90 days"));
-
-let pages = dv.pages('"claude-sessions"')
-    .where(p => p.type === "claude-session" && p.date && p.date >= cutoff);
-
-let total = 0;
-let byProject = {};
+const statsByProject = {};
 let oldestDate = null;
-
-for (let p of pages) {
-    let content = await dv.io.load(p.file.path);
-    if (!content) continue;
-    let match = content.match(/## Open Questions[^\n]*\n([\s\S]*?)(?=\n## |\n# |$)/);
-    if (!match) continue;
-    let lines = match[1].split("\n");
-    for (let line of lines) {
-        if (/^- \[ \] /.test(line)) {
-            total++;
-            let project = p.project || "unknown";
-            byProject[project] = (byProject[project] || 0) + 1;
-            if (!oldestDate || p.date < oldestDate) oldestDate = p.date;
-        }
-    }
+for (const i of allItems) {
+    statsByProject[i.project] = (statsByProject[i.project] || 0) + 1;
+    if (!oldestDate || i.date < oldestDate) oldestDate = i.date;
 }
 
-dv.paragraph("**Total open items (last 90 days):** " + total);
-dv.paragraph("**Projects with open items:** " + Object.keys(byProject).length);
+dv.paragraph("**Total open items (last 90 days):** " + allItems.length);
+dv.paragraph("**Projects with open items:** " + Object.keys(statsByProject).length);
 if (oldestDate) {
     dv.paragraph("**Oldest open item from:** " + oldestDate.toFormat("yyyy-MM-dd"));
 }
 
-if (Object.keys(byProject).length > 0) {
+if (Object.keys(statsByProject).length > 0) {
     dv.table(
         ["Project", "Open Items"],
-        Object.entries(byProject).sort((a, b) => b[1] - a[1])
+        Object.entries(statsByProject).sort((a, b) => b[1] - a[1])
     );
 }
 \```

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -169,16 +169,18 @@ If unsummarized notes were upgraded in Step 3, also mention:
 
 After presenting the context brief, scan the loaded context for evidence that any open items have been completed.
 
-1. **Collect open items for the current project.** Use Grep:
+1. **Collect open items for the current project.** **Re-use the project-scoped file list from Step 4** (the result of Search A — sessions matching `project: $PROJECT`). For each file in that list, run a per-file Grep:
 
 ```
 pattern: ^- \[ \] 
-path: $VAULT_PATH/$SESSIONS_FOLDER/
+path: <each session file from Step 4>
 output_mode: content
 -n: true
 ```
 
-For each match, verify the matching file has `project: $PROJECT` in its frontmatter (re-use the file list from Step 4). Extract `(file_path, line_number, item_text)` tuples for items appearing under a `## Open Questions / Next Steps` section. To verify the section context, read 30 lines before each match and confirm the most recent `## ` heading is `## Open Questions / Next Steps`.
+This avoids an O(vault size) Grep across the entire sessions folder — we already have the project-scoped file list and reuse it directly.
+
+For each match, extract `(file_path, line_number, item_text)` tuples for items appearing under a `## Open Questions / Next Steps` section. To verify the section context, read 30 lines before each match and confirm the most recent `## ` heading is `## Open Questions / Next Steps`.
 
 2. **Skip if zero open items.** If no items found, skip to Step 8 silently.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -2,7 +2,7 @@
 name: recall
 description: "Loads historical context from the Obsidian vault for the current project. Summarizes any unsummarized session notes, then presents a context brief with recent sessions, open items, and curated insights. Use when: (1) /recall command, (2) /recall <project-name>, (3) resuming work on a project and wanting prior context."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # Recall — Load Project Context from Obsidian Vault
@@ -164,6 +164,71 @@ Then output the context brief from Step 6.
 If unsummarized notes were upgraded in Step 3, also mention:
 
 > _Upgraded N session note(s) with AI summaries._
+
+### Step 7.5 — Detect completed open items (project-scoped auto-detect)
+
+After presenting the context brief, scan the loaded context for evidence that any open items have been completed.
+
+1. **Collect open items for the current project.** Use Grep:
+
+```
+pattern: ^- \[ \] 
+path: $VAULT_PATH/$SESSIONS_FOLDER/
+output_mode: content
+-n: true
+```
+
+For each match, verify the matching file has `project: $PROJECT` in its frontmatter (re-use the file list from Step 4). Extract `(file_path, line_number, item_text)` tuples for items appearing under a `## Open Questions / Next Steps` section. To verify the section context, read 30 lines before each match and confirm the most recent `## ` heading is `## Open Questions / Next Steps`.
+
+2. **Skip if zero open items.** If no items found, skip to Step 8 silently.
+
+3. **Use loaded context as evidence pool.** The most recent session was already read in full during Step 5. Concatenate the text of its `## Summary`, `## Changes Made`, and `## Errors Encountered` sections — store as `EVIDENCE_TEXT`.
+
+4. **Match items to evidence.** For each open item:
+   - **Tokenize** the item text into words, lowercase, drop common stopwords (`the`, `a`, `an`, `to`, `for`, `in`, `on`, `of`, `and`, `or`, `but`, `is`, `are`, `was`, `were`, `be`).
+   - **Substring match:** Count how many tokens (3+ characters) appear as substrings in `EVIDENCE_TEXT` (also lowercased). If count >= 3, mark as candidate.
+   - **Distinctive token match:** If the item contains any of these distinctive tokens and they appear in evidence, mark as candidate even if substring count < 3:
+     - File paths (contains `/` or `.py`/`.md`/`.json`/`.ts`/`.js`/`.tsx`/`.jsx`)
+     - PR/issue references (matches `#\d+` or `PR \d+` or `issue \d+`)
+     - Branch names (contains `feature/` or `release/` or `hotfix/`)
+     - Version numbers (matches `v?\d+\.\d+\.\d+`)
+   - **Completion phrase boost:** If a completion phrase (`merged`, `shipped`, `fixed`, `released`, `closed`, `removed`, `implemented`, `deleted`, `done`, `completed`) appears within 200 characters of any matched token in evidence, increase confidence.
+
+5. **Skip if no candidates.** Fast path: if zero items match, skip to Step 8.
+
+6. **Present candidates to user.** Print:
+
+```
+I noticed these open items may now be done:
+
+1. [x] <item text>
+     From: <basename of source file>
+     Evidence: "<short snippet from EVIDENCE_TEXT showing the match>"
+
+2. [x] <item text>
+     ...
+
+Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
+```
+
+7. **Wait for user response.** Parse the response:
+   - `none` or empty → skip checkoff entirely, proceed to Step 8
+   - `all` → check off all candidates
+   - Comma-separated numbers (e.g. `1,3`) → check off only those
+
+8. **For each confirmed checkoff, edit the source file.** Use Read to load the full source file. Find the exact line containing `- [ ] <item text>`. Replace it with `- [x] <item text>`. Use the Edit tool with `replace_all: false` and provide enough context (the full line plus the line before and after if available) to ensure uniqueness within the file. If the line is ambiguous (multiple matches), skip that item and warn:
+
+```
+⚠️  Could not check off item "<item text>" — line is not unique in <file>. Edit manually in Obsidian.
+```
+
+9. **Confirm checkoffs to user.** Print:
+
+```
+✅ Checked off N item(s) across <list of files>.
+```
+
+Then proceed to Step 8.
 
 ### Step 8 — Offer options
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recall
-description: "Loads historical context from the Obsidian vault for the current project. Summarizes any unsummarized session notes, then presents a context brief with recent sessions, open items, and curated insights. Use when: (1) /recall command, (2) /recall <project-name>, (3) resuming work on a project and wanting prior context."
+description: "Loads historical context from the Obsidian vault for the current project. Summarizes any unsummarized session notes, then presents a context brief with recent sessions, open items, and curated insights. Also auto-detects open items completed in the most recent loaded session and offers to check them off. Use when: (1) /recall command, (2) /recall <project-name>, (3) resuming work on a project and wanting prior context."
 metadata:
   version: 1.1.0
 ---

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -2,7 +2,7 @@
 name: standup
 description: "Generates daily/weekly standup summaries across all projects from the Obsidian vault. Use when: (1) /standup for today's summary, (2) /standup this week for weekly summary, (3) /standup <date range> for custom range."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # Standup — Generate Standup Summaries from Obsidian Vault
@@ -198,6 +198,8 @@ When multiple notes need sub-agent reads, spawn them in parallel (one sub-agent 
 
 From each note (whether read directly or via sub-agent), extract: project name (from frontmatter `project:` field), note type (`type:` field), date, title (first `# Heading`), summary (content of `## Summary` section), decisions (bullets from `## Key Decisions`), errors resolved (bullets from `## Errors Encountered`), open items (checkboxes from `## Open Questions / Next Steps`), and the filename (for wikilinks).
 
+**Also extract closed items for the "Closed This Period" section:** For each session note in the date range, check the file modification time using `stat -f %m "$file" 2>/dev/null || stat -c %Y "$file"` (macOS / Linux fallback). Convert to YYYY-MM-DD. If the file was modified within the standup date range (`START_DATE` to `END_DATE`), Grep the file for `- \[x\]` lines under the `## Open Questions / Next Steps` section using the same line-range verification as for open items. Collect `(project, item_text)` tuples for each checked item.
+
 Collect all distilled records as `NOTE_DATA`.
 
 ### Step 8 — Group by project
@@ -255,6 +257,19 @@ Precede all project sections with a header block that includes a highlights summ
 - [ ] $PROJECT_A: $MOST_IMPORTANT_OPEN_ITEM
 - [ ] $PROJECT_B: $MOST_IMPORTANT_OPEN_ITEM
 ```
+
+### Closed This Period
+
+For each project that had at least one item closed within the standup window, render:
+
+- **<project name>** (<N> closed)
+  - <item text 1>
+  - <item text 2>
+  - ...
+
+If zero items were closed across all projects, **omit this entire section** — do not render an empty header.
+
+Order projects alphabetically. Within each project, preserve the order items were extracted (file mtime descending — newest checkoffs first).
 
 Rules for the header sections:
 - **Highlights:** Include only projects with substantive work (skip vault-import-only or config-tweak sessions). Write 1-2 sentences per project summarizing the outcome, not the process. Order by impact/significance, not alphabetically.

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: standup
-description: "Generates daily/weekly standup summaries across all projects from the Obsidian vault. Use when: (1) /standup for today's summary, (2) /standup this week for weekly summary, (3) /standup <date range> for custom range."
+description: "Generates daily/weekly standup summaries across all projects from the Obsidian vault. Includes a Closed This Period section listing items checked off during the window, grouped by project. Use when: (1) /standup for today's summary, (2) /standup this week for weekly summary, (3) /standup <date range> for custom range."
 metadata:
   version: 1.1.0
 ---
@@ -267,7 +267,11 @@ For each project that had at least one item closed within the standup window, re
   - <item text 2>
   - ...
 
-If zero items were closed across all projects, **omit this entire section** — do not render an empty header.
+After the list, append this footnote on its own line in italics:
+
+> _Detected via file modification time — may include items checked off earlier if a session note was edited during this window for unrelated reasons._
+
+If zero items were closed across all projects, **omit this entire section** — do not render an empty header or the footnote.
 
 Order projects alphabetically. Within each project, preserve the order items were extracted (file mtime descending — newest checkoffs first).
 

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -198,7 +198,16 @@ When multiple notes need sub-agent reads, spawn them in parallel (one sub-agent 
 
 From each note (whether read directly or via sub-agent), extract: project name (from frontmatter `project:` field), note type (`type:` field), date, title (first `# Heading`), summary (content of `## Summary` section), decisions (bullets from `## Key Decisions`), errors resolved (bullets from `## Errors Encountered`), open items (checkboxes from `## Open Questions / Next Steps`), and the filename (for wikilinks).
 
-**Also extract closed items for the "Closed This Period" section:** For each session note in the date range, check the file modification time using `stat -f %m "$file" 2>/dev/null || stat -c %Y "$file"` (macOS / Linux fallback). Convert to YYYY-MM-DD. If the file was modified within the standup date range (`START_DATE` to `END_DATE`), Grep the file for `- \[x\]` lines under the `## Open Questions / Next Steps` section using the same line-range verification as for open items. Collect `(project, item_text)` tuples for each checked item.
+**Also extract closed items for the "Closed This Period" section:** For each session note in the date range, get the file modification time as a YYYY-MM-DD string (in the local timezone, matching how `START_DATE` and `END_DATE` were calculated):
+
+```bash
+# Get mtime as epoch, then format. Both forms work cross-platform.
+MTIME_DATE=$(date -r "$file" +%Y-%m-%d 2>/dev/null || date -d @"$(stat -c %Y "$file")" +%Y-%m-%d)
+```
+
+The first form (`date -r FILE`) works on macOS. The Linux fallback uses `stat -c %Y` for the epoch then `date -d @EPOCH` to format. Both produce a YYYY-MM-DD string in the local timezone, which matches the format of `START_DATE` and `END_DATE`.
+
+If `MTIME_DATE` is lexicographically within the range (`MTIME_DATE >= START_DATE && MTIME_DATE <= END_DATE`), Grep the file for `- \[x\]` lines under the `## Open Questions / Next Steps` section using the same line-range verification as for open items. Collect `(project, item_text)` tuples for each checked item.
 
 Collect all distilled records as `NOTE_DATA`.
 


### PR DESCRIPTION
## Summary
- New cross-project open items dashboard (`claude-dashboards/open-items.md`) with 4 sections: by project, recent (7d), stale (>30d), stats. 90-day window for performance.
- New `/check-items` skill: cross-project sweep that proposes completed-item matches and flips them to checked after user confirmation.
- `/recall` Step 7.5: project-scoped auto-detect during context load.
- `/standup` Closed This Period section: lists items checked off during the standup window, grouped by project.
- Source of truth stays in session notes — manual checkoff (editing notes in Obsidian) remains the always-available baseline.

## Test plan
- [ ] Run `/obsidian-setup` in upgrade mode and verify `open-items.md` is installed without overwriting existing dashboards
- [ ] Open `open-items.md` in Obsidian and verify the 4 sections render without errors
- [ ] Run `/recall` on a project with completed work and verify Step 7.5 surfaces a candidate
- [ ] Confirm a checkoff and verify the source session note has `- [ ]` flipped to `- [x]`
- [ ] Run `/check-items` cross-project and verify candidates appear from multiple projects
- [ ] Run `/standup this week` and verify the "Closed This Period" section appears
- [ ] Manually edit a session note in Obsidian to flip `- [ ]` → `- [x]` and verify the dashboard updates immediately

## Spec
docs/superpowers/specs/2026-04-06-obsidian-brain-open-items-dashboard-design.md

## Plan
docs/superpowers/plans/2026-04-07-obsidian-brain-open-items-dashboard.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)