### PR TITLE
fix: replace vague recall prompt with explicit load manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Defensive initialization of `parsed` variable in `upgrade_unsummarized_note()` to prevent potential `NameError` on future refactors
+- **`/recall` Step 8 UX** — replaced vague "Want me to load this context?" with an explicit load manifest showing which sessions and insights are in the conversation, and made the session history table actionable for loading additional sessions
 
 ### Added
 - **Open item deduplication** — new `hooks/open_item_dedup.py` module with hybrid matching (distinctive tokens + fuzzy overlap) prevents duplicate open items across session notes

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -288,17 +288,20 @@ Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
 
 Then proceed to Step 8.
 
-### Step 8 — Offer options
+### Step 8 — Show load manifest and offer options
 
-Ask:
+After the context brief, explicitly list what was loaded into the conversation so the user knows exactly what context is available:
 
-> Want me to load this context? Or focus on a specific session/insight?
+> **Loaded into this conversation:**
+> - Full session: *"[most recent session title]"* ([date])
+> - Summary only: *"[second session title]"* ([date])
+> - [N] curated insight(s)
+>
+> Pick any session from the history table above to load it, or ready to start working?
 
-If the user says yes or wants to load it, the context brief is already in the conversation — it is loaded. Confirm:
+The session history table from Step 6 serves as a menu — if the user picks a session by name or date, use the Read tool to load that specific file and present its full contents.
 
-> Context loaded. Ready to continue where you left off.
-
-If the user asks about a specific session or insight, use the Read tool to load that specific file and present its full contents.
+If the user says they're ready to work, the context is already loaded — proceed.
 
 ## Edge Cases
 


### PR DESCRIPTION
## Summary
- Replaces the ambiguous "Want me to load this context?" prompt in `/recall` Step 8 with an explicit load manifest showing exactly which sessions and insights were loaded into the conversation
- Makes the session history table actionable — users can pick any session by name/date to load it

## Test plan
- [ ] Run `/recall` on a project with 3+ sessions and verify the load manifest lists the full session, summary session, and insight count
- [ ] Pick a session from the history table and verify it loads the full contents
- [ ] Say "ready to work" and verify it proceeds without further prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)