### PR TITLE
fix: initialize parsed={} before conditional assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Defensive initialization of `parsed` variable in `upgrade_unsummarized_note()` to prevent potential `NameError` on future refactors
+
 ### Added
 - **Open item deduplication** — new `hooks/open_item_dedup.py` module with hybrid matching (distinctive tokens + fuzzy overlap) prevents duplicate open items across session notes
   - Creation-time prevention: `generate_summary()` appends existing items to Haiku prompt + post-generation dedup pass strips duplicates before disk write

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1432,6 +1432,7 @@ def upgrade_unsummarized_note(
 
     # Find and parse the JSONL transcript
     jsonl_path = find_transcript_jsonl(session_id)
+    parsed: dict = {}
     warnings: list[str] = []
     user_msgs: list[str] = []
     assistant_msgs: list[str] = []


### PR DESCRIPTION
## Summary
- Defensive initialization of `parsed = {}` before the `if jsonl_path:` conditional in `upgrade_unsummarized_note()`
- Prevents potential `NameError` if the `jsonl_path` guard is refactored in the future

## Test plan
- [x] One-line code change + changelog, no behavioral difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)