### PR TITLE
feat: sub-agent-first summarization for batch /recall upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- `/recall` Step 3 now uses parallel sub-agents as the default summarization
-  strategy when 2+ unsummarized notes are found, with conditional JSONL
-  transcript extraction for truncated sessions. Single-note case unchanged
-  (Haiku pipeline + sub-agent fallback).
-
 ### Added
 - User-visible task manifest during `/recall` showing progress across all
   steps with per-note granularity during summarization.
 - `prepare_summary_input()` helper in `obsidian_utils.py` for conditional
   JSONL-to-temp-file extraction.
+- `/dev-test` skill and `test-dev-skill.sh` script for swapping the installed
+  plugin cache with the repo working copy during local testing.
+
+### Changed
+- `/recall` Step 3 now uses parallel sub-agents as the default summarization
+  strategy when 2+ unsummarized notes are found, with conditional JSONL
+  transcript extraction for truncated sessions. Single-note case unchanged
+  (Haiku pipeline + sub-agent fallback).
 
 ## [1.7.2] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `/recall` Step 3 now uses parallel sub-agents as the default summarization
+  strategy when 2+ unsummarized notes are found, with conditional JSONL
+  transcript extraction for truncated sessions. Single-note case unchanged
+  (Haiku pipeline + sub-agent fallback).
+
+### Added
+- User-visible task manifest during `/recall` showing progress across all
+  steps with per-note granularity during summarization.
+- `prepare_summary_input()` helper in `obsidian_utils.py` for conditional
+  JSONL-to-temp-file extraction.
+
 ## [1.7.2] - 2026-04-09
 
 ### Fixed

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1601,37 +1601,43 @@ def prepare_summary_input(note_path: str) -> str:
         return f"NO_CONTENT:{note_path}"
 
     # Find and parse JSONL transcript
-    jsonl_path = find_transcript_jsonl(session_id)
-    if not jsonl_path:
-        return f"RAW_OK:{note_path}"
+    try:
+        jsonl_path = find_transcript_jsonl(session_id)
+        if not jsonl_path:
+            return f"RAW_OK:{note_path}"
 
-    parsed = parse_full_transcript(jsonl_path)
-    if not parsed.get("raw_note_would_truncate", False):
-        return f"RAW_OK:{note_path}"
+        parsed = parse_full_transcript(jsonl_path)
 
-    # Raw note would truncate — extract JSONL content to temp file
-    user_msgs = parsed.get("user_msgs", [])
-    assistant_msgs = parsed.get("assistant_msgs", [])
-    if not user_msgs and not assistant_msgs:
-        return f"RAW_OK:{note_path}"
+        # Surface transcript warnings (Issue #1: never discard these)
+        for w in parsed.get("warnings", []):
+            print(f"[obsidian-brain] transcript warning for {os.path.basename(note_path)}: {w}", file=sys.stderr)
 
-    # Sample messages using same logic as generate_summary()
-    if len(user_msgs) > 20:
-        sampled_user = user_msgs[:10] + ["[... middle messages omitted ...]"] + user_msgs[-10:]
-    else:
-        sampled_user = user_msgs
-    if len(assistant_msgs) > 20:
-        sampled_asst = assistant_msgs[:10] + ["[... middle messages omitted ...]"] + assistant_msgs[-10:]
-    else:
-        sampled_asst = assistant_msgs
+        if not parsed.get("raw_note_would_truncate", False):
+            return f"RAW_OK:{note_path}"
 
-    user_sample = "\n---\n".join(sampled_user)[:12000]
-    assistant_sample = "\n---\n".join(sampled_asst)[:12000]
+        # Raw note would truncate — extract JSONL content to temp file
+        user_msgs = parsed.get("user_msgs", [])
+        assistant_msgs = parsed.get("assistant_msgs", [])
+        if not user_msgs and not assistant_msgs:
+            return f"RAW_OK:{note_path}"
 
-    files_touched = parsed.get("files_touched", [])[:15]
-    files_str = ", ".join(files_touched) if files_touched else "none detected"
+        # Sample messages using same logic as generate_summary()
+        if len(user_msgs) > 20:
+            sampled_user = user_msgs[:10] + ["[... middle messages omitted ...]"] + user_msgs[-10:]
+        else:
+            sampled_user = user_msgs
+        if len(assistant_msgs) > 20:
+            sampled_asst = assistant_msgs[:10] + ["[... middle messages omitted ...]"] + assistant_msgs[-10:]
+        else:
+            sampled_asst = assistant_msgs
 
-    content = f"""# Session Summary Input (extracted from JSONL transcript)
+        user_sample = "\n---\n".join(sampled_user)[:12000]
+        assistant_sample = "\n---\n".join(sampled_asst)[:12000]
+
+        files_touched = parsed.get("files_touched", [])[:15]
+        files_str = ", ".join(files_touched) if files_touched else "none detected"
+
+        content = f"""# Session Summary Input (extracted from JSONL transcript)
 
 **Project:** {project}
 **Branch:** {git_branch}
@@ -1647,16 +1653,20 @@ def prepare_summary_input(note_path: str) -> str:
 {assistant_sample}
 """
 
-    # Write to temp file
-    temp_path = f"/tmp/ob-prep-{session_id[:8]}.md"
-    try:
-        with open(temp_path, 'w', encoding='utf-8') as f:
-            f.write(content)
-    except OSError as exc:
-        print(f"[obsidian-brain] cannot write temp file {temp_path}: {exc}", file=sys.stderr)
-        return f"RAW_OK:{note_path}"
+        # Write to temp file (use full session_id to avoid collisions)
+        temp_path = f"/tmp/ob-prep-{session_id}.md"
+        try:
+            with open(temp_path, 'w', encoding='utf-8') as f:
+                f.write(content)
+        except OSError as exc:
+            print(f"[obsidian-brain] cannot write temp file {temp_path}, falling back to truncated raw note: {exc}", file=sys.stderr)
+            return f"RAW_OK:{note_path}"
 
-    return f"JSONL_PREPPED:{temp_path}:{note_path}"
+        return f"JSONL_PREPPED:{temp_path}:{note_path}"
+
+    except Exception as exc:
+        print(f"[obsidian-brain] unexpected error in JSONL prep for {os.path.basename(note_path)}: {exc}", file=sys.stderr)
+        return f"RAW_OK:{note_path}"
 
 
 def upgrade_unsummarized_note(

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1558,6 +1558,107 @@ def upgrade_note_with_summary(
     return status
 
 
+def prepare_summary_input(note_path: str) -> str:
+    """Check if raw note would truncate; if so, extract JSONL to temp file.
+
+    Called by /recall Step 3 before spawning sub-agents. Determines
+    whether the sub-agent should read the raw note directly or a
+    pre-extracted JSONL temp file with sampled messages.
+
+    Returns one of:
+      RAW_OK:<note_path>
+      JSONL_PREPPED:<temp_file_path>:<note_path>
+      NO_CONTENT:<note_path>
+    """
+    # Read frontmatter to extract session_id
+    try:
+        with open(note_path, 'r', encoding='utf-8') as f:
+            raw_lines = f.readlines()
+    except OSError as exc:
+        print(f"[obsidian-brain] cannot read {os.path.basename(note_path)}: {exc}", file=sys.stderr)
+        return f"NO_CONTENT:{note_path}"
+
+    session_id = None
+    project = "unknown"
+    git_branch = "unknown"
+    duration_minutes = 0.0
+    for line in raw_lines[:20]:
+        stripped = line.strip()
+        if stripped.startswith('session_id:'):
+            session_id = stripped.split(':', 1)[1].strip().strip('"').strip("'")
+        elif stripped.startswith('project:'):
+            project = stripped.split(':', 1)[1].strip().strip('"')
+        elif stripped.startswith('git_branch:'):
+            git_branch = stripped.split(':', 1)[1].strip().strip('"')
+        elif stripped.startswith('duration_minutes:'):
+            try:
+                duration_minutes = float(stripped.split(':', 1)[1].strip())
+            except ValueError:
+                pass
+
+    if not session_id:
+        print(f"[obsidian-brain] no session_id in {os.path.basename(note_path)}", file=sys.stderr)
+        return f"NO_CONTENT:{note_path}"
+
+    # Find and parse JSONL transcript
+    jsonl_path = find_transcript_jsonl(session_id)
+    if not jsonl_path:
+        return f"RAW_OK:{note_path}"
+
+    parsed = parse_full_transcript(jsonl_path)
+    if not parsed.get("raw_note_would_truncate", False):
+        return f"RAW_OK:{note_path}"
+
+    # Raw note would truncate — extract JSONL content to temp file
+    user_msgs = parsed.get("user_msgs", [])
+    assistant_msgs = parsed.get("assistant_msgs", [])
+    if not user_msgs and not assistant_msgs:
+        return f"RAW_OK:{note_path}"
+
+    # Sample messages using same logic as generate_summary()
+    if len(user_msgs) > 20:
+        sampled_user = user_msgs[:10] + ["[... middle messages omitted ...]"] + user_msgs[-10:]
+    else:
+        sampled_user = user_msgs
+    if len(assistant_msgs) > 20:
+        sampled_asst = assistant_msgs[:10] + ["[... middle messages omitted ...]"] + assistant_msgs[-10:]
+    else:
+        sampled_asst = assistant_msgs
+
+    user_sample = "\n---\n".join(sampled_user)[:12000]
+    assistant_sample = "\n---\n".join(sampled_asst)[:12000]
+
+    files_touched = parsed.get("files_touched", [])[:15]
+    files_str = ", ".join(files_touched) if files_touched else "none detected"
+
+    content = f"""# Session Summary Input (extracted from JSONL transcript)
+
+**Project:** {project}
+**Branch:** {git_branch}
+**Duration:** {duration_minutes} minutes
+**Files touched:** {files_str}
+
+## Conversation
+
+### User Messages (sampled)
+{user_sample}
+
+### Assistant Messages (sampled)
+{assistant_sample}
+"""
+
+    # Write to temp file
+    temp_path = f"/tmp/ob-prep-{session_id[:8]}.md"
+    try:
+        with open(temp_path, 'w', encoding='utf-8') as f:
+            f.write(content)
+    except OSError as exc:
+        print(f"[obsidian-brain] cannot write temp file {temp_path}: {exc}", file=sys.stderr)
+        return f"RAW_OK:{note_path}"
+
+    return f"JSONL_PREPPED:{temp_path}:{note_path}"
+
+
 def upgrade_unsummarized_note(
     note_path: str,
     vault_path: str,

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1570,10 +1570,10 @@ def prepare_summary_input(note_path: str) -> str:
       JSONL_PREPPED:<temp_file_path>:<note_path>
       NO_CONTENT:<note_path>
     """
-    # Read frontmatter to extract session_id
+    # Read only frontmatter (first 20 lines) — avoids loading large raw notes into memory
     try:
         with open(note_path, 'r', encoding='utf-8') as f:
-            raw_lines = f.readlines()
+            raw_lines = [f.readline() for _ in range(20)]
     except OSError as exc:
         print(f"[obsidian-brain] cannot read {os.path.basename(note_path)}: {exc}", file=sys.stderr)
         return f"NO_CONTENT:{note_path}"
@@ -1582,7 +1582,7 @@ def prepare_summary_input(note_path: str) -> str:
     project = "unknown"
     git_branch = "unknown"
     duration_minutes = 0.0
-    for line in raw_lines[:20]:
+    for line in raw_lines:
         stripped = line.strip()
         if stripped.startswith('session_id:'):
             session_id = stripped.split(':', 1)[1].strip().strip('"').strip("'")

--- a/scripts/test-dev-skill.sh
+++ b/scripts/test-dev-skill.sh
@@ -45,7 +45,7 @@ case "$cmd" in
         echo "Backing up: $CACHE_DIR -> $BACKUP_DIR"
         cp -R "$CACHE_DIR" "$BACKUP_DIR"
 
-        # Auto-restore on failure
+        # On failure, warn user to restore manually
         trap 'echo "ERROR: Install failed partway. Run \"$0 restore\" to recover." >&2' ERR
 
         echo "Installing dev versions..."
@@ -98,7 +98,7 @@ case "$cmd" in
 
     status)
         echo "Plugin: $PLUGIN_NAME"
-        echo "Repo version: $PLUGIN_VERSION"
+        echo "Installed cache version: $PLUGIN_VERSION"
         echo "Cache dir: $CACHE_DIR"
         echo ""
 

--- a/scripts/test-dev-skill.sh
+++ b/scripts/test-dev-skill.sh
@@ -45,6 +45,9 @@ case "$cmd" in
         echo "Backing up: $CACHE_DIR -> $BACKUP_DIR"
         cp -R "$CACHE_DIR" "$BACKUP_DIR"
 
+        # Auto-restore on failure
+        trap 'echo "ERROR: Install failed partway. Run \"$0 restore\" to recover." >&2' ERR
+
         echo "Installing dev versions..."
 
         # Copy hooks (Python files)
@@ -55,9 +58,13 @@ case "$cmd" in
         for skill_dir in "$REPO_ROOT/skills/"*/; do
             skill_name=$(basename "$skill_dir")
             mkdir -p "$CACHE_DIR/skills/$skill_name"
-            cp "$skill_dir"* "$CACHE_DIR/skills/$skill_name/" 2>/dev/null || true
+            if compgen -G "$skill_dir"* > /dev/null 2>&1; then
+                cp "$skill_dir"* "$CACHE_DIR/skills/$skill_name/"
+            fi
             echo "  skills/$skill_name/ -> cache"
         done
+
+        trap - ERR
 
         echo ""
         echo "Dev version installed to cache (v${PLUGIN_VERSION})."
@@ -72,6 +79,12 @@ case "$cmd" in
             echo "No backup found at $BACKUP_DIR — nothing to restore."
             echo "Current cache is the original version."
             exit 0
+        fi
+
+        # Sanity check: CACHE_DIR must be under CACHE_BASE
+        if [[ "$CACHE_DIR" != "${CACHE_BASE}/"* ]]; then
+            echo "ERROR: CACHE_DIR '$CACHE_DIR' is outside expected base. Aborting." >&2
+            exit 1
         fi
 
         echo "Restoring: $BACKUP_DIR -> $CACHE_DIR"

--- a/scripts/test-dev-skill.sh
+++ b/scripts/test-dev-skill.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# test-dev-skill.sh — Swap installed plugin cache with dev version for testing.
+#
+# Usage:
+#   ./scripts/test-dev-skill.sh install   # backup cache, install dev version
+#   ./scripts/test-dev-skill.sh restore   # restore original cached version
+#   ./scripts/test-dev-skill.sh status    # show which version is active
+#
+# After "install", start a NEW Claude Code session to pick up the changes.
+# After testing, run "restore" to put the original version back.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PLUGIN_NAME="obsidian-brain"
+
+# Discover the latest installed cache version (highest semver directory)
+CACHE_BASE="${HOME}/.claude/plugins/cache/claude-code-skills/${PLUGIN_NAME}"
+PLUGIN_VERSION=$(ls -1 "$CACHE_BASE" 2>/dev/null | grep -v '\.bak$' | sort -V | tail -1)
+if [[ -z "$PLUGIN_VERSION" ]]; then
+    echo "ERROR: No cached version found at $CACHE_BASE"
+    exit 1
+fi
+
+CACHE_DIR="${CACHE_BASE}/${PLUGIN_VERSION}"
+BACKUP_DIR="${CACHE_BASE}/${PLUGIN_VERSION}.bak"
+
+cmd="${1:-status}"
+
+case "$cmd" in
+    install)
+        if [[ ! -d "$CACHE_DIR" ]]; then
+            echo "ERROR: Cache directory not found: $CACHE_DIR"
+            echo "Available versions:"
+            ls "$CACHE_BASE" 2>/dev/null || echo "  (none)"
+            exit 1
+        fi
+
+        if [[ -d "$BACKUP_DIR" ]]; then
+            echo "WARNING: Backup already exists at $BACKUP_DIR"
+            echo "Run 'restore' first, or remove the backup manually."
+            exit 1
+        fi
+
+        echo "Backing up: $CACHE_DIR -> $BACKUP_DIR"
+        cp -R "$CACHE_DIR" "$BACKUP_DIR"
+
+        echo "Installing dev versions..."
+
+        # Copy hooks (Python files)
+        cp "$REPO_ROOT/hooks/"*.py "$CACHE_DIR/hooks/"
+        echo "  hooks/*.py -> cache"
+
+        # Copy skills
+        for skill_dir in "$REPO_ROOT/skills/"*/; do
+            skill_name=$(basename "$skill_dir")
+            mkdir -p "$CACHE_DIR/skills/$skill_name"
+            cp "$skill_dir"* "$CACHE_DIR/skills/$skill_name/" 2>/dev/null || true
+            echo "  skills/$skill_name/ -> cache"
+        done
+
+        echo ""
+        echo "Dev version installed to cache (v${PLUGIN_VERSION})."
+        echo "Start a NEW Claude Code session to pick up the changes."
+        echo ""
+        echo "When done testing, run:"
+        echo "  ./scripts/test-dev-skill.sh restore"
+        ;;
+
+    restore)
+        if [[ ! -d "$BACKUP_DIR" ]]; then
+            echo "No backup found at $BACKUP_DIR — nothing to restore."
+            echo "Current cache is the original version."
+            exit 0
+        fi
+
+        echo "Restoring: $BACKUP_DIR -> $CACHE_DIR"
+        rm -rf "$CACHE_DIR"
+        mv "$BACKUP_DIR" "$CACHE_DIR"
+
+        echo ""
+        echo "Original v${PLUGIN_VERSION} restored."
+        echo "Start a NEW session to pick up the restored version."
+        ;;
+
+    status)
+        echo "Plugin: $PLUGIN_NAME"
+        echo "Repo version: $PLUGIN_VERSION"
+        echo "Cache dir: $CACHE_DIR"
+        echo ""
+
+        if [[ -d "$BACKUP_DIR" ]]; then
+            echo "Status: DEV VERSION ACTIVE (backup exists)"
+            echo "Backup: $BACKUP_DIR"
+            echo ""
+            echo "Files changed from original:"
+            diff -rq "$BACKUP_DIR" "$CACHE_DIR" 2>/dev/null | head -20 || echo "  (diff failed)"
+        elif [[ -d "$CACHE_DIR" ]]; then
+            echo "Status: ORIGINAL (no backup, cache is clean)"
+        else
+            echo "Status: NOT INSTALLED (cache dir missing)"
+        fi
+        ;;
+
+    *)
+        echo "Usage: $0 {install|restore|status}"
+        exit 1
+        ;;
+esac

--- a/skills/dev-test/SKILL.md
+++ b/skills/dev-test/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: dev-test
+description: "Install dev version of obsidian-brain into the plugin cache for local testing, or restore the original. Use when: (1) /dev-test install to test unreleased changes, (2) /dev-test restore to put back the original, (3) /dev-test to check current status."
+metadata:
+  version: 1.0.0
+---
+
+# Dev Test — Install/Restore Dev Plugin for Testing
+
+Swaps the installed plugin cache with the current repo working copy for local testing. After install, start a new Claude Code session to pick up the changes.
+
+**Tools needed:** Bash
+
+## Procedure
+
+### Step 1 — Parse argument
+
+Check the argument passed to `/dev-test`:
+
+- `install` → go to Step 2
+- `restore` → go to Step 3
+- No argument or `status` → go to Step 4
+
+### Step 2 — Install dev version
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+./scripts/test-dev-skill.sh install
+```
+
+Report the output. Then tell the user:
+
+> Dev version installed. **Start a new Claude Code session** to pick up the changes. When done testing, run `/dev-test restore`.
+
+Stop here.
+
+### Step 3 — Restore original
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+./scripts/test-dev-skill.sh restore
+```
+
+Report the output. Then tell the user:
+
+> Original version restored. **Start a new session** to pick up the restored version.
+
+Stop here.
+
+### Step 4 — Show status
+
+Run:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+./scripts/test-dev-skill.sh status
+```
+
+Report the output.

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -44,7 +44,7 @@ Stop here if config is missing.
 **Create the task manifest** for the full `/recall` flow:
 
 ```
-TaskCreate: subject="Find unsummarized notes", activeForm="Searching for unsummarized notes", status immediately set to in_progress
+TaskCreate: subject="Find unsummarized notes", activeForm="Searching for unsummarized notes"
 TaskCreate: subject="Summarize unsummarized notes", activeForm="Summarizing notes"
 TaskCreate: subject="Search sessions and insights", activeForm="Searching vault"
 TaskCreate: subject="Read and rank notes", activeForm="Reading notes"
@@ -52,7 +52,7 @@ TaskCreate: subject="Compose context brief", activeForm="Composing brief"
 TaskCreate: subject="Present results and detect completed items", activeForm="Presenting results"
 ```
 
-Track the returned task IDs — you will update them as each step completes. Task #1 is already `in_progress`.
+Track the returned task IDs — you will update them as each step completes. Immediately set task #1 to `in_progress` via TaskUpdate.
 
 ### Step 2 — Derive project name
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -206,7 +206,9 @@ Where `<READ_PATH>` is:
 - For `RAW_OK` notes: the raw note path
 - For `JSONL_PREPPED` notes: the temp file path (e.g. `/tmp/ob-prep-{hash}.md`)
 
-When all sub-agents return, update each summarize sub-task to completed.
+When all sub-agents return, check each result:
+- If the sub-agent returned a valid summary (contains `## Summary`), update its summarize sub-task to completed.
+- If the sub-agent returned an error, empty output, or no `## Summary` section, update its summarize sub-task subject to `Failed: <basename>` and mark completed. Exclude this note from Wave 3 — it stays unsummarized for the next `/recall`. Report the failure to the user.
 
 ##### Wave 3 — Write back (parallel Bash calls)
 
@@ -236,19 +238,23 @@ SUMMARY_EOF
 
 Launch all write-back Bash calls in a single message turn.
 
-When all return, update each write-back sub-task to completed.
+When all return, parse each result:
+- If the status does NOT start with "Failed:", update the write-back sub-task to completed.
+- If the status starts with "Failed:", update the sub-task subject to `Failed: <basename>` and mark completed. Count it in the failure tally.
 
 ##### Cleanup
 
-Clean up temp files:
+Clean up only the specific temp files created in Wave 1 (not a glob — avoids racing with concurrent `/recall` invocations):
 
 ```bash
-rm -f /tmp/ob-prep-*.md
+rm -f /tmp/ob-prep-<session_id_1>.md /tmp/ob-prep-<session_id_2>.md ...
 ```
 
-Mark task #2 as completed. Report results: how many upgraded, how many skipped, how many failed.
+Mark task #2 as completed. Report results: how many upgraded, how many skipped (NO_CONTENT), how many failed.
 
 If any sub-agents returned empty or invalid summaries, report those notes as still unsummarized — they will be retried on the next `/recall`.
+
+For `NO_CONTENT` notes, inform the user: "Note `<basename>` has no session_id or conversation content. Manually edit it in Obsidian to add a summary, or delete it if it's empty."
 
 ### Step 4 — Search for project sessions and insights (parallel)
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -59,13 +59,9 @@ Store as `PROJECT`. Normalize: lowercase, hyphens for spaces.
 >
 > If Grep finds any file matching both "AI summary unavailable" AND `project: $PROJECT`, you **must** produce an upgraded summary for every such file before proceeding to Step 4. "Skipping to save context" or "the other session covers it" is a bug, not an optimization — the user ran `/recall` specifically to get current-session context, and stale unsummarized notes are exactly what they asked you to fix.
 >
-> **Large-note handling:** If the `Read` tool errors because the raw note exceeds the 10k token limit, use `offset` + `limit` to read it in chunks (e.g. `limit: 80` repeatedly) and concatenate mentally. Do NOT use that error as a reason to skip the upgrade.
->
-> **Missing-JSONL fallback:** If `find_transcript_jsonl` returns null, you still produce a summary — from the raw note itself, with the fallback disclaimer specified in sub-step 4. Null JSONL is not a skip signal.
->
 > **Visibility requirement:** Before Step 4, emit a one-line status: `Step 3: processing N unsummarized note(s) for $PROJECT` (or `Step 3: no unsummarized notes for $PROJECT` if the intersection is empty). This makes the decision auditable in the tool trace.
 
-This is the critical upgrade step. Search for raw/unsummarized session notes matching this project, and prefer the original Claude Code transcript JSONL over the truncated raw note when the JSONL has more data.
+Search for raw/unsummarized session notes matching this project.
 
 Use Grep to find notes containing the "AI summary unavailable" marker in the sessions folder:
 
@@ -83,30 +79,39 @@ path: <each matched file>
 output_mode: content
 ```
 
-For each file that matches BOTH conditions (unsummarized AND belongs to this project):
+Count the files that match BOTH conditions (unsummarized AND belongs to this project). Store as `N`.
 
-1. **Run the upgrade pipeline in Python** — a single Bash call that handles JSONL lookup, transcript parsing, source decision, AI summarization, dedup, and atomic write:
+Update task #1 to completed. Update task #2 subject to `Summarize N unsummarized note(s)` and set to `in_progress`.
 
-   ```bash
-   cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-   python3 -c '
-   import sys
-   sys.path.insert(0, "hooks")
-   from obsidian_utils import upgrade_unsummarized_note
-   status = upgrade_unsummarized_note(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
-   print(status)
-   ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
-   ```
+#### Path A: N=0 (no unsummarized notes)
 
-   Where `$NOTE_PATH` is the full path of the unsummarized note. The function returns a one-line status like:
-   - `"Upgraded 2026-04-07-obsidian-brain-aeb5.md (source: JSONL transcript), deduped 2 item(s)"`
-   - `"Failed: AI summarization returned empty for 2026-04-07-obsidian-brain-aeb5.md"`
+Update task #2 subject to `No unsummarized notes found` and set to `completed`. Skip to Step 4.
 
-   Report the status to the user. If it starts with "Failed:", **collect the note path into a fallback list** but continue to the next unsummarized note.
+#### Path B: N=1 (single note — Python pipeline)
 
-2. **Sub-agent fallback for failed notes.** If any notes returned "Failed:" status:
+Create a sub-task for the note:
 
-   For each failed note, spawn a sub-agent in parallel using the Agent tool:
+```
+TaskCreate: subject="Haiku pipeline: <basename>", activeForm="Summarizing <basename> via Haiku"
+```
+
+Run the upgrade pipeline in Python:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 -c '
+import sys
+sys.path.insert(0, "hooks")
+from obsidian_utils import upgrade_unsummarized_note
+status = upgrade_unsummarized_note(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+print(status)
+' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
+```
+
+If the status starts with "Failed:", use the sub-agent fallback:
+
+1. Update the sub-task subject to `Sub-agent fallback: <basename>`.
+2. Spawn a single sub-agent:
 
    ```
    Agent({
@@ -115,10 +120,7 @@ For each file that matches BOTH conditions (unsummarized AND belongs to this pro
    })
    ```
 
-   Invoke multiple Agent tool calls in the same response turn (one per failed note) so they run in parallel. When each sub-agent returns its structured summary text:
-
-   - If the sub-agent returned an error or empty output, skip that note — log the failure and continue.
-   - Otherwise, pass the returned summary text to the Python pipeline via a heredoc. The Agent tool's return value is text in your context — write it into the heredoc verbatim:
+3. If the sub-agent returns a valid summary, write it back via heredoc:
 
    ```bash
    cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -130,28 +132,110 @@ For each file that matches BOTH conditions (unsummarized AND belongs to this pro
    status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4])
    print(status)
    ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" <<'SUMMARY_EOF'
-## Summary
-1-3 sentence overview from the sub-agent.
-
-## Key Decisions
-- Example bullet from the sub-agent.
-
-## Changes Made
-- Example bullet from the sub-agent.
-
-## Errors Encountered
-None.
-
-## Open Questions / Next Steps
-- [ ] Example follow-up item.
-SUMMARY_EOF
+   <paste sub-agent summary here at column 0, no leading indentation>
+   SUMMARY_EOF
    ```
 
-   **Important:** Paste the sub-agent summary into the heredoc verbatim with NO leading indentation. Start `## Summary` at column 0, and keep the closing `SUMMARY_EOF` terminator at column 0 as well. Leading spaces before the summary content will cause `upgrade_note_with_summary()` validation to fail, and leading spaces before `SUMMARY_EOF` will prevent the heredoc from terminating correctly.
+   **Important:** Paste the sub-agent summary into the heredoc verbatim with NO leading indentation. Start `## Summary` at column 0, and keep the closing `SUMMARY_EOF` terminator at column 0 as well.
 
-   Report each result. If the pipeline returns "Failed:", note it but continue — the note stays unsummarized for the next `/recall`.
+Mark the sub-task and task #2 as completed. Report the result.
 
-If no unsummarized notes are found for this project, skip to Step 4.
+#### Path C: N>=2 (batch — sub-agent-first, three waves)
+
+##### Wave 1 — Prep (parallel Bash calls)
+
+Create a prep sub-task for each note:
+
+```
+TaskCreate: subject="Prep: <basename>", activeForm="Prepping <basename>"
+```
+
+For each unsummarized note, run a parallel Bash call:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 -c '
+import sys
+sys.path.insert(0, "hooks")
+from obsidian_utils import prepare_summary_input
+result = prepare_summary_input(sys.argv[1])
+print(result)
+' "$NOTE_PATH"
+```
+
+Launch all N Bash calls in a single message turn so they run in parallel.
+
+When all return, update each prep sub-task to completed (include result in subject: e.g. `Prep: ...2322.md (RAW_OK)` or `Prep: ...4653.md (JSONL_PREPPED)`).
+
+Parse each result:
+- `RAW_OK:<note_path>` → sub-agent will read the raw note path
+- `JSONL_PREPPED:<temp_path>:<note_path>` → sub-agent will read the temp file path; track `<note_path>` for Wave 3
+- `NO_CONTENT:<note_path>` → skip this note, report to user
+
+##### Wave 2 — Summarize (parallel sub-agents)
+
+Create a summarize sub-task for each note (excluding NO_CONTENT):
+
+```
+TaskCreate: subject="Summarize: <basename>", activeForm="Summarizing <basename>"
+```
+
+Spawn all sub-agents in a **single message turn** so they run in parallel:
+
+```
+Agent({
+  description: "Summarize session note <basename>",
+  prompt: "Read the file at <READ_PATH>. Produce a structured summary with these exact markdown sections:\n\n## Summary\n1-3 sentence overview of what was accomplished.\n\n## Key Decisions\n- Bullet list of important technical decisions. Write \"None noted.\" if none.\n\n## Changes Made\n- Bullet list of files modified/created with brief description. Write \"None noted.\" if none.\n\n## Errors Encountered\n- Bullet list of errors and how resolved. Write \"None.\" if none.\n\n## Open Questions / Next Steps\n- [ ] Checkbox list of unresolved items. Write \"None.\" if none.\n\nReturn ONLY these markdown sections. No preamble, no commentary."
+})
+```
+
+Where `<READ_PATH>` is:
+- For `RAW_OK` notes: the raw note path
+- For `JSONL_PREPPED` notes: the temp file path (e.g. `/tmp/ob-prep-{hash}.md`)
+
+When all sub-agents return, update each summarize sub-task to completed.
+
+##### Wave 3 — Write back (parallel Bash calls)
+
+Create a write-back sub-task for each note that got a valid summary:
+
+```
+TaskCreate: subject="Write back: <basename>", activeForm="Writing <basename>"
+```
+
+For each sub-agent that returned a valid summary (contains `## Summary`), pipe it through `upgrade_note_with_summary()` via a heredoc:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 -c '
+import sys
+sys.path.insert(0, "hooks")
+from obsidian_utils import upgrade_note_with_summary
+summary = sys.stdin.read()
+status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
+print(status)
+' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "sub-agent" <<'SUMMARY_EOF'
+<paste sub-agent summary here at column 0>
+SUMMARY_EOF
+```
+
+**Important:** The `$NOTE_PATH` here is always the **original vault note path** (not the temp file), even for JSONL_PREPPED notes.
+
+Launch all write-back Bash calls in a single message turn.
+
+When all return, update each write-back sub-task to completed.
+
+##### Cleanup
+
+Clean up temp files:
+
+```bash
+rm -f /tmp/ob-prep-*.md
+```
+
+Mark task #2 as completed. Report results: how many upgraded, how many skipped, how many failed.
+
+If any sub-agents returned empty or invalid summaries, report those notes as still unsummarized — they will be retried on the next `/recall`.
 
 ### Step 4 — Search for project sessions and insights (parallel)
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -2,7 +2,7 @@
 name: recall
 description: "Loads historical context from the Obsidian vault for the current project. Summarizes any unsummarized session notes, then presents a context brief with recent sessions, open items, and curated insights. Also auto-detects open items completed in the most recent loaded session and offers to check them off. Use when: (1) /recall command, (2) /recall <project-name>, (3) resuming work on a project and wanting prior context."
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 # Recall — Load Project Context from Obsidian Vault
@@ -40,6 +40,19 @@ If the output is empty or errors, tell the user:
 > Config not found. Run `/obsidian-setup` first to configure your Obsidian vault.
 
 Stop here if config is missing.
+
+**Create the task manifest** for the full `/recall` flow:
+
+```
+TaskCreate: subject="Find unsummarized notes", activeForm="Searching for unsummarized notes", status immediately set to in_progress
+TaskCreate: subject="Summarize unsummarized notes", activeForm="Summarizing notes"
+TaskCreate: subject="Search sessions and insights", activeForm="Searching vault"
+TaskCreate: subject="Read and rank notes", activeForm="Reading notes"
+TaskCreate: subject="Compose context brief", activeForm="Composing brief"
+TaskCreate: subject="Present results and detect completed items", activeForm="Presenting results"
+```
+
+Track the returned task IDs — you will update them as each step completes. Task #1 is already `in_progress`.
 
 ### Step 2 — Derive project name
 
@@ -239,6 +252,8 @@ If any sub-agents returned empty or invalid summaries, report those notes as sti
 
 ### Step 4 — Search for project sessions and insights (parallel)
 
+Update task #3 to `in_progress`.
+
 Run these two searches in parallel using Grep:
 
 **Search A — Sessions:**
@@ -259,7 +274,11 @@ output_mode: files_with_matches
 
 Collect both result sets.
 
+Update task #3 to `completed`.
+
 ### Step 5 — Rank and select notes
+
+Update task #4 to `in_progress`.
 
 From the session files found, sort by date (extract from frontmatter `date:` field or filename). Select:
 
@@ -274,7 +293,11 @@ Read the selected files using the Read tool. For efficiency:
 - For older sessions, read only the first 50 lines (enough for frontmatter + summary + open questions)
 - Read all insight files in full (they are typically short)
 
+Update task #4 to `completed`.
+
 ### Step 6 — Compose context brief
+
+Update task #5 to `in_progress`.
 
 Build a context brief targeting approximately 2000 tokens. Structure it as follows:
 
@@ -301,7 +324,11 @@ $ALL_INSIGHTS_CONTENT
 
 If the brief exceeds ~2000 tokens, trim older session summaries first, then truncate insight bodies (keep titles).
 
+Update task #5 to `completed`.
+
 ### Step 7 — Present to user
+
+Update task #6 to `in_progress`.
 
 Display:
 
@@ -433,6 +460,8 @@ After the context brief, explicitly list what was loaded into the conversation s
 The session history table from Step 6 serves as a menu — if the user picks a session by name or date, use the Read tool to load that specific file and present its full contents.
 
 If the user says they're ready to work, the context is already loaded — proceed.
+
+Update task #6 to `completed`.
 
 ## Edge Cases
 


### PR DESCRIPTION
## Summary
- When `/recall` Step 3 finds 2+ unsummarized notes, skip the Haiku pipeline and go straight to parallel sub-agents with three-wave orchestration (prep → summarize → write-back)
- Conditional JSONL prep via new `prepare_summary_input()` helper extracts full transcript data to temp files only when raw notes would truncate
- User-visible task manifest via TaskCreate/TaskUpdate shows progress across all `/recall` steps with per-note granularity during summarization
- N=0 and N=1 paths unchanged (N=1 still uses Haiku pipeline + sub-agent fallback)

## Test plan
- [ ] Run `/recall` with 0 unsummarized notes — task #2 shows "No unsummarized notes found"
- [ ] Run `/recall` with 1 unsummarized note — uses Haiku pipeline, sub-task visible
- [ ] Run `/recall` with 2+ unsummarized notes — three-wave sub-agent path with per-note sub-tasks
- [ ] Verify truncated session gets JSONL prep (`JSONL_PREPPED` in output)
- [ ] Verify short session skips prep (`RAW_OK` in output)
- [ ] Verify temp files cleaned up after Wave 3
- [ ] Verify all 6 top-level tasks reach completed state

🤖 Generated with [Claude Code](https://claude.com/claude-code)