### PR TITLE
feat: lock marketplace.json to plugin.json + harden /recall Step 3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "obsidian-brain",
       "source": "./",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "description": "Persistent brain for Claude Code sessions using Obsidian."
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "obsidian-brain",
       "source": "./",
-      "version": "1.1.0",
+      "version": "1.6.1",
       "description": "Persistent brain for Claude Code sessions using Obsidian."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "obsidian-brain",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`commit-preflight.sh` plugin manifest version sync check** — Preflight now parses `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` and fails the commit if the registry pointer version drifts from the actual plugin version. Prevents the class of bug where the marketplace listing advertises a stale version to users.
+- **`bump-version.sh` auto-updates `marketplace.json`** — Running `./scripts/bump-version.sh <type>` now updates every matching plugin entry in `marketplace.json` alongside `plugin.json`, so release-branch bumps stay in lockstep by default.
+
 ### Fixed
 - Bumped `.claude-plugin/marketplace.json` plugin version from stale `1.1.0` to `1.6.1` so the marketplace registry pointer matches the actually published plugin version.
+
+### Changed
+- **`/recall` Step 3 hardened against skipping** — Added an explicit mandatory-step callout, large-note chunked-read handling (Read token-limit errors are not a skip signal), missing-JSONL fallback clarification, and a required one-line status emission (`Step 3: processing N unsummarized note(s)` / `no unsummarized notes`) so the upgrade decision is auditable in the tool trace. Fixes the failure mode where `/recall` silently skipped unsummarized notes under execution momentum.
 
 ## [1.6.1] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bumped `.claude-plugin/marketplace.json` plugin version from stale `1.1.0` to `1.6.1` so the marketplace registry pointer matches the actually published plugin version.
+
 ## [1.6.1] - 2026-04-07
 
 ### Fixed

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -153,10 +153,25 @@ update_version "$PROJECT_ROOT/.claude-plugin/plugin.json" "$NEW_VERSION"
 # Keep the marketplace registry pointer in lockstep with plugin.json.
 # Without this, /plugin marketplace browse advertises a stale version
 # to users even though the plugin itself has been released.
+#
+# Mirrors the python3-or-node fallback the rest of this script uses for
+# JSON updates so the marketplace sync works in environments that only
+# have Node.js installed (Copilot iter-2 finding on PR #14).
 MARKETPLACE_JSON="$PROJECT_ROOT/.claude-plugin/marketplace.json"
+PLUGIN_JSON="$PROJECT_ROOT/.claude-plugin/plugin.json"
 if [[ -f "$MARKETPLACE_JSON" ]]; then
-  PLUGIN_NAME=$(python3 -c "import json; print(json.load(open('$PROJECT_ROOT/.claude-plugin/plugin.json'))['name'])")
-  if ! python3 - "$MARKETPLACE_JSON" "$NEW_VERSION" "$PLUGIN_NAME" <<'PY'
+  if command -v python3 &>/dev/null; then
+    PLUGIN_NAME=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['name'])" "$PLUGIN_JSON")
+  elif command -v node &>/dev/null; then
+    PLUGIN_NAME=$(node -e "console.log(require(process.argv[1]).name)" "$PLUGIN_JSON")
+  else
+    print_error "Need python3 or node to sync marketplace.json"
+    exit 1
+  fi
+
+  SYNC_EXIT=0
+  if command -v python3 &>/dev/null; then
+    python3 - "$MARKETPLACE_JSON" "$NEW_VERSION" "$PLUGIN_NAME" <<'PY' || SYNC_EXIT=$?
 import json, os, pathlib, sys, tempfile
 path = pathlib.Path(sys.argv[1])
 new_version = sys.argv[2]
@@ -207,14 +222,83 @@ if changed:
             pass
         raise
     print(f"marketplace.json: updated {changed} entry for '{plugin_name}' to {new_version}")
+    # Exit code 0 = updated, exit code 10 = already in sync. Bash caller
+    # uses this to print a sync confirmation only when work was done.
+    sys.exit(0)
 else:
     print(f"marketplace.json: '{plugin_name}' already at {new_version}")
+    sys.exit(10)
 PY
-  then
-    print_error "Failed to sync marketplace.json — fix the above and re-run"
-    exit 1
+  else
+    node - "$MARKETPLACE_JSON" "$NEW_VERSION" "$PLUGIN_NAME" <<'JS' || SYNC_EXIT=$?
+const fs = require('fs');
+const path = require('path');
+const [, , marketPath, newVersion, pluginName] = process.argv;
+
+let data;
+try {
+  data = JSON.parse(fs.readFileSync(marketPath, 'utf-8'));
+} catch (e) {
+  process.stderr.write(`ERROR: could not parse ${marketPath}: ${e.message}\n`);
+  process.exit(2);
+}
+
+if (!Array.isArray(data.plugins) || data.plugins.length === 0) {
+  process.stderr.write(`ERROR: ${marketPath} has no 'plugins' array\n`);
+  process.exit(2);
+}
+
+const matches = data.plugins.filter((p) => p && p.name === pluginName);
+if (matches.length === 0) {
+  process.stderr.write(
+    `ERROR: marketplace.json has no entry for plugin '${pluginName}'. ` +
+      `Add an entry before releasing, or the marketplace listing will lie ` +
+      `about the version.\n`,
+  );
+  process.exit(1);
+}
+
+let changed = 0;
+for (const p of matches) {
+  if (p.version !== newVersion) {
+    p.version = newVersion;
+    changed += 1;
+  }
+}
+
+if (changed > 0) {
+  // Atomic write: tempfile in same dir + rename, mirroring the python branch.
+  const tmp = `${marketPath}.${process.pid}.tmp`;
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n');
+    fs.renameSync(tmp, marketPath);
+  } catch (e) {
+    try { fs.unlinkSync(tmp); } catch (_) {}
+    throw e;
+  }
+  console.log(`marketplace.json: updated ${changed} entry for '${pluginName}' to ${newVersion}`);
+  process.exit(0);
+} else {
+  console.log(`marketplace.json: '${pluginName}' already at ${newVersion}`);
+  process.exit(10);
+}
+JS
   fi
-  print_success "Synced marketplace.json entry for $PLUGIN_NAME to $NEW_VERSION"
+
+  case "$SYNC_EXIT" in
+    0)
+      print_success "Synced marketplace.json entry for $PLUGIN_NAME to $NEW_VERSION"
+      ;;
+    10)
+      # Already in sync — Python/Node already printed an informational
+      # line; do not also print a misleading "Synced" success message
+      # (Copilot iter-2 finding on PR #14).
+      ;;
+    *)
+      print_error "Failed to sync marketplace.json — fix the above and re-run"
+      exit 1
+      ;;
+  esac
 fi
 
 echo ""

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -160,12 +160,30 @@ update_version "$PROJECT_ROOT/.claude-plugin/plugin.json" "$NEW_VERSION"
 MARKETPLACE_JSON="$PROJECT_ROOT/.claude-plugin/marketplace.json"
 PLUGIN_JSON="$PROJECT_ROOT/.claude-plugin/plugin.json"
 if [[ -f "$MARKETPLACE_JSON" ]]; then
+  # Mirror read_version()'s python-then-node fallback rather than letting
+  # `set -e` abort the script if the python3 read fails (e.g. malformed
+  # plugin.json or missing `name`). Both branches `|| true` so a failing
+  # read leaves PLUGIN_NAME empty and falls through to the next branch.
+  PLUGIN_NAME=""
   if command -v python3 &>/dev/null; then
-    PLUGIN_NAME=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['name'])" "$PLUGIN_JSON")
-  elif command -v node &>/dev/null; then
-    PLUGIN_NAME=$(node -e "console.log(require(process.argv[1]).name)" "$PLUGIN_JSON")
-  else
-    print_error "Need python3 or node to sync marketplace.json"
+    PLUGIN_NAME=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+name = d.get('name')
+if not name:
+    sys.exit(1)
+print(name)
+" "$PLUGIN_JSON" 2>/dev/null || true)
+  fi
+  if [[ -z "$PLUGIN_NAME" ]] && command -v node &>/dev/null; then
+    PLUGIN_NAME=$(node -e "
+const d = require(process.argv[1]);
+if (!d.name) process.exit(1);
+console.log(d.name);
+" "$PLUGIN_JSON" 2>/dev/null || true)
+  fi
+  if [[ -z "$PLUGIN_NAME" ]]; then
+    print_error "Could not read plugin name from $PLUGIN_JSON (need python3 or node, and a valid 'name' field)"
     exit 1
   fi
 
@@ -232,7 +250,6 @@ PY
   else
     node - "$MARKETPLACE_JSON" "$NEW_VERSION" "$PLUGIN_NAME" <<'JS' || SYNC_EXIT=$?
 const fs = require('fs');
-const path = require('path');
 const [, , marketPath, newVersion, pluginName] = process.argv;
 
 let data;

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -148,23 +148,21 @@ p.write_text(content)
   print_success "Updated $(basename "$file") to $version"
 }
 
-update_version "$PROJECT_ROOT/.claude-plugin/plugin.json" "$NEW_VERSION"
-
-# Keep the marketplace registry pointer in lockstep with plugin.json.
-# Without this, /plugin marketplace browse advertises a stale version
-# to users even though the plugin itself has been released.
-#
-# Mirrors the python3-or-node fallback the rest of this script uses for
-# JSON updates so the marketplace sync works in environments that only
-# have Node.js installed (Copilot iter-2 finding on PR #14).
+# ── Pre-bump marketplace validation (all-or-nothing guard) ──
+# CRITICAL: validate marketplace.json has a matching entry BEFORE we
+# write the new version into plugin.json. Otherwise a marketplace sync
+# failure leaves plugin.json bumped but marketplace.json stale —
+# reintroducing the exact drift this PR exists to prevent (Copilot
+# iter-5 finding on PR #14). Read-only at this point; the actual
+# write happens after plugin.json is updated.
 MARKETPLACE_JSON="$PROJECT_ROOT/.claude-plugin/marketplace.json"
 PLUGIN_JSON="$PROJECT_ROOT/.claude-plugin/plugin.json"
+PLUGIN_NAME=""
 if [[ -f "$MARKETPLACE_JSON" ]]; then
-  # Mirror read_version()'s python-then-node fallback rather than letting
-  # `set -e` abort the script if the python3 read fails (e.g. malformed
-  # plugin.json or missing `name`). Both branches `|| true` so a failing
-  # read leaves PLUGIN_NAME empty and falls through to the next branch.
-  PLUGIN_NAME=""
+  # python-then-node fallback for the name extraction (stays in sync
+  # with read_version()'s pattern). Each branch `|| true` so a failing
+  # read leaves PLUGIN_NAME empty and falls through, with a final guard
+  # printing a clear remediation if neither succeeds.
   if command -v python3 &>/dev/null; then
     PLUGIN_NAME=$(python3 -c "
 import json, sys
@@ -186,6 +184,55 @@ console.log(d.name);
     print_error "Could not read plugin name from $PLUGIN_JSON (need python3 or node, and a valid 'name' field)"
     exit 1
   fi
+
+  # Read-only verification that the entry exists. Same logic as the
+  # write helper below but with no mutation. Aborts the bump if missing.
+  if command -v python3 &>/dev/null; then
+    if ! python3 -c "
+import json, sys
+data = json.load(open(sys.argv[1]))
+plugins = data.get('plugins')
+if not isinstance(plugins, list) or not plugins:
+    sys.stderr.write(f'ERROR: {sys.argv[1]} has no plugins array\n')
+    sys.exit(2)
+matches = [p for p in plugins if p.get('name') == sys.argv[2]]
+if not matches:
+    sys.stderr.write(
+        f\"ERROR: marketplace.json has no entry for plugin '{sys.argv[2]}'. \"
+        f'Add an entry before releasing.\n'
+    )
+    sys.exit(1)
+" "$MARKETPLACE_JSON" "$PLUGIN_NAME"; then
+      print_error "Pre-bump marketplace validation failed — aborting before plugin.json is touched"
+      exit 1
+    fi
+  elif command -v node &>/dev/null; then
+    if ! node -e "
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf-8'));
+if (!Array.isArray(data.plugins) || data.plugins.length === 0) {
+  process.stderr.write('ERROR: marketplace.json has no plugins array\n');
+  process.exit(2);
+}
+const matches = data.plugins.filter((p) => p && p.name === process.argv[2]);
+if (matches.length === 0) {
+  process.stderr.write(\`ERROR: marketplace.json has no entry for plugin '\${process.argv[2]}'. Add an entry before releasing.\n\`);
+  process.exit(1);
+}
+" "$MARKETPLACE_JSON" "$PLUGIN_NAME"; then
+      print_error "Pre-bump marketplace validation failed — aborting before plugin.json is touched"
+      exit 1
+    fi
+  fi
+fi
+
+update_version "$PROJECT_ROOT/.claude-plugin/plugin.json" "$NEW_VERSION"
+
+# Now perform the actual marketplace.json write. By this point we already
+# verified above that the entry exists, so the only failure modes left
+# are I/O errors (disk full, permissions) which are vanishingly rare and
+# would also affect the plugin.json write that just succeeded.
+if [[ -f "$MARKETPLACE_JSON" ]]; then
 
   SYNC_EXIT=0
   if command -v python3 &>/dev/null; then

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -150,6 +150,30 @@ p.write_text(content)
 
 update_version "$PROJECT_ROOT/.claude-plugin/plugin.json" "$NEW_VERSION"
 
+# Keep the marketplace registry pointer in lockstep with plugin.json.
+# Without this, /plugin marketplace browse advertises a stale version
+# to users even though the plugin itself has been released.
+MARKETPLACE_JSON="$PROJECT_ROOT/.claude-plugin/marketplace.json"
+if [[ -f "$MARKETPLACE_JSON" ]]; then
+  python3 - "$MARKETPLACE_JSON" "$NEW_VERSION" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+new_version = sys.argv[2]
+data = json.loads(path.read_text())
+updated = False
+for plugin in data.get("plugins", []):
+    if plugin.get("version") != new_version:
+        plugin["version"] = new_version
+        updated = True
+if updated:
+    path.write_text(json.dumps(data, indent=2) + "\n")
+    print(f"marketplace.json synced to {new_version}")
+else:
+    print(f"marketplace.json already at {new_version}")
+PY
+  print_success "Updated marketplace.json plugin entries to $NEW_VERSION"
+fi
+
 echo ""
 print_success "Version bumped from $CURRENT_VERSION to $NEW_VERSION"
 echo ""

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -155,23 +155,66 @@ update_version "$PROJECT_ROOT/.claude-plugin/plugin.json" "$NEW_VERSION"
 # to users even though the plugin itself has been released.
 MARKETPLACE_JSON="$PROJECT_ROOT/.claude-plugin/marketplace.json"
 if [[ -f "$MARKETPLACE_JSON" ]]; then
-  python3 - "$MARKETPLACE_JSON" "$NEW_VERSION" <<'PY'
-import json, pathlib, sys
+  PLUGIN_NAME=$(python3 -c "import json; print(json.load(open('$PROJECT_ROOT/.claude-plugin/plugin.json'))['name'])")
+  if ! python3 - "$MARKETPLACE_JSON" "$NEW_VERSION" "$PLUGIN_NAME" <<'PY'
+import json, os, pathlib, sys, tempfile
 path = pathlib.Path(sys.argv[1])
 new_version = sys.argv[2]
-data = json.loads(path.read_text())
-updated = False
-for plugin in data.get("plugins", []):
+plugin_name = sys.argv[3]
+
+try:
+    data = json.loads(path.read_text())
+except Exception as e:
+    sys.stderr.write(f"ERROR: could not parse {path}: {e}\n")
+    sys.exit(2)
+
+plugins = data.get("plugins")
+if not isinstance(plugins, list) or not plugins:
+    sys.stderr.write(f"ERROR: {path} has no 'plugins' array\n")
+    sys.exit(2)
+
+matches = [p for p in plugins if p.get("name") == plugin_name]
+if not matches:
+    sys.stderr.write(
+        f"ERROR: marketplace.json has no entry for plugin '{plugin_name}'. "
+        f"Add an entry before releasing, or the marketplace listing will "
+        f"lie about the version.\n"
+    )
+    sys.exit(1)
+
+changed = 0
+for plugin in matches:
     if plugin.get("version") != new_version:
         plugin["version"] = new_version
-        updated = True
-if updated:
-    path.write_text(json.dumps(data, indent=2) + "\n")
-    print(f"marketplace.json synced to {new_version}")
+        changed += 1
+
+if changed:
+    # Atomic write: temp file in same dir + os.replace. Mirrors the
+    # write_vault_note() convention in hooks/obsidian_utils.py so a
+    # SIGINT or disk-full mid-write cannot corrupt the registry pointer.
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=path.name + ".", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(tmp_fd, "w") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    print(f"marketplace.json: updated {changed} entry for '{plugin_name}' to {new_version}")
 else:
-    print(f"marketplace.json already at {new_version}")
+    print(f"marketplace.json: '{plugin_name}' already at {new_version}")
 PY
-  print_success "Updated marketplace.json plugin entries to $NEW_VERSION"
+  then
+    print_error "Failed to sync marketplace.json — fix the above and re-run"
+    exit 1
+  fi
+  print_success "Synced marketplace.json entry for $PLUGIN_NAME to $NEW_VERSION"
 fi
 
 echo ""

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -359,7 +359,21 @@ JS
       # (Copilot iter-2 finding on PR #14).
       ;;
     *)
-      print_error "Failed to sync marketplace.json — fix the above and re-run"
+      # All-or-nothing rollback: marketplace sync failed AFTER plugin.json
+      # was already updated. Restore plugin.json to CURRENT_VERSION so
+      # the working tree is not left in a drifted state. The pre-bump
+      # validation (above) catches the common "missing entry" case before
+      # plugin.json is touched, but a runtime write failure (read-only
+      # file, disk full, permissions change between validation and write)
+      # can only be handled here (Copilot iter-6 finding on PR #14).
+      print_warning "marketplace.json sync failed AFTER plugin.json was updated — rolling plugin.json back to $CURRENT_VERSION"
+      if update_version "$PROJECT_ROOT/.claude-plugin/plugin.json" "$CURRENT_VERSION"; then
+        print_info "plugin.json restored to $CURRENT_VERSION — working tree is consistent"
+      else
+        print_error "ROLLBACK FAILED: plugin.json is at $NEW_VERSION but marketplace.json is at $CURRENT_VERSION."
+        print_error "Manually restore plugin.json to $CURRENT_VERSION before committing."
+      fi
+      print_error "Failed to sync marketplace.json — fix the underlying issue and re-run"
       exit 1
       ;;
   esac

--- a/scripts/commit-preflight.sh
+++ b/scripts/commit-preflight.sh
@@ -81,6 +81,98 @@ if [ "$AUTO_DETECT" = true ]; then
     echo ""
 fi
 
+# ── Plugin manifest version sync (ALWAYS runs, even in skip modes) ──
+# Must run BEFORE the --docs-only / --skip-tests / --auto early-exit
+# below — those skip modes intentionally bypass tests, but version
+# drift between plugin.json and marketplace.json must NEVER be skipped
+# regardless of flag. This is the gate that catches the bug PR #14
+# was opened to fix; if it lives below the early-exit it provides
+# zero protection against any user who runs preflight with a skip flag
+# (Copilot iter-4 finding on PR #14).
+PLUGIN_JSON_PRE="$PROJECT_DIR/.claude-plugin/plugin.json"
+MARKETPLACE_JSON_PRE="$PROJECT_DIR/.claude-plugin/marketplace.json"
+VERSION_SYNC_RAN=false
+if [ -f "$PLUGIN_JSON_PRE" ] && [ -f "$MARKETPLACE_JSON_PRE" ]; then
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "🔖 Checking plugin manifest version sync..."
+    VERSION_SYNC_EXIT=0
+    VERSION_CHECK_TMP=$(mktemp -t preflight-version-XXXXXX)
+    VERSION_CHECK_STDOUT=$(python3 - "$PLUGIN_JSON_PRE" "$MARKETPLACE_JSON_PRE" 2>"$VERSION_CHECK_TMP" <<'PY'
+import json, sys, traceback
+plugin_path, market_path = sys.argv[1], sys.argv[2]
+try:
+    plugin = json.load(open(plugin_path))
+    market = json.load(open(market_path))
+except Exception as e:
+    sys.stderr.write(f"parse error: {e}\n")
+    sys.exit(2)
+plugin_v = plugin.get("version")
+plugin_name = plugin.get("name")
+if not plugin_v or not plugin_name:
+    sys.stderr.write("plugin.json missing 'name' or 'version'\n")
+    sys.exit(2)
+try:
+    entries = [p for p in market.get("plugins", []) if p.get("name") == plugin_name]
+    if not entries:
+        sys.stderr.write(f"marketplace.json has no entry for '{plugin_name}'\n")
+        sys.exit(2)
+    mismatches = []
+    for idx, entry in enumerate(entries):
+        market_v = entry.get("version")
+        if market_v is None:
+            sys.stderr.write(
+                f"marketplace.json entry #{idx} for '{plugin_name}' has no 'version' field\n"
+            )
+            sys.exit(2)
+        if market_v != plugin_v:
+            mismatches.append((idx, market_v))
+    if mismatches:
+        details = ", ".join(f"entry#{i}={v}" for i, v in mismatches)
+        print(f"MISMATCH: plugin.json={plugin_v} marketplace.json={details}")
+        sys.exit(1)
+    suffix = "" if len(entries) == 1 else f" ({len(entries)} entries)"
+    print(f"OK: {plugin_name}@{plugin_v}{suffix}")
+except Exception:
+    sys.stderr.write("unexpected error during version sync check:\n")
+    traceback.print_exc(file=sys.stderr)
+    sys.exit(2)
+PY
+) || VERSION_SYNC_EXIT=$?
+    VERSION_CHECK_STDERR=$(cat "$VERSION_CHECK_TMP" 2>/dev/null || true)
+    rm -f "$VERSION_CHECK_TMP"
+    if [ -n "$VERSION_CHECK_STDOUT" ]; then
+        echo "$VERSION_CHECK_STDOUT"
+    fi
+    case "$VERSION_SYNC_EXIT" in
+        0)
+            VERSION_SYNC_RAN=true
+            ;;
+        1)
+            echo ""
+            echo "❌ Plugin manifest versions are out of sync."
+            echo "   Update .claude-plugin/marketplace.json to match plugin.json,"
+            echo "   or run ./scripts/bump-version.sh which updates both."
+            echo "   This check runs even in --skip-tests modes."
+            rm -f "$TOKEN_FILE"
+            exit 1
+            ;;
+        *)
+            echo ""
+            echo "❌ Plugin manifest version check failed with a structural error:"
+            if [ -n "$VERSION_CHECK_STDERR" ]; then
+                echo "$VERSION_CHECK_STDERR" | sed 's/^/   /'
+            else
+                echo "   (no error output — python exited with code $VERSION_SYNC_EXIT)"
+            fi
+            echo "   Fix the manifest files before committing."
+            rm -f "$TOKEN_FILE"
+            exit 1
+            ;;
+    esac
+    unset VERSION_SYNC_EXIT VERSION_CHECK_STDOUT VERSION_CHECK_STDERR VERSION_CHECK_TMP
+    echo ""
+fi
+
 # Handle skip tests mode
 if [ "$SKIP_TESTS" = true ]; then
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
@@ -89,13 +181,19 @@ if [ "$SKIP_TESTS" = true ]; then
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo ""
 
+    # Even in skip mode, version-sync must be recorded if it ran above
+    # — it is the one check that is NEVER actually skipped.
+    SKIP_CHECKS_RUN="skipped"
+    if [ "$VERSION_SYNC_RAN" = true ]; then
+        SKIP_CHECKS_RUN="version-sync,skipped-tests"
+    fi
     TIMESTAMP=$(date +%s)
     TOKEN_DATA=$(cat <<EOF
 {
     "created": $TIMESTAMP,
     "expires": $((TIMESTAMP + TOKEN_EXPIRY_SECONDS)),
     "staged_files": $(echo "$STAGED_FILES" | wc -l | tr -d ' '),
-    "checks_run": "skipped",
+    "checks_run": "$SKIP_CHECKS_RUN",
     "skip_reason": "$(echo "$SKIP_REASON" | sed 's/\\/\\\\/g; s/"/\\"/g')"
 }
 EOF
@@ -122,99 +220,12 @@ else
     CHECKS_PASSED=false
 fi
 
-# ── Plugin manifest version sync ─────────────────────────────
-# Ensures .claude-plugin/marketplace.json registry pointer stays in lockstep
-# with .claude-plugin/plugin.json. Drift has caused the marketplace listing
-# to advertise a stale version to users (bug fixed on 2026-04-07).
-PLUGIN_JSON="$PROJECT_DIR/.claude-plugin/plugin.json"
-MARKETPLACE_JSON="$PROJECT_DIR/.claude-plugin/marketplace.json"
-if [ -f "$PLUGIN_JSON" ] && [ -f "$MARKETPLACE_JSON" ]; then
-    echo ""
-    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-    echo "🔖 Checking plugin manifest version sync..."
-    # Initialize explicitly so a stale value from an earlier iteration
-    # (if this script is ever sourced or extended) can't leak into the
-    # check and falsely fail on a clean repo.
-    VERSION_SYNC_EXIT=0
-    VERSION_CHECK_STDOUT=""
-    VERSION_CHECK_STDERR=""
-    VERSION_CHECK_TMP=$(mktemp -t preflight-version-XXXXXX)
-    VERSION_CHECK_STDOUT=$(python3 - "$PLUGIN_JSON" "$MARKETPLACE_JSON" 2>"$VERSION_CHECK_TMP" <<'PY'
-import json, sys, traceback
-plugin_path, market_path = sys.argv[1], sys.argv[2]
-try:
-    plugin = json.load(open(plugin_path))
-    market = json.load(open(market_path))
-except Exception as e:
-    sys.stderr.write(f"parse error: {e}\n")
-    sys.exit(2)
-plugin_v = plugin.get("version")
-plugin_name = plugin.get("name")
-if not plugin_v or not plugin_name:
-    sys.stderr.write("plugin.json missing 'name' or 'version'\n")
-    sys.exit(2)
-try:
-    entries = [p for p in market.get("plugins", []) if p.get("name") == plugin_name]
-    if not entries:
-        sys.stderr.write(f"marketplace.json has no entry for '{plugin_name}'\n")
-        sys.exit(2)
-    # Iterate ALL matching entries (not just entries[0]) so a mismatched
-    # secondary entry can't slip through preflight. Symmetric with
-    # bump-version.sh, which updates every matching entry.
-    mismatches = []
-    for idx, entry in enumerate(entries):
-        market_v = entry.get("version")
-        if market_v is None:
-            sys.stderr.write(
-                f"marketplace.json entry #{idx} for '{plugin_name}' has no 'version' field\n"
-            )
-            sys.exit(2)
-        if market_v != plugin_v:
-            mismatches.append((idx, market_v))
-    if mismatches:
-        details = ", ".join(f"entry#{i}={v}" for i, v in mismatches)
-        print(f"MISMATCH: plugin.json={plugin_v} marketplace.json={details}")
-        sys.exit(1)
-    suffix = "" if len(entries) == 1 else f" ({len(entries)} entries)"
-    print(f"OK: {plugin_name}@{plugin_v}{suffix}")
-except Exception:
-    # Defensive: any unexpected crash (KeyError, TypeError on a malformed
-    # entry, etc.) goes to stderr with traceback and exits 2 so the shell
-    # caller can surface it as a structural error, not a version mismatch.
-    sys.stderr.write("unexpected error during version sync check:\n")
-    traceback.print_exc(file=sys.stderr)
-    sys.exit(2)
-PY
-) || VERSION_SYNC_EXIT=$?
-    VERSION_CHECK_STDERR=$(cat "$VERSION_CHECK_TMP" 2>/dev/null || true)
-    rm -f "$VERSION_CHECK_TMP"
-    if [ -n "$VERSION_CHECK_STDOUT" ]; then
-        echo "$VERSION_CHECK_STDOUT"
-    fi
-    case "$VERSION_SYNC_EXIT" in
-        0)
-            CHECKS_RUN="${CHECKS_RUN}version-sync,"
-            ;;
-        1)
-            echo ""
-            echo "❌ Plugin manifest versions are out of sync."
-            echo "   Update .claude-plugin/marketplace.json to match plugin.json,"
-            echo "   or run ./scripts/bump-version.sh which updates both."
-            CHECKS_PASSED=false
-            ;;
-        *)
-            echo ""
-            echo "❌ Plugin manifest version check failed with a structural error:"
-            if [ -n "$VERSION_CHECK_STDERR" ]; then
-                echo "$VERSION_CHECK_STDERR" | sed 's/^/   /'
-            else
-                echo "   (no error output — python exited with code $VERSION_SYNC_EXIT)"
-            fi
-            echo "   Fix the manifest files before committing."
-            CHECKS_PASSED=false
-            ;;
-    esac
-    unset VERSION_SYNC_EXIT VERSION_CHECK_STDOUT VERSION_CHECK_STDERR VERSION_CHECK_TMP
+# Plugin manifest version sync was already verified above (before the
+# skip-tests early-exit) so it cannot be bypassed by --docs-only,
+# --skip-tests, or --auto. Record it in CHECKS_RUN for the normal-mode
+# token bookkeeping.
+if [ "$VERSION_SYNC_RAN" = true ]; then
+    CHECKS_RUN="${CHECKS_RUN}version-sync,"
 fi
 
 # ══════════════════════════════════════════════════════════════

--- a/scripts/commit-preflight.sh
+++ b/scripts/commit-preflight.sh
@@ -158,14 +158,25 @@ try:
     if not entries:
         sys.stderr.write(f"marketplace.json has no entry for '{plugin_name}'\n")
         sys.exit(2)
-    market_v = entries[0].get("version")
-    if market_v is None:
-        sys.stderr.write(f"marketplace.json entry for '{plugin_name}' has no 'version' field\n")
-        sys.exit(2)
-    if market_v != plugin_v:
-        print(f"MISMATCH: plugin.json={plugin_v} marketplace.json={market_v}")
+    # Iterate ALL matching entries (not just entries[0]) so a mismatched
+    # secondary entry can't slip through preflight. Symmetric with
+    # bump-version.sh, which updates every matching entry.
+    mismatches = []
+    for idx, entry in enumerate(entries):
+        market_v = entry.get("version")
+        if market_v is None:
+            sys.stderr.write(
+                f"marketplace.json entry #{idx} for '{plugin_name}' has no 'version' field\n"
+            )
+            sys.exit(2)
+        if market_v != plugin_v:
+            mismatches.append((idx, market_v))
+    if mismatches:
+        details = ", ".join(f"entry#{i}={v}" for i, v in mismatches)
+        print(f"MISMATCH: plugin.json={plugin_v} marketplace.json={details}")
         sys.exit(1)
-    print(f"OK: {plugin_name}@{plugin_v}")
+    suffix = "" if len(entries) == 1 else f" ({len(entries)} entries)"
+    print(f"OK: {plugin_name}@{plugin_v}{suffix}")
 except Exception:
     # Defensive: any unexpected crash (KeyError, TypeError on a malformed
     # entry, etc.) goes to stderr with traceback and exits 2 so the shell

--- a/scripts/commit-preflight.sh
+++ b/scripts/commit-preflight.sh
@@ -96,7 +96,7 @@ if [ -f "$PLUGIN_JSON_PRE" ] && [ -f "$MARKETPLACE_JSON_PRE" ]; then
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo "🔖 Checking plugin manifest version sync..."
     VERSION_SYNC_EXIT=0
-    VERSION_CHECK_TMP=$(mktemp -t preflight-version-XXXXXX)
+    VERSION_CHECK_TMP=$(mktemp "${TMPDIR:-/tmp}/preflight-version.XXXXXX")
     VERSION_CHECK_STDOUT=$(python3 - "$PLUGIN_JSON_PRE" "$MARKETPLACE_JSON_PRE" 2>"$VERSION_CHECK_TMP" <<'PY'
 import json, sys, traceback
 plugin_path, market_path = sys.argv[1], sys.argv[2]
@@ -182,10 +182,13 @@ if [ "$SKIP_TESTS" = true ]; then
     echo ""
 
     # Even in skip mode, version-sync must be recorded if it ran above
-    # — it is the one check that is NEVER actually skipped.
+    # — it is the one check that is NEVER actually skipped. Use a
+    # generic "skipped" marker for everything else (lint, secret scan,
+    # tests are all skipped, not just tests) so the audit trail is
+    # accurate (Copilot iter-5 finding on PR #14).
     SKIP_CHECKS_RUN="skipped"
     if [ "$VERSION_SYNC_RAN" = true ]; then
-        SKIP_CHECKS_RUN="version-sync,skipped-tests"
+        SKIP_CHECKS_RUN="version-sync,skipped"
     fi
     TIMESTAMP=$(date +%s)
     TOKEN_DATA=$(cat <<EOF

--- a/scripts/commit-preflight.sh
+++ b/scripts/commit-preflight.sh
@@ -132,41 +132,78 @@ if [ -f "$PLUGIN_JSON" ] && [ -f "$MARKETPLACE_JSON" ]; then
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     echo "🔖 Checking plugin manifest version sync..."
-    VERSION_CHECK=$(python3 - "$PLUGIN_JSON" "$MARKETPLACE_JSON" <<'PY'
-import json, sys
+    # Initialize explicitly so a stale value from an earlier iteration
+    # (if this script is ever sourced or extended) can't leak into the
+    # check and falsely fail on a clean repo.
+    VERSION_SYNC_EXIT=0
+    VERSION_CHECK_STDOUT=""
+    VERSION_CHECK_STDERR=""
+    VERSION_CHECK_TMP=$(mktemp -t preflight-version-XXXXXX)
+    VERSION_CHECK_STDOUT=$(python3 - "$PLUGIN_JSON" "$MARKETPLACE_JSON" 2>"$VERSION_CHECK_TMP" <<'PY'
+import json, sys, traceback
 plugin_path, market_path = sys.argv[1], sys.argv[2]
 try:
     plugin = json.load(open(plugin_path))
     market = json.load(open(market_path))
 except Exception as e:
-    print(f"ERROR: could not parse manifest: {e}")
+    sys.stderr.write(f"parse error: {e}\n")
     sys.exit(2)
 plugin_v = plugin.get("version")
 plugin_name = plugin.get("name")
 if not plugin_v or not plugin_name:
-    print("ERROR: plugin.json missing 'name' or 'version'")
+    sys.stderr.write("plugin.json missing 'name' or 'version'\n")
     sys.exit(2)
-entries = [p for p in market.get("plugins", []) if p.get("name") == plugin_name]
-if not entries:
-    print(f"ERROR: marketplace.json has no entry for '{plugin_name}'")
+try:
+    entries = [p for p in market.get("plugins", []) if p.get("name") == plugin_name]
+    if not entries:
+        sys.stderr.write(f"marketplace.json has no entry for '{plugin_name}'\n")
+        sys.exit(2)
+    market_v = entries[0].get("version")
+    if market_v is None:
+        sys.stderr.write(f"marketplace.json entry for '{plugin_name}' has no 'version' field\n")
+        sys.exit(2)
+    if market_v != plugin_v:
+        print(f"MISMATCH: plugin.json={plugin_v} marketplace.json={market_v}")
+        sys.exit(1)
+    print(f"OK: {plugin_name}@{plugin_v}")
+except Exception:
+    # Defensive: any unexpected crash (KeyError, TypeError on a malformed
+    # entry, etc.) goes to stderr with traceback and exits 2 so the shell
+    # caller can surface it as a structural error, not a version mismatch.
+    sys.stderr.write("unexpected error during version sync check:\n")
+    traceback.print_exc(file=sys.stderr)
     sys.exit(2)
-market_v = entries[0].get("version")
-if market_v != plugin_v:
-    print(f"MISMATCH: plugin.json={plugin_v} marketplace.json={market_v}")
-    sys.exit(1)
-print(f"OK: {plugin_name}@{plugin_v}")
 PY
 ) || VERSION_SYNC_EXIT=$?
-    echo "$VERSION_CHECK"
-    if [ "${VERSION_SYNC_EXIT:-0}" -ne 0 ]; then
-        echo ""
-        echo "❌ Plugin manifest versions are out of sync."
-        echo "   Update .claude-plugin/marketplace.json to match plugin.json,"
-        echo "   or run ./scripts/bump-version.sh which updates both."
-        CHECKS_PASSED=false
-    else
-        CHECKS_RUN="${CHECKS_RUN}version-sync,"
+    VERSION_CHECK_STDERR=$(cat "$VERSION_CHECK_TMP" 2>/dev/null || true)
+    rm -f "$VERSION_CHECK_TMP"
+    if [ -n "$VERSION_CHECK_STDOUT" ]; then
+        echo "$VERSION_CHECK_STDOUT"
     fi
+    case "$VERSION_SYNC_EXIT" in
+        0)
+            CHECKS_RUN="${CHECKS_RUN}version-sync,"
+            ;;
+        1)
+            echo ""
+            echo "❌ Plugin manifest versions are out of sync."
+            echo "   Update .claude-plugin/marketplace.json to match plugin.json,"
+            echo "   or run ./scripts/bump-version.sh which updates both."
+            CHECKS_PASSED=false
+            ;;
+        *)
+            echo ""
+            echo "❌ Plugin manifest version check failed with a structural error:"
+            if [ -n "$VERSION_CHECK_STDERR" ]; then
+                echo "$VERSION_CHECK_STDERR" | sed 's/^/   /'
+            else
+                echo "   (no error output — python exited with code $VERSION_SYNC_EXIT)"
+            fi
+            echo "   Fix the manifest files before committing."
+            CHECKS_PASSED=false
+            ;;
+    esac
+    unset VERSION_SYNC_EXIT VERSION_CHECK_STDOUT VERSION_CHECK_STDERR VERSION_CHECK_TMP
 fi
 
 # ══════════════════════════════════════════════════════════════

--- a/scripts/commit-preflight.sh
+++ b/scripts/commit-preflight.sh
@@ -122,6 +122,53 @@ else
     CHECKS_PASSED=false
 fi
 
+# ── Plugin manifest version sync ─────────────────────────────
+# Ensures .claude-plugin/marketplace.json registry pointer stays in lockstep
+# with .claude-plugin/plugin.json. Drift has caused the marketplace listing
+# to advertise a stale version to users (bug fixed on 2026-04-07).
+PLUGIN_JSON="$PROJECT_DIR/.claude-plugin/plugin.json"
+MARKETPLACE_JSON="$PROJECT_DIR/.claude-plugin/marketplace.json"
+if [ -f "$PLUGIN_JSON" ] && [ -f "$MARKETPLACE_JSON" ]; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "🔖 Checking plugin manifest version sync..."
+    VERSION_CHECK=$(python3 - "$PLUGIN_JSON" "$MARKETPLACE_JSON" <<'PY'
+import json, sys
+plugin_path, market_path = sys.argv[1], sys.argv[2]
+try:
+    plugin = json.load(open(plugin_path))
+    market = json.load(open(market_path))
+except Exception as e:
+    print(f"ERROR: could not parse manifest: {e}")
+    sys.exit(2)
+plugin_v = plugin.get("version")
+plugin_name = plugin.get("name")
+if not plugin_v or not plugin_name:
+    print("ERROR: plugin.json missing 'name' or 'version'")
+    sys.exit(2)
+entries = [p for p in market.get("plugins", []) if p.get("name") == plugin_name]
+if not entries:
+    print(f"ERROR: marketplace.json has no entry for '{plugin_name}'")
+    sys.exit(2)
+market_v = entries[0].get("version")
+if market_v != plugin_v:
+    print(f"MISMATCH: plugin.json={plugin_v} marketplace.json={market_v}")
+    sys.exit(1)
+print(f"OK: {plugin_name}@{plugin_v}")
+PY
+) || VERSION_SYNC_EXIT=$?
+    echo "$VERSION_CHECK"
+    if [ "${VERSION_SYNC_EXIT:-0}" -ne 0 ]; then
+        echo ""
+        echo "❌ Plugin manifest versions are out of sync."
+        echo "   Update .claude-plugin/marketplace.json to match plugin.json,"
+        echo "   or run ./scripts/bump-version.sh which updates both."
+        CHECKS_PASSED=false
+    else
+        CHECKS_RUN="${CHECKS_RUN}version-sync,"
+    fi
+fi
+
 # ══════════════════════════════════════════════════════════════
 # LINT SECTION — customized by /harden-repo during installation
 # ══════════════════════════════════════════════════════════════

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -43,6 +43,16 @@ Store as `PROJECT`. Normalize: lowercase, hyphens for spaces.
 
 ### Step 3 — Summarize unsummarized notes (deferred summarization, truncation-aware)
 
+> ⚠️ **THIS STEP IS MANDATORY. DO NOT SKIP IT.**
+>
+> If Grep finds any file matching both "AI summary unavailable" AND `project: $PROJECT`, you **must** produce an upgraded summary for every such file before proceeding to Step 4. "Skipping to save context" or "the other session covers it" is a bug, not an optimization — the user ran `/recall` specifically to get current-session context, and stale unsummarized notes are exactly what they asked you to fix.
+>
+> **Large-note handling:** If the `Read` tool errors because the raw note exceeds the 10k token limit, use `offset` + `limit` to read it in chunks (e.g. `limit: 80` repeatedly) and concatenate mentally. Do NOT use that error as a reason to skip the upgrade.
+>
+> **Missing-JSONL fallback:** If `find_transcript_jsonl` returns null, you still produce a summary — from the raw note itself, with the fallback disclaimer specified in sub-step 4. Null JSONL is not a skip signal.
+>
+> **Visibility requirement:** Before Step 4, emit a one-line status: `Step 3: processing N unsummarized note(s) for $PROJECT` (or `Step 3: no unsummarized notes for $PROJECT` if the intersection is empty). This makes the decision auditable in the tool trace.
+
 This is the critical upgrade step. Search for raw/unsummarized session notes matching this project, and prefer the original Claude Code transcript JSONL over the truncated raw note when the JSONL has more data.
 
 Use Grep to find notes containing the "AI summary unavailable" marker in the sessions folder:

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -2,7 +2,7 @@
 name: recall
 description: "Loads historical context from the Obsidian vault for the current project. Summarizes any unsummarized session notes, then presents a context brief with recent sessions, open items, and curated insights. Also auto-detects open items completed in the most recent loaded session and offers to check them off. Use when: (1) /recall command, (2) /recall <project-name>, (3) resuming work on a project and wanting prior context."
 metadata:
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Recall — Load Project Context from Obsidian Vault


### PR DESCRIPTION
## Summary

Initially a one-line bump of a stale registry pointer, expanded into a full fix for the class of bug.

**Root cause of the drift:** `.claude-plugin/marketplace.json` held the plugin version in a registry pointer that was never touched by any release tooling. `plugin.json` was bumped on every release (via `bump-version.sh`); `marketplace.json` just sat at `1.1.0` from the initial plugin registration until a user noticed the marketplace listing lied about the version.

**Fix (defense in depth):**
1. **Data fix** — bump `marketplace.json` `1.1.0` → `1.6.1`.
2. **Preflight gate (catches drift on every commit)** — `commit-preflight.sh` now parses both manifests and fails if the per-plugin versions don't match. Runs on every `git commit`; no way to land a drifted state without actively skipping preflight.
3. **Release-script automation (keeps the happy path effortless)** — `bump-version.sh` now auto-updates every matching plugin entry in `marketplace.json` alongside `plugin.json`, so `/release` bumps stay in lockstep by default.

**Bonus: `/recall` Step 3 hardening** — separate failure mode observed in this session: under execution momentum, `/recall` silently skipped unsummarized notes to save context tokens even though Step 3 explicitly requires processing them. The skill's `SKILL.md` Step 3 now has:
- An explicit "**THIS STEP IS MANDATORY. DO NOT SKIP IT.**" callout explaining that this is a bug, not an optimization.
- Large-note handling clause: if `Read` errors on 10k-token limit, use `offset`/`limit` to chunk-read. The error is not a skip signal.
- Missing-JSONL clarification: null JSONL means fall back to the raw note, not skip.
- Required status-line emission (`Step 3: processing N unsummarized note(s)` / `no unsummarized notes`) so the upgrade decision is auditable in the tool trace.

## Files changed

- `.claude-plugin/marketplace.json` — `1.1.0` → `1.6.1`
- `scripts/commit-preflight.sh` — new plugin-manifest version sync check
- `scripts/bump-version.sh` — auto-sync `marketplace.json` on bump
- `skills/recall/SKILL.md` — Step 3 hardening
- `CHANGELOG.md` — `[Unreleased]` entries for all of the above

## Test plan

- [x] Preflight runs the new version sync check (`version-sync` present in `checks_run`, `OK: obsidian-brain@1.6.1` in output)
- [x] Versions match before commit (verified via smoke-test one-liner)
- [ ] Manually flip `marketplace.json` to a mismatched version and confirm preflight fails with `MISMATCH`
- [ ] Run `./scripts/bump-version.sh patch` in a scratch copy and verify both files update

🤖 Generated with [Claude Code](https://claude.com/claude-code)
