### PR TITLE
fix: retry Haiku summarization with 2x timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Haiku summarization timeout retry** — `generate_summary()` now retries once at 2x timeout (15s → 30s) before giving up, reducing unnecessary sub-agent fallbacks
+
 ## [1.7.1] - 2026-04-09
 
 ### Added

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -776,8 +776,8 @@ OUTPUT EXACTLY these markdown sections with no preamble, no commentary, no quest
         for _, _, item_text in existing_items:
             prompt += f"- {item_text}\n"
 
-    retry_timeout = timeout * 2  # escalate on first timeout
-    for attempt_timeout in (timeout, retry_timeout):
+    attempts = (timeout, timeout * 2)  # escalate on first timeout
+    for i, attempt_timeout in enumerate(attempts):
         try:
             result = subprocess.run(
                 ["claude", "-p", "--model", model],
@@ -804,13 +804,14 @@ OUTPUT EXACTLY these markdown sections with no preamble, no commentary, no quest
                 file=sys.stderr,
             )
             break  # won't succeed on retry
-        except subprocess.TimeoutExpired:
-            if attempt_timeout < retry_timeout:
-                print(f"[obsidian-brain] claude -p timed out at {attempt_timeout}s, retrying with {retry_timeout}s", file=sys.stderr)
+        except subprocess.TimeoutExpired as exc:
+            stderr_snippet = f" stderr: {exc.stderr[:200]}" if exc.stderr else ""
+            if i < len(attempts) - 1:
+                print(f"[obsidian-brain] claude -p timed out at {attempt_timeout}s, retrying with {attempts[i+1]}s{stderr_snippet}", file=sys.stderr)
                 continue
-            print(f"[obsidian-brain] claude -p timed out at {attempt_timeout}s, giving up", file=sys.stderr)
+            print(f"[obsidian-brain] claude -p timed out at {attempt_timeout}s, giving up{stderr_snippet}", file=sys.stderr)
         except Exception as exc:
-            print(f"[obsidian-brain] claude -p error: {exc}", file=sys.stderr)
+            print(f"[obsidian-brain] claude -p error ({type(exc).__name__}): {exc}", file=sys.stderr)
             break  # unknown error, don't retry
 
     return None

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -776,34 +776,42 @@ OUTPUT EXACTLY these markdown sections with no preamble, no commentary, no quest
         for _, _, item_text in existing_items:
             prompt += f"- {item_text}\n"
 
-    try:
-        result = subprocess.run(
-            ["claude", "-p", "--model", model],
-            input=prompt,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            summary_text = result.stdout.strip()
-            # Layer 2: Post-generation dedup pass (string-based, pre-write)
-            if existing_items:
-                summary_text = _dedup_summary_open_items(summary_text, existing_items)
-            return summary_text
-        print(
-            f"[obsidian-brain] claude -p failed (rc={result.returncode}): "
-            f"{result.stderr[:200]}",
-            file=sys.stderr,
-        )
-    except FileNotFoundError:
-        print(
-            "[obsidian-brain] claude CLI not found, summarization unavailable",
-            file=sys.stderr,
-        )
-    except subprocess.TimeoutExpired:
-        print("[obsidian-brain] claude -p timed out", file=sys.stderr)
-    except Exception as exc:
-        print(f"[obsidian-brain] claude -p error: {exc}", file=sys.stderr)
+    retry_timeout = timeout * 2  # escalate on first timeout
+    for attempt_timeout in (timeout, retry_timeout):
+        try:
+            result = subprocess.run(
+                ["claude", "-p", "--model", model],
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=attempt_timeout,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                summary_text = result.stdout.strip()
+                # Layer 2: Post-generation dedup pass (string-based, pre-write)
+                if existing_items:
+                    summary_text = _dedup_summary_open_items(summary_text, existing_items)
+                return summary_text
+            print(
+                f"[obsidian-brain] claude -p failed (rc={result.returncode}): "
+                f"{result.stderr[:200]}",
+                file=sys.stderr,
+            )
+            break  # non-timeout failure, don't retry
+        except FileNotFoundError:
+            print(
+                "[obsidian-brain] claude CLI not found, summarization unavailable",
+                file=sys.stderr,
+            )
+            break  # won't succeed on retry
+        except subprocess.TimeoutExpired:
+            if attempt_timeout < retry_timeout:
+                print(f"[obsidian-brain] claude -p timed out at {attempt_timeout}s, retrying with {retry_timeout}s", file=sys.stderr)
+                continue
+            print(f"[obsidian-brain] claude -p timed out at {attempt_timeout}s, giving up", file=sys.stderr)
+        except Exception as exc:
+            print(f"[obsidian-brain] claude -p error: {exc}", file=sys.stderr)
+            break  # unknown error, don't retry
 
     return None
 


### PR DESCRIPTION
## Summary
- `generate_summary()` was failing with 15s timeout for larger sessions — Haiku API is fine, but subprocess startup + large prompt + network variability exceeds 15s
- Now retries once at 2x timeout (15s → 30s) on `TimeoutExpired`; non-timeout failures (bad exit code, CLI not found) still fail immediately

## Test plan
- [ ] Run `/recall` on a project with unsummarized notes — verify Haiku summarization succeeds within 30s
- [ ] Verify sub-agent fallback still triggers if both attempts fail
- [ ] Check stderr logs show retry message on first timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)