### PR TITLE
feat: sub-agent fallback for session note summarization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Sub-agent summary fallback** — when Haiku API times out during `/recall` Step 3, parallel sub-agents (inheriting parent model) produce structured summaries. New `upgrade_note_with_summary()` function accepts pre-generated summary text and handles the pipeline finish (frontmatter flip, dedup, atomic write). Zero overhead when Haiku succeeds.
+- **Sub-agent summary fallback** — when Haiku API times out during `/recall` Step 3, parallel sub-agents (inheriting parent model) produce structured summaries. New `upgrade_note_with_summary()` function accepts pre-generated summary text and handles the pipeline finish (frontmatter flip, dedup, atomic write). Minimal overhead when Haiku succeeds.
 
 ## [1.7.0] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Sub-agent summary fallback** — when Haiku API times out during `/recall` Step 3, parallel sub-agents (inheriting parent model) produce structured summaries. New `upgrade_note_with_summary()` function accepts pre-generated summary text and handles the pipeline finish (frontmatter flip, dedup, atomic write). Zero overhead when Haiku succeeds.
+
 ## [1.7.0] - 2026-04-09
 
 ### Added

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1418,7 +1418,7 @@ def upgrade_note_with_summary(
     if warnings is None:
         warnings = []
 
-    if "## Summary" not in summary_text:
+    if not re.search(r"^## Summary\s*$", summary_text, re.MULTILINE):
         return f"Failed: malformed summary (no ## Summary section) from {source} for {os.path.basename(note_path)}"
 
     # Read the raw note

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1419,7 +1419,7 @@ def upgrade_note_with_summary(
         warnings = []
 
     if "## Summary" not in summary_text:
-        return f"Failed: sub-agent returned malformed summary (no ## Summary section) for {os.path.basename(note_path)}"
+        return f"Failed: malformed summary (no ## Summary section) from {source} for {os.path.basename(note_path)}"
 
     # Read the raw note
     try:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1478,14 +1478,18 @@ def upgrade_note_with_summary(
     # Add source note
     new_lines.append(f'\n_(Summary source: {source})_\n')
 
-    # Preserve original audit trail sections
+    # Preserve original audit trail sections (skip frontmatter, and exclude
+    # sections already covered by summary_text: Changes Made, Errors Encountered)
     in_audit = False
-    for line in raw_lines:
+    for line in raw_lines[frontmatter_end:]:
         stripped = line.strip()
-        if stripped.startswith('## Tool Usage') or stripped.startswith('## Errors Encountered') or \
-           stripped.startswith('## Conversation (raw)') or stripped.startswith('## Session Metadata') or \
-           stripped.startswith('## Files Touched') or stripped.startswith('## Changes Made'):
+        if stripped.startswith('## Tool Usage') or \
+           stripped.startswith('## Conversation (raw)') or \
+           stripped.startswith('## Session Metadata') or \
+           stripped.startswith('## Files Touched'):
             in_audit = True
+        elif stripped.startswith('## '):
+            in_audit = False
         if in_audit:
             new_lines.append(line)
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1398,6 +1398,136 @@ def is_resumed_session(
     return False
 
 
+def upgrade_note_with_summary(
+    note_path: str,
+    summary_text: str,
+    vault_path: str,
+    sessions_folder: str,
+    project: str,
+    source: str = "sub-agent fallback",
+    warnings: list[str] | None = None,
+) -> str:
+    """Apply a pre-generated summary to a raw session note.
+
+    Handles the pipeline finish: read raw note, validate summary has
+    ## Summary, rebuild note (frontmatter with status: summarized, title,
+    summary sections, audit trail), run dedup, atomic write.
+
+    Returns a one-line status string.
+    """
+    if warnings is None:
+        warnings = []
+
+    if "## Summary" not in summary_text:
+        return f"Failed: sub-agent returned malformed summary (no ## Summary section) for {os.path.basename(note_path)}"
+
+    # Read the raw note
+    try:
+        with open(note_path, 'r', encoding='utf-8') as f:
+            raw_lines = f.readlines()
+    except OSError as exc:
+        return f"Failed: cannot read {os.path.basename(note_path)}: {exc}"
+
+    # Build upgraded note: original frontmatter + new summary + original audit trail
+    new_lines: list[str] = []
+
+    # Copy frontmatter, flipping status
+    past_first_marker = False
+    frontmatter_end = 0
+    for i, line in enumerate(raw_lines):
+        if line.strip() == '---':
+            if not past_first_marker:
+                past_first_marker = True
+                new_lines.append(line)
+                continue
+            else:
+                # End of frontmatter
+                new_lines.append(line)
+                frontmatter_end = i + 1
+                break
+        if past_first_marker:
+            if line.strip().startswith('status:'):
+                new_lines.append(re.sub(r'^(\s*status:\s*).*', r'\1summarized', line) + '\n' if not line.endswith('\n') else re.sub(r'^(\s*status:\s*).*', r'\1summarized', line))
+            else:
+                new_lines.append(line)
+
+    if frontmatter_end == 0:
+        return f"Failed: malformed frontmatter in {os.path.basename(note_path)} (missing closing ---)"
+
+    # Add title from original
+    title_found = False
+    for line in raw_lines[frontmatter_end:]:
+        if line.strip().startswith('# '):
+            new_lines.append('\n')
+            new_lines.append(line)
+            title_found = True
+            break
+    if not title_found:
+        new_lines.append('\n# Untitled Session\n')
+
+    # Add warnings if any
+    if warnings:
+        new_lines.append('\n## ⚠️ Transcript re-parse warnings\n')
+        for w in warnings:
+            new_lines.append(f'- {w}\n')
+
+    # Add summary sections
+    new_lines.append('\n')
+    new_lines.append(summary_text + '\n')
+
+    # Add source note
+    new_lines.append(f'\n_(Summary source: {source})_\n')
+
+    # Preserve original audit trail sections
+    in_audit = False
+    for line in raw_lines:
+        stripped = line.strip()
+        if stripped.startswith('## Tool Usage') or stripped.startswith('## Errors Encountered') or \
+           stripped.startswith('## Conversation (raw)') or stripped.startswith('## Session Metadata') or \
+           stripped.startswith('## Files Touched') or stripped.startswith('## Changes Made'):
+            in_audit = True
+        if in_audit:
+            new_lines.append(line)
+
+    # Atomic write
+    note_dir = os.path.dirname(note_path)
+    fd, tmp_path = tempfile.mkstemp(prefix='.ob-upgrade-', suffix='.md.tmp', dir=note_dir)
+    try:
+        try:
+            orig_mode = os.stat(note_path).st_mode
+        except OSError:
+            orig_mode = 0o644
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            f.writelines(new_lines)
+        os.chmod(tmp_path, orig_mode)
+        os.replace(tmp_path, note_path)
+    except OSError as exc:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return f"Failed: atomic write error for {os.path.basename(note_path)}: {exc}"
+
+    # Run dedup pass (non-fatal — note is already upgraded)
+    removed = []
+    try:
+        _hooks_dir = os.path.dirname(os.path.abspath(__file__))
+        if _hooks_dir not in sys.path:
+            sys.path.insert(0, _hooks_dir)
+        from open_item_dedup import dedup_note_open_items
+        removed = dedup_note_open_items(vault_path, sessions_folder, project, note_path)
+    except Exception as exc:
+        print(f"[obsidian-brain] dedup failed (non-fatal, note already upgraded): {exc}", file=sys.stderr)
+
+    # Build status
+    status = f"Upgraded {os.path.basename(note_path)} (source: {source})"
+    if removed:
+        status += f", deduped {len(removed)} item(s)"
+    if warnings:
+        status += f", {len(warnings)} warning(s)"
+    return status
+
+
 def upgrade_unsummarized_note(
     note_path: str,
     vault_path: str,
@@ -1519,101 +1649,7 @@ def upgrade_unsummarized_note(
     if not summary_text:
         return f"Failed: AI summarization returned empty for {os.path.basename(note_path)}"
 
-    # Build upgraded note: original frontmatter + new summary + original audit trail
-    new_lines: list[str] = []
-
-    # Copy frontmatter, flipping status
-    past_first_marker = False
-    frontmatter_end = 0
-    for i, line in enumerate(raw_lines):
-        if line.strip() == '---':
-            if not past_first_marker:
-                past_first_marker = True
-                new_lines.append(line)
-                continue
-            else:
-                # End of frontmatter
-                new_lines.append(line)
-                frontmatter_end = i + 1
-                break
-        if past_first_marker:
-            if line.strip().startswith('status:'):
-                new_lines.append(re.sub(r'^(\s*status:\s*).*', r'\1summarized', line) + '\n' if not line.endswith('\n') else re.sub(r'^(\s*status:\s*).*', r'\1summarized', line))
-            else:
-                new_lines.append(line)
-
-    if frontmatter_end == 0:
-        return f"Failed: malformed frontmatter in {os.path.basename(note_path)} (missing closing ---)"
-
-    # Add title from original
-    title_found = False
-    for line in raw_lines[frontmatter_end:]:
-        if line.strip().startswith('# '):
-            new_lines.append('\n')
-            new_lines.append(line)
-            title_found = True
-            break
-    if not title_found:
-        new_lines.append('\n# Untitled Session\n')
-
-    # Add warnings if any
-    if warnings:
-        new_lines.append('\n## ⚠️ Transcript re-parse warnings\n')
-        for w in warnings:
-            new_lines.append(f'- {w}\n')
-
-    # Add summary sections
-    new_lines.append('\n')
-    new_lines.append(summary_text + '\n')
-
-    # Add source note
-    new_lines.append(f'\n_(Summary source: {source})_\n')
-
-    # Preserve original audit trail sections
-    in_audit = False
-    for line in raw_lines:
-        stripped = line.strip()
-        if stripped.startswith('## Tool Usage') or stripped.startswith('## Errors Encountered') or \
-           stripped.startswith('## Conversation (raw)') or stripped.startswith('## Session Metadata') or \
-           stripped.startswith('## Files Touched') or stripped.startswith('## Changes Made'):
-            in_audit = True
-        if in_audit:
-            new_lines.append(line)
-
-    # Atomic write
-    note_dir = os.path.dirname(note_path)
-    fd, tmp_path = tempfile.mkstemp(prefix='.ob-upgrade-', suffix='.md.tmp', dir=note_dir)
-    try:
-        try:
-            orig_mode = os.stat(note_path).st_mode
-        except OSError:
-            orig_mode = 0o644
-        with os.fdopen(fd, 'w', encoding='utf-8') as f:
-            f.writelines(new_lines)
-        os.chmod(tmp_path, orig_mode)
-        os.replace(tmp_path, note_path)
-    except OSError as exc:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        return f"Failed: atomic write error for {os.path.basename(note_path)}: {exc}"
-
-    # Run dedup pass (non-fatal — note is already upgraded)
-    removed = []
-    try:
-        _hooks_dir = os.path.dirname(os.path.abspath(__file__))
-        if _hooks_dir not in sys.path:
-            sys.path.insert(0, _hooks_dir)
-        from open_item_dedup import dedup_note_open_items
-        removed = dedup_note_open_items(vault_path, sessions_folder, project, note_path)
-    except Exception as exc:
-        print(f"[obsidian-brain] dedup failed (non-fatal, note already upgraded): {exc}", file=sys.stderr)
-
-    # Build status
-    status = f"Upgraded {os.path.basename(note_path)} (source: {source})"
-    if removed:
-        status += f", deduped {len(removed)} item(s)"
-    if warnings:
-        status += f", {len(warnings)} warning(s)"
-    return status
+    return upgrade_note_with_summary(
+        note_path, summary_text, vault_path, sessions_folder, project,
+        source=source, warnings=warnings,
+    )

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1478,15 +1478,22 @@ def upgrade_note_with_summary(
     # Add source note
     new_lines.append(f'\n_(Summary source: {source})_\n')
 
-    # Preserve original audit trail sections (skip frontmatter, and exclude
-    # sections already covered by summary_text: Changes Made, Errors Encountered)
+    # Preserve original audit trail sections (skip frontmatter).
+    # Only exclude ## Changes Made / ## Errors Encountered if summary_text
+    # actually contains them — otherwise preserve the raw audit data.
+    audit_sections = [
+        '## Tool Usage', '## Conversation (raw)',
+        '## Session Metadata', '## Files Touched',
+    ]
+    if '## Changes Made' not in summary_text:
+        audit_sections.append('## Changes Made')
+    if '## Errors Encountered' not in summary_text:
+        audit_sections.append('## Errors Encountered')
+
     in_audit = False
     for line in raw_lines[frontmatter_end:]:
         stripped = line.strip()
-        if stripped.startswith('## Tool Usage') or \
-           stripped.startswith('## Conversation (raw)') or \
-           stripped.startswith('## Session Metadata') or \
-           stripped.startswith('## Files Touched'):
+        if any(stripped.startswith(s) for s in audit_sections):
             in_audit = True
         elif stripped.startswith('## '):
             in_audit = False
@@ -1495,7 +1502,10 @@ def upgrade_note_with_summary(
 
     # Atomic write
     note_dir = os.path.dirname(note_path)
-    fd, tmp_path = tempfile.mkstemp(prefix='.ob-upgrade-', suffix='.md.tmp', dir=note_dir)
+    try:
+        fd, tmp_path = tempfile.mkstemp(prefix='.ob-upgrade-', suffix='.md.tmp', dir=note_dir)
+    except OSError as exc:
+        return f"Failed: cannot create temp file in {note_dir}: {exc}"
     try:
         try:
             orig_mode = os.stat(note_path).st_mode
@@ -1514,19 +1524,26 @@ def upgrade_note_with_summary(
 
     # Run dedup pass (non-fatal — note is already upgraded)
     removed = []
+    dedup_failed = False
     try:
         _hooks_dir = os.path.dirname(os.path.abspath(__file__))
         if _hooks_dir not in sys.path:
             sys.path.insert(0, _hooks_dir)
         from open_item_dedup import dedup_note_open_items
         removed = dedup_note_open_items(vault_path, sessions_folder, project, note_path)
-    except Exception as exc:
+    except (ImportError, OSError) as exc:
+        dedup_failed = True
         print(f"[obsidian-brain] dedup failed (non-fatal, note already upgraded): {exc}", file=sys.stderr)
+    except Exception as exc:
+        dedup_failed = True
+        print(f"[obsidian-brain] dedup unexpected error: {exc}", file=sys.stderr)
 
     # Build status
     status = f"Upgraded {os.path.basename(note_path)} (source: {source})"
     if removed:
         status += f", deduped {len(removed)} item(s)"
+    if dedup_failed:
+        status += ", dedup failed (see stderr)"
     if warnings:
         status += f", {len(warnings)} warning(s)"
     return status

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -102,7 +102,36 @@ For each file that matches BOTH conditions (unsummarized AND belongs to this pro
    - `"Upgraded 2026-04-07-obsidian-brain-aeb5.md (source: JSONL transcript), deduped 2 item(s)"`
    - `"Failed: AI summarization returned empty for 2026-04-07-obsidian-brain-aeb5.md"`
 
-   Report the status to the user. If it starts with "Failed:", note the failure but continue to the next unsummarized note (do not stop the entire `/recall` flow).
+   Report the status to the user. If it starts with "Failed:", **collect the note path into a fallback list** but continue to the next unsummarized note.
+
+2. **Sub-agent fallback for failed notes.** If any notes returned "Failed:" status:
+
+   For each failed note, spawn a sub-agent in parallel using the Agent tool:
+
+   ```
+   Agent({
+     description: "Summarize session note <basename>",
+     prompt: "Read the session note at <NOTE_PATH>. Produce a structured summary with these exact markdown sections:\n\n## Summary\n1-3 sentence overview of what was accomplished.\n\n## Key Decisions\n- Bullet list of important technical decisions. Write \"None noted.\" if none.\n\n## Changes Made\n- Bullet list of files modified/created with brief description. Write \"None noted.\" if none.\n\n## Errors Encountered\n- Bullet list of errors and how resolved. Write \"None.\" if none.\n\n## Open Questions / Next Steps\n- [ ] Checkbox list of unresolved items. Write \"None.\" if none.\n\nReturn ONLY these markdown sections. No preamble, no commentary."
+   })
+   ```
+
+   Spawn all failed notes' sub-agents in a single message (parallel). When each returns, pass its output to the Python pipeline:
+
+   ```bash
+   cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+   python3 -c '
+   import sys
+   sys.path.insert(0, "hooks")
+   from obsidian_utils import upgrade_note_with_summary
+   summary = sys.stdin.read()
+   status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4])
+   print(status)
+   ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" <<'SUMMARY_EOF'
+   <paste sub-agent output here>
+   SUMMARY_EOF
+   ```
+
+   Report each result. If the sub-agent also fails (error or malformed summary), note the failure but continue — the note stays unsummarized for the next `/recall`.
 
 If no unsummarized notes are found for this project, skip to Step 4.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -130,10 +130,11 @@ For each file that matches BOTH conditions (unsummarized AND belongs to this pro
    status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4])
    print(status)
    ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" <<'SUMMARY_EOF'
-   ## Summary
-   ...the sub-agent's returned markdown sections go here verbatim...
+   <sub-agent output here — NO leading spaces, start lines at column 0>
    SUMMARY_EOF
    ```
+
+   **Important:** The heredoc body must have NO leading indentation — start `## Summary` at column 0. Leading spaces will cause the `## Summary` validation to fail.
 
    Report each result. If the pipeline returns "Failed:", note it but continue — the note stays unsummarized for the next `/recall`.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -115,7 +115,10 @@ For each file that matches BOTH conditions (unsummarized AND belongs to this pro
    })
    ```
 
-   Spawn all failed notes' sub-agents in a single message (parallel). When each returns, pass its output to the Python pipeline:
+   Invoke multiple Agent tool calls in the same response turn (one per failed note) so they run in parallel. When each sub-agent returns its structured summary text:
+
+   - If the sub-agent returned an error or empty output, skip that note — log the failure and continue.
+   - Otherwise, pass the returned summary text to the Python pipeline via a heredoc. The Agent tool's return value is text in your context — write it into the heredoc verbatim:
 
    ```bash
    cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -127,11 +130,12 @@ For each file that matches BOTH conditions (unsummarized AND belongs to this pro
    status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4])
    print(status)
    ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" <<'SUMMARY_EOF'
-   <paste sub-agent output here>
+   ## Summary
+   ...the sub-agent's returned markdown sections go here verbatim...
    SUMMARY_EOF
    ```
 
-   Report each result. If the sub-agent also fails (error or malformed summary), note the failure but continue — the note stays unsummarized for the next `/recall`.
+   Report each result. If the pipeline returns "Failed:", note it but continue — the note stays unsummarized for the next `/recall`.
 
 If no unsummarized notes are found for this project, skip to Step 4.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -130,11 +130,24 @@ For each file that matches BOTH conditions (unsummarized AND belongs to this pro
    status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4])
    print(status)
    ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" <<'SUMMARY_EOF'
-   <sub-agent output here — NO leading spaces, start lines at column 0>
-   SUMMARY_EOF
+## Summary
+1-3 sentence overview from the sub-agent.
+
+## Key Decisions
+- Example bullet from the sub-agent.
+
+## Changes Made
+- Example bullet from the sub-agent.
+
+## Errors Encountered
+None.
+
+## Open Questions / Next Steps
+- [ ] Example follow-up item.
+SUMMARY_EOF
    ```
 
-   **Important:** The heredoc body must have NO leading indentation — start `## Summary` at column 0. Leading spaces will cause the `## Summary` validation to fail.
+   **Important:** Paste the sub-agent summary into the heredoc verbatim with NO leading indentation. Start `## Summary` at column 0, and keep the closing `SUMMARY_EOF` terminator at column 0 as well. Leading spaces before the summary content will cause `upgrade_note_with_summary()` validation to fail, and leading spaces before `SUMMARY_EOF` will prevent the heredoc from terminating correctly.
 
    Report each result. If the pipeline returns "Failed:", note it but continue — the note stays unsummarized for the next `/recall`.
 


### PR DESCRIPTION
## Summary
- When Haiku API times out during `/recall` Step 3, parallel sub-agents (inheriting parent model) now produce structured summaries as a fallback
- New `upgrade_note_with_summary()` function accepts pre-generated summary text and handles the pipeline finish (frontmatter flip, dedup, atomic write)
- `upgrade_unsummarized_note()` refactored to delegate post-summary logic to the new function, eliminating ~98 lines of duplication
- Fixed pre-existing audit trail duplication bug: `## Changes Made` and `## Errors Encountered` were copied from both the AI summary and the raw note's audit trail

## Test plan
- [ ] Verify `upgrade_note_with_summary()` rejects malformed input (no `## Summary`): `python3 -c "from obsidian_utils import upgrade_note_with_summary; print(upgrade_note_with_summary('/tmp/x.md', 'bad', '/tmp', 's', 'p'))"`
- [ ] Verify existing Haiku path still works: run `/recall` on a project with unsummarized notes when Haiku is available
- [ ] Verify fallback path: run `/recall` when Haiku times out — sub-agents should produce summaries and pipe them through the pipeline
- [ ] Verify audit trail sections (Tool Usage, Conversation) are preserved without duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)