### PR TITLE
feat: delegate recall Steps 4-7.5 to context builder sub-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,25 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plugin cache with the repo working copy during local testing.
 
 ### Changed
-- `/recall` Step 3 now uses parallel sub-agents as the default summarization
+- `/recall` Step 2 now uses parallel sub-agents as the default summarization
   strategy when 2+ unsummarized notes are found, with conditional JSONL
-  transcript extraction for truncated sessions. Single-note case unchanged
-  (Haiku pipeline + sub-agent fallback).
-- `/recall` Steps 4-7.5 now delegated to a single context builder sub-agent,
-  reducing parent context from ~14k to ~6.5k tokens. Task manifest collapsed
-  from 6 to 4 top-level tasks. Fallback to in-context reads if sub-agent fails.
-- Sub-agent summaries now written to temp files instead of passed through parent
-  context via heredocs, saving ~800 tokens per note during batch summarization.
-- Per-note task sub-tasks skipped when N>5 — uses wave-level progress updates
-  instead, saving ~15-20s of parent round-trip overhead at large batch sizes.
-- `/recall` Step 3 context builder replaced from sub-agent (~145s, 70 Read calls)
-  to pure Python `build_context_brief()` function (<3s, direct file I/O). Total
-  `/recall` estimated to drop from ~4 min to ~1.5 min. Sub-agent fallback removed.
-- Config load and project derivation merged into single Python call, eliminating
-  one parent round (~5s). `/recall` steps renumbered from 8 to 5.
-- Session history table and load manifest titles in `build_context_brief()` now
-  use the first sentence of `## Summary` instead of the generic H1 heading
-  (`Session: project (branch)`), making each row descriptive of what happened.
+  transcript extraction for truncated sessions. Sub-agent summaries written to
+  temp files (no heredoc pass-through). Per-note sub-tasks skipped when N>5.
+  Single-note case unchanged (Haiku pipeline + sub-agent fallback).
+- `/recall` Step 3 context building done by pure Python `build_context_brief()`
+  function (<3s, direct file I/O) instead of sub-agent (~145s, 70 Read calls).
+  Unsummarized note detection also moved to Python `find_unsummarized_notes()`.
+  Total `/recall` reduced from ~4 min to ~1.3 min.
+- `/recall` steps reduced from 8 to 4. Config + project merged into single call.
+  Task manifest collapsed from 6 to 4 top-level tasks.
+- Session history table titles use first sentence of `## Summary` instead of
+  generic H1 heading, making each row descriptive of what happened.
 
 ### Fixed
 - f-string SyntaxError in all 10 skill templates — `python3 -c '...'` one-liners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in conversation excerpts, causing false positives and unnecessary re-summarization.
   Changed from body text pattern (`"AI summary unavailable"`) to frontmatter
   field (`^status: auto-logged`).
+- Legacy notes (119 across all projects) had `status: auto-logged` but already
+  contained real AI summaries from old SessionEnd inline-summarization path.
+  Added defense-in-depth guard to `/recall` Step 2 that checks for `## Summary`
+  before re-summarizing and auto-fixes stale status fields.
 
 ## [1.7.2] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/recall` Steps 4-7.5 now delegated to a single context builder sub-agent,
   reducing parent context from ~14k to ~6.5k tokens. Task manifest collapsed
   from 6 to 4 top-level tasks. Fallback to in-context reads if sub-agent fails.
+- Sub-agent summaries now written to temp files instead of passed through parent
+  context via heredocs, saving ~800 tokens per note during batch summarization.
+
+### Fixed
+- Config load `python3 -c` one-liner used f-strings with dict key access
+  (`c[\"vault_path\"]`) which breaks inside Bash single-quoted strings.
+  Replaced with string concatenation.
 
 ## [1.7.2] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from 6 to 4 top-level tasks. Fallback to in-context reads if sub-agent fails.
 - Sub-agent summaries now written to temp files instead of passed through parent
   context via heredocs, saving ~800 tokens per note during batch summarization.
+- Per-note task sub-tasks skipped when N>5 — uses wave-level progress updates
+  instead, saving ~15-20s of parent round-trip overhead at large batch sizes.
+- Context builder sub-agent instructed to read all files in parallel and cap
+  insights at 20 most recent, reducing sequential read bottleneck.
+- Config load and project derivation merged into single Python call, eliminating
+  one parent round (~5s). `/recall` steps renumbered from 8 to 5.
 
 ### Fixed
 - f-string SyntaxError in all 10 skill templates — `python3 -c '...'` one-liners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   context via heredocs, saving ~800 tokens per note during batch summarization.
 - Per-note task sub-tasks skipped when N>5 — uses wave-level progress updates
   instead, saving ~15-20s of parent round-trip overhead at large batch sizes.
-- Context builder sub-agent instructed to read all files in parallel and cap
-  insights at 20 most recent, reducing sequential read bottleneck.
+- `/recall` Step 3 context builder replaced from sub-agent (~145s, 70 Read calls)
+  to pure Python `build_context_brief()` function (<3s, direct file I/O). Total
+  `/recall` estimated to drop from ~4 min to ~1.5 min. Sub-agent fallback removed.
 - Config load and project derivation merged into single Python call, eliminating
   one parent round (~5s). `/recall` steps renumbered from 8 to 5.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   strategy when 2+ unsummarized notes are found, with conditional JSONL
   transcript extraction for truncated sessions. Single-note case unchanged
   (Haiku pipeline + sub-agent fallback).
+- `/recall` Steps 4-7.5 now delegated to a single context builder sub-agent,
+  reducing parent context from ~14k to ~6.5k tokens. Task manifest collapsed
+  from 6 to 4 top-level tasks. Fallback to in-context reads if sub-agent fails.
 
 ## [1.7.2] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contained real AI summaries from old SessionEnd inline-summarization path.
   Added defense-in-depth guard to `/recall` Step 2 and `/standup` Step 5 that
   checks for `## Summary` before re-summarizing and auto-fixes stale status fields.
+- Stale metadata cache caused `find_unsummarized_notes()` to skip genuinely
+  unsummarized notes and re-summarize already-upgraded ones. Function now reads
+  frontmatter directly from disk, and `upgrade_note_with_summary()` invalidates
+  cache entries after status changes.
 
 ## [1.7.2] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   used f-strings with dict key access (`c[\"vault_path\"]`) which breaks inside
   Bash single-quoted strings. Replaced with string concatenation across config
   load (10 skills) and session context (4 skills).
+- `/recall` and `/standup` grep for unsummarized notes matched tool-usage logs
+  in conversation excerpts, causing false positives and unnecessary re-summarization.
+  Changed from body text pattern (`"AI summary unavailable"`) to frontmatter
+  field (`^status: auto-logged`).
 
 ## [1.7.2] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   field (`^status: auto-logged`).
 - Legacy notes (119 across all projects) had `status: auto-logged` but already
   contained real AI summaries from old SessionEnd inline-summarization path.
-  Added defense-in-depth guard to `/recall` Step 2 that checks for `## Summary`
-  before re-summarizing and auto-fixes stale status fields.
+  Added defense-in-depth guard to `/recall` Step 2 and `/standup` Step 5 that
+  checks for `## Summary` before re-summarizing and auto-fixes stale status fields.
 
 ## [1.7.2] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/recall` estimated to drop from ~4 min to ~1.5 min. Sub-agent fallback removed.
 - Config load and project derivation merged into single Python call, eliminating
   one parent round (~5s). `/recall` steps renumbered from 8 to 5.
+- Session history table and load manifest titles in `build_context_brief()` now
+  use the first sentence of `## Summary` instead of the generic H1 heading
+  (`Session: project (branch)`), making each row descriptive of what happened.
 
 ### Fixed
 - f-string SyntaxError in all 10 skill templates — `python3 -c '...'` one-liners

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   context via heredocs, saving ~800 tokens per note during batch summarization.
 
 ### Fixed
-- Config load `python3 -c` one-liner used f-strings with dict key access
-  (`c[\"vault_path\"]`) which breaks inside Bash single-quoted strings.
-  Replaced with string concatenation.
+- f-string SyntaxError in all 10 skill templates — `python3 -c '...'` one-liners
+  used f-strings with dict key access (`c[\"vault_path\"]`) which breaks inside
+  Bash single-quoted strings. Replaced with string concatenation across config
+  load (10 skills) and session context (4 skills).
 
 ## [1.7.2] - 2026-04-09
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -925,6 +925,74 @@ def find_latest_session(
     return None
 
 
+def find_unsummarized_notes(
+    vault_path: str,
+    sessions_folder: str,
+    project: str,
+) -> str:
+    """Find unsummarized session notes for a project, with defense-in-depth.
+
+    Scans sessions folder for notes with status: auto-logged in frontmatter,
+    filters by project, and checks for false positives (notes that already
+    have a real ## Summary but stale status). Auto-fixes stale status inline.
+
+    Returns JSON string: {"unsummarized": [paths], "auto_fixed": N}
+    """
+    sessions_dir = Path(vault_path) / sessions_folder
+    if not sessions_dir.is_dir():
+        return json.dumps({"unsummarized": [], "auto_fixed": 0})
+
+    unsummarized: list[str] = []
+    auto_fixed = 0
+
+    for f in sorted(sessions_dir.iterdir(), reverse=True):
+        if f.suffix != '.md':
+            continue
+
+        meta = read_note_metadata(str(f))
+        if not meta:
+            continue
+
+        # Must be auto-logged
+        if meta.get('status') != 'auto-logged':
+            continue
+
+        # Must match project
+        fm_project = meta.get('project', '')
+        if fm_project.lower() != project.lower() and slugify(fm_project) != slugify(project):
+            continue
+
+        # Defense-in-depth: check if already has a real summary
+        try:
+            with open(f, 'r', encoding='utf-8', errors='replace') as fh:
+                content = fh.read()
+            has_summary = bool(re.search(r'^## Summary', content, re.MULTILINE))
+            has_unavailable = 'AI summary unavailable' in content
+
+            if has_summary and not has_unavailable:
+                # Already summarized by legacy code path — fix status
+                try:
+                    fixed = re.sub(
+                        r'^status: auto-logged',
+                        'status: summarized',
+                        content,
+                        count=1,
+                        flags=re.MULTILINE,
+                    )
+                    with open(f, 'w', encoding='utf-8') as fw:
+                        fw.write(fixed)
+                    auto_fixed += 1
+                except OSError:
+                    pass
+                continue
+        except OSError:
+            continue
+
+        unsummarized.append(str(f))
+
+    return json.dumps({"unsummarized": unsummarized, "auto_fixed": auto_fixed})
+
+
 def build_context_brief(
     vault_path: str,
     sessions_folder: str,

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -983,13 +983,13 @@ def build_context_brief(
             m = _summary_re.search(text)
             if m:
                 most_recent_summary = m.group(1).strip()
+                # Use first sentence of summary as title
+                first_line = most_recent_summary.split('\n')[0].strip()
+                if first_line:
+                    most_recent_title = first_line
             m = _next_steps_re.search(text)
             if m:
                 most_recent_open_items = m.group(1).strip()
-            for line in text.split('\n'):
-                if line.startswith('# '):
-                    most_recent_title = line[2:].strip()
-                    break
         except OSError:
             most_recent_summary = "(could not read session note)"
 
@@ -1006,10 +1006,10 @@ def build_context_brief(
             m = _summary_re.search(text)
             if m:
                 second_summary = m.group(1).strip()
-            for line in lines:
-                if line.startswith('# '):
-                    second_title = line[2:].strip()
-                    break
+                # Use first sentence of summary as title
+                first_line = second_summary.split('\n')[0].strip()
+                if first_line:
+                    second_title = first_line
         except OSError:
             second_summary = "(could not read session note)"
 
@@ -1021,7 +1021,14 @@ def build_context_brief(
         branch = meta.get('git_branch', '')
         try:
             with open(fpath, 'r', encoding='utf-8', errors='replace') as f:
-                for line_text in f:
+                content_text = f.read()
+            # Prefer first sentence of ## Summary as title (more descriptive)
+            summary_match = re.search(r'## Summary\n(.+)', content_text)
+            if summary_match:
+                title = summary_match.group(1).strip()
+            else:
+                # Fall back to H1 heading
+                for line_text in content_text.split('\n'):
                     if line_text.startswith('# '):
                         title = line_text[2:].strip()
                         break

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -991,8 +991,20 @@ def find_unsummarized_notes(
                     count=1,
                     flags=re.MULTILINE,
                 )
-                with open(f, 'w', encoding='utf-8') as fw:
-                    fw.write(fixed)
+                # Atomic write: temp file + rename (per CLAUDE.md convention)
+                fd, tmp = tempfile.mkstemp(
+                    prefix='.ob-fix-', suffix='.md.tmp', dir=str(f.parent)
+                )
+                try:
+                    with os.fdopen(fd, 'w', encoding='utf-8') as fw:
+                        fw.write(fixed)
+                    os.replace(tmp, str(f))
+                except Exception:
+                    try:
+                        os.unlink(tmp)
+                    except OSError:
+                        pass
+                    continue
                 # Invalidate cache for this file
                 sid = _get_session_id_fast()
                 cache_key = f"metadata:{str(f)}"
@@ -1105,7 +1117,7 @@ def build_context_brief(
             with open(fpath, 'r', encoding='utf-8', errors='replace') as f:
                 content_text = f.read()
             # Prefer first sentence of ## Summary as title (more descriptive)
-            summary_match = re.search(r'## Summary\n(.+)', content_text)
+            summary_match = re.search(r'## Summary\n+(.+)', content_text)
             if summary_match:
                 title = summary_match.group(1).strip()
             else:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -245,7 +245,7 @@ def read_note_metadata(file_path: str) -> dict | None:
     Cached per file path within the session.
     """
     sid = _get_session_id_fast()
-    cache_key = f"metadata:{file_path}"
+    cache_key = f"metadata:{os.path.realpath(file_path)}"
     _CACHE_SENTINEL = {"__no_frontmatter__": True}
     cached = cache_get(sid, cache_key)
     if cached is not None:
@@ -953,7 +953,8 @@ def find_unsummarized_notes(
         # has a persistent cache that may be stale after status changes.
         try:
             content = f.read_text(encoding='utf-8', errors='replace')
-        except OSError:
+        except OSError as exc:
+            print(f"[obsidian-brain] cannot read {f.name}: {exc}", file=sys.stderr)
             continue
 
         # Parse frontmatter inline (no cache)
@@ -1007,7 +1008,7 @@ def find_unsummarized_notes(
                     continue
                 # Invalidate cache for this file
                 sid = _get_session_id_fast()
-                cache_key = f"metadata:{str(f)}"
+                cache_key = f"metadata:{os.path.realpath(str(f))}"
                 cache_set(sid, cache_key, None)
                 auto_fixed += 1
             except OSError:
@@ -1262,17 +1263,18 @@ def build_context_brief(
         f"insight_count: {insight_count}",
     ]
 
+    # Use unique delimiters that cannot appear in user-authored markdown content
     output_parts = [
-        "CONTEXT_BRIEF:",
+        "<<<OB_CONTEXT_BRIEF>>>",
         brief,
         "",
-        "LOAD_MANIFEST:",
+        "<<<OB_LOAD_MANIFEST>>>",
         "\n".join(manifest_lines),
         "",
-        "MOST_RECENT_SESSION_PATH:",
+        "<<<OB_MOST_RECENT_SESSION_PATH>>>",
         most_recent_path,
         "",
-        "OPEN_ITEM_CANDIDATES:",
+        "<<<OB_OPEN_ITEM_CANDIDATES>>>",
         candidates_output,
     ]
 
@@ -1903,7 +1905,7 @@ def upgrade_note_with_summary(
 
     # Invalidate metadata cache for this note (status changed from auto-logged to summarized)
     sid = _get_session_id_fast()
-    cache_set(sid, f"metadata:{note_path}", None)
+    cache_set(sid, f"metadata:{os.path.realpath(note_path)}", None)
 
     # Build status
     status = f"Upgraded {os.path.basename(note_path)} (source: {source})"

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1244,7 +1244,9 @@ def build_context_brief(
             evidence = "\n".join(evidence_parts)
             if evidence:
                 items = collect_open_items(vault_path, sessions_folder, project)
-                if items:
+                if not items:
+                    candidates_output = "NO_ITEMS"
+                elif items:
                     candidates = match_items_against_evidence(evidence, items)
                     if candidates:
                         filtered = [c for c in candidates if c.get("confidence", 0) >= 3]
@@ -1255,11 +1257,11 @@ def build_context_brief(
 
     # --- 6. Compose structured output ---
     manifest_lines = [
-        f"full_session_title: {most_recent_title}",
-        f"full_session_date: {most_recent_date}",
-        f"full_session_path: {most_recent_path}",
-        f"summary_session_title: {second_title}",
-        f"summary_session_date: {second_date}",
+        f"full_session_title: {most_recent_title or '(none)'}",
+        f"full_session_date: {most_recent_date or '(none)'}",
+        f"full_session_path: {most_recent_path or '(none)'}",
+        f"summary_session_title: {second_title or '(none)'}",
+        f"summary_session_date: {second_date or '(none)'}",
         f"insight_count: {insight_count}",
     ]
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -925,6 +925,259 @@ def find_latest_session(
     return None
 
 
+def build_context_brief(
+    vault_path: str,
+    sessions_folder: str,
+    insights_folder: str,
+    project: str,
+) -> str:
+    """Build the /recall context brief entirely in Python.
+
+    Reads session and insight files directly (no sub-agent), composes
+    a structured markdown brief, and runs open-item detection.
+
+    Returns a structured string with labeled sections:
+      CONTEXT_BRIEF: <markdown brief>
+      LOAD_MANIFEST: <key-value metadata>
+      MOST_RECENT_SESSION_PATH: <path>
+      OPEN_ITEM_CANDIDATES: <JSON array or NO_CANDIDATES>
+    """
+    sessions_dir = Path(vault_path) / sessions_folder
+    insights_dir = Path(vault_path) / insights_folder
+
+    # --- 1. Scan and filter sessions ---
+    session_files: list[tuple[str, str, dict]] = []  # (filename, path, metadata)
+    if sessions_dir.is_dir():
+        for f in sorted(sessions_dir.iterdir(), reverse=True):
+            if not f.suffix == '.md':
+                continue
+            meta = read_note_metadata(str(f))
+            if not meta:
+                continue
+            fm_project = meta.get('project', '')
+            if fm_project.lower() != project.lower() and slugify(fm_project) != slugify(project):
+                continue
+            session_files.append((f.name, str(f), meta))
+
+    # --- 2. Read sessions (tiered) ---
+    most_recent_summary = ""
+    most_recent_open_items = ""
+    most_recent_title = ""
+    most_recent_date = ""
+    most_recent_path = ""
+    second_summary = ""
+    second_title = ""
+    second_date = ""
+
+    _summary_re = re.compile(r"## Summary\n(.+?)(?=\n## |\Z)", re.DOTALL)
+    _next_steps_re = re.compile(r"## Open Questions / Next Steps\n(.+?)(?=\n## |\Z)", re.DOTALL)
+
+    if len(session_files) >= 1:
+        _, most_recent_path, meta = session_files[0]
+        most_recent_date = meta.get('date', '')
+        most_recent_title = f"Session: {meta.get('project', project)}"
+        if meta.get('git_branch'):
+            most_recent_title += f" ({meta['git_branch']})"
+        try:
+            text = Path(most_recent_path).read_text(encoding='utf-8', errors='replace')
+            m = _summary_re.search(text)
+            if m:
+                most_recent_summary = m.group(1).strip()
+            m = _next_steps_re.search(text)
+            if m:
+                most_recent_open_items = m.group(1).strip()
+            for line in text.split('\n'):
+                if line.startswith('# '):
+                    most_recent_title = line[2:].strip()
+                    break
+        except OSError:
+            most_recent_summary = "(could not read session note)"
+
+    if len(session_files) >= 2:
+        _, second_path, meta = session_files[1]
+        second_date = meta.get('date', '')
+        second_title = f"Session: {meta.get('project', project)}"
+        if meta.get('git_branch'):
+            second_title += f" ({meta['git_branch']})"
+        try:
+            with open(second_path, 'r', encoding='utf-8', errors='replace') as f:
+                lines = [f.readline() for _ in range(50)]
+            text = ''.join(lines)
+            m = _summary_re.search(text)
+            if m:
+                second_summary = m.group(1).strip()
+            for line in lines:
+                if line.startswith('# '):
+                    second_title = line[2:].strip()
+                    break
+        except OSError:
+            second_summary = "(could not read session note)"
+
+    # History table (last 5 sessions)
+    history_rows: list[str] = []
+    for i, (fname, fpath, meta) in enumerate(session_files[:5]):
+        date = meta.get('date', '')
+        title = meta.get('project', project)
+        branch = meta.get('git_branch', '')
+        try:
+            with open(fpath, 'r', encoding='utf-8', errors='replace') as f:
+                for line_text in f:
+                    if line_text.startswith('# '):
+                        title = line_text[2:].strip()
+                        break
+        except OSError:
+            pass
+        history_rows.append(f"| {date} | {title} | {branch} |")
+
+    # --- 3. Scan and read insights ---
+    insight_entries: list[tuple[str, str]] = []  # (title, key_point)
+    insight_count = 0
+    if insights_dir.is_dir():
+        insight_files = sorted(
+            [f for f in insights_dir.iterdir() if f.suffix == '.md'],
+            reverse=True
+        )
+        project_insights: list[Path] = []
+        for f in insight_files:
+            meta = read_note_metadata(str(f))
+            if not meta:
+                continue
+            fm_project = meta.get('project', '')
+            if fm_project.lower() != project.lower() and slugify(fm_project) != slugify(project):
+                continue
+            project_insights.append(f)
+
+        insight_count = len(project_insights)
+        for f in project_insights[:20]:
+            title = f.stem
+            key_point = ""
+            try:
+                with open(f, 'r', encoding='utf-8', errors='replace') as fh:
+                    past_frontmatter = False
+                    frontmatter_closed = False
+                    for line_text in fh:
+                        stripped = line_text.strip()
+                        if stripped == '---':
+                            if not past_frontmatter:
+                                past_frontmatter = True
+                                continue
+                            else:
+                                frontmatter_closed = True
+                                continue
+                        if not frontmatter_closed:
+                            continue
+                        if stripped.startswith('# '):
+                            title = stripped[2:].strip()
+                            continue
+                        if stripped and not stripped.startswith('#') and not stripped.startswith('---'):
+                            key_point = stripped[:100]
+                            break
+            except OSError:
+                pass
+            insight_entries.append((title, key_point))
+
+    # Trim insights to ~500 tokens (~375 words, ~1875 chars)
+    insight_text_parts: list[str] = []
+    total_chars = 0
+    for title, key_point in insight_entries:
+        entry = f"- **{title}**"
+        if key_point:
+            entry += f" — {key_point}"
+        if total_chars + len(entry) > 1875:
+            insight_text_parts.append(f"- **{title}**")
+            total_chars += len(title) + 6
+            if total_chars > 2200:
+                break
+            continue
+        insight_text_parts.append(entry)
+        total_chars += len(entry)
+
+    insights_section = "\n".join(insight_text_parts) if insight_text_parts else "No curated insights yet for this project."
+
+    # --- 4. Compose brief ---
+    brief_parts: list[str] = [f"## Project Context: {project}"]
+
+    if most_recent_summary:
+        brief_parts.append(f"\n### Last Session ({most_recent_date})")
+        brief_parts.append(most_recent_summary)
+        if most_recent_open_items:
+            brief_parts.append(f"\n**Open Items / Next Steps:**\n{most_recent_open_items}")
+    else:
+        brief_parts.append(f"\nNo session history found for {project}.")
+
+    if second_summary:
+        brief_parts.append(f"\n### Previous Session ({second_date})")
+        brief_parts.append(second_summary)
+
+    brief_parts.append(f"\n### Curated Insights")
+    brief_parts.append(insights_section)
+
+    if history_rows:
+        brief_parts.append("\n### Recent Session History")
+        brief_parts.append("| Date | Title | Branch |")
+        brief_parts.append("|------|-------|--------|")
+        brief_parts.extend(history_rows)
+
+    brief = "\n".join(brief_parts)
+
+    # --- 5. Open-item detection ---
+    candidates_output = "NO_CANDIDATES"
+    if most_recent_path:
+        try:
+            _hooks_dir = os.path.dirname(os.path.abspath(__file__))
+            if _hooks_dir not in sys.path:
+                sys.path.insert(0, _hooks_dir)
+            from open_item_dedup import collect_open_items
+
+            evidence_parts: list[str] = []
+            try:
+                content = Path(most_recent_path).read_text(encoding='utf-8', errors='replace')
+                for section in ["Summary", "Key Decisions", "Changes Made", "Errors Encountered"]:
+                    m = re.search(rf"## {section}\n(.*?)(?=\n## |\Z)", content, re.DOTALL)
+                    if m:
+                        evidence_parts.append(m.group(1))
+            except OSError:
+                pass
+
+            evidence = "\n".join(evidence_parts)
+            if evidence:
+                items = collect_open_items(vault_path, sessions_folder, project)
+                if items:
+                    candidates = match_items_against_evidence(evidence, items)
+                    if candidates:
+                        filtered = [c for c in candidates if c.get("confidence", 0) >= 3]
+                        if filtered:
+                            candidates_output = json.dumps(filtered)
+        except Exception as exc:
+            print(f"[obsidian-brain] open-item detection failed (non-fatal): {exc}", file=sys.stderr)
+
+    # --- 6. Compose structured output ---
+    manifest_lines = [
+        f"full_session_title: {most_recent_title}",
+        f"full_session_date: {most_recent_date}",
+        f"full_session_path: {most_recent_path}",
+        f"summary_session_title: {second_title}",
+        f"summary_session_date: {second_date}",
+        f"insight_count: {insight_count}",
+    ]
+
+    output_parts = [
+        "CONTEXT_BRIEF:",
+        brief,
+        "",
+        "LOAD_MANIFEST:",
+        "\n".join(manifest_lines),
+        "",
+        "MOST_RECENT_SESSION_PATH:",
+        most_recent_path,
+        "",
+        "OPEN_ITEM_CANDIDATES:",
+        candidates_output,
+    ]
+
+    return "\n".join(output_parts)
+
+
 # ---------------------------------------------------------------------------
 # Filename / slug helpers
 # ---------------------------------------------------------------------------

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -949,43 +949,57 @@ def find_unsummarized_notes(
         if f.suffix != '.md':
             continue
 
-        meta = read_note_metadata(str(f))
-        if not meta:
+        # Read ENTIRE file from disk — DO NOT use read_note_metadata() which
+        # has a persistent cache that may be stale after status changes.
+        try:
+            content = f.read_text(encoding='utf-8', errors='replace')
+        except OSError:
             continue
 
+        # Parse frontmatter inline (no cache)
+        if not content.startswith('---'):
+            continue
+        fm_end = content.find('\n---', 3)
+        if fm_end == -1:
+            continue
+        frontmatter = content[:fm_end]
+
         # Must be auto-logged
-        if meta.get('status') != 'auto-logged':
+        status_match = re.search(r'^status:\s*(.+)$', frontmatter, re.MULTILINE)
+        if not status_match or status_match.group(1).strip() != 'auto-logged':
             continue
 
         # Must match project
-        fm_project = meta.get('project', '')
+        project_match = re.search(r'^project:\s*(.+)$', frontmatter, re.MULTILINE)
+        if not project_match:
+            continue
+        fm_project = project_match.group(1).strip().strip('"').strip("'")
         if fm_project.lower() != project.lower() and slugify(fm_project) != slugify(project):
             continue
 
         # Defense-in-depth: check if already has a real summary
-        try:
-            with open(f, 'r', encoding='utf-8', errors='replace') as fh:
-                content = fh.read()
-            has_summary = bool(re.search(r'^## Summary', content, re.MULTILINE))
-            has_unavailable = 'AI summary unavailable' in content
+        has_summary = bool(re.search(r'^## Summary', content, re.MULTILINE))
+        has_unavailable = 'AI summary unavailable' in content
 
-            if has_summary and not has_unavailable:
-                # Already summarized by legacy code path — fix status
-                try:
-                    fixed = re.sub(
-                        r'^status: auto-logged',
-                        'status: summarized',
-                        content,
-                        count=1,
-                        flags=re.MULTILINE,
-                    )
-                    with open(f, 'w', encoding='utf-8') as fw:
-                        fw.write(fixed)
-                    auto_fixed += 1
-                except OSError:
-                    pass
-                continue
-        except OSError:
+        if has_summary and not has_unavailable:
+            # Already summarized by legacy code path — fix status on disk
+            try:
+                fixed = re.sub(
+                    r'^status: auto-logged',
+                    'status: summarized',
+                    content,
+                    count=1,
+                    flags=re.MULTILINE,
+                )
+                with open(f, 'w', encoding='utf-8') as fw:
+                    fw.write(fixed)
+                # Invalidate cache for this file
+                sid = _get_session_id_fast()
+                cache_key = f"metadata:{str(f)}"
+                cache_set(sid, cache_key, None)
+                auto_fixed += 1
+            except OSError:
+                pass
             continue
 
         unsummarized.append(str(f))
@@ -1874,6 +1888,10 @@ def upgrade_note_with_summary(
     except Exception as exc:
         dedup_failed = True
         print(f"[obsidian-brain] dedup unexpected error: {exc}", file=sys.stderr)
+
+    # Invalidate metadata cache for this note (status changed from auto-logged to summarized)
+    sid = _get_session_id_fast()
+    cache_set(sid, f"metadata:{note_path}", None)
 
     # Build status
     status = f"Upgraded {os.path.basename(note_path)} (source: {source})"

--- a/skills/check-items/SKILL.md
+++ b/skills/check-items/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 
@@ -166,7 +166,7 @@ Where:
   from obsidian_utils import load_config, get_session_context
   c = load_config()
   ctx = get_session_context(c["vault_path"], c.get("sessions_folder", "claude-sessions"))
-  print(f"SID={ctx[\"session_id\"]} HASH={ctx[\"hash\"]} PROJECT={ctx[\"project\"]} SESSION_NOTE={ctx[\"session_note_name\"]}")
+  print("SID=" + ctx["session_id"] + " HASH=" + ctx["hash"] + " PROJECT=" + ctx["project"] + " SESSION_NOTE=" + ctx["session_note_name"])
   '
   ```
 

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 
@@ -150,7 +150,7 @@ Where:
   from obsidian_utils import load_config, get_session_context
   c = load_config()
   ctx = get_session_context(c["vault_path"], c.get("sessions_folder", "claude-sessions"))
-  print(f"SID={ctx[\"session_id\"]} HASH={ctx[\"hash\"]} PROJECT={ctx[\"project\"]} SESSION_NOTE={ctx[\"session_note_name\"]}")
+  print("SID=" + ctx["session_id"] + " HASH=" + ctx["hash"] + " PROJECT=" + ctx["project"] + " SESSION_NOTE=" + ctx["session_note_name"])
   '
   ```
 

--- a/skills/error-log/SKILL.md
+++ b/skills/error-log/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 
@@ -139,7 +139,7 @@ Where:
   from obsidian_utils import load_config, get_session_context
   c = load_config()
   ctx = get_session_context(c["vault_path"], c.get("sessions_folder", "claude-sessions"))
-  print(f"SID={ctx[\"session_id\"]} HASH={ctx[\"hash\"]} PROJECT={ctx[\"project\"]} SESSION_NOTE={ctx[\"session_note_name\"]}")
+  print("SID=" + ctx["session_id"] + " HASH=" + ctx["hash"] + " PROJECT=" + ctx["project"] + " SESSION_NOTE=" + ctx["session_note_name"])
   '
   ```
 

--- a/skills/link/SKILL.md
+++ b/skills/link/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 
@@ -122,16 +122,16 @@ print(status)
 If the status starts with "Failed:", use the sub-agent fallback:
 
 1. Update the sub-task subject to `Sub-agent fallback: <basename>`.
-2. Spawn a single sub-agent:
+2. Spawn a single sub-agent that writes its summary to a temp file:
 
    ```
    Agent({
      description: "Summarize session note <basename>",
-     prompt: "Read the session note at <NOTE_PATH>. Produce a structured summary with these exact markdown sections:\n\n## Summary\n1-3 sentence overview of what was accomplished.\n\n## Key Decisions\n- Bullet list of important technical decisions. Write \"None noted.\" if none.\n\n## Changes Made\n- Bullet list of files modified/created with brief description. Write \"None noted.\" if none.\n\n## Errors Encountered\n- Bullet list of errors and how resolved. Write \"None.\" if none.\n\n## Open Questions / Next Steps\n- [ ] Checkbox list of unresolved items. Write \"None.\" if none.\n\nReturn ONLY these markdown sections. No preamble, no commentary."
+     prompt: "Read the session note at <NOTE_PATH>. Produce a structured summary with these exact markdown sections:\n\n## Summary\n1-3 sentence overview of what was accomplished.\n\n## Key Decisions\n- Bullet list of important technical decisions. Write \"None noted.\" if none.\n\n## Changes Made\n- Bullet list of files modified/created with brief description. Write \"None noted.\" if none.\n\n## Errors Encountered\n- Bullet list of errors and how resolved. Write \"None.\" if none.\n\n## Open Questions / Next Steps\n- [ ] Checkbox list of unresolved items. Write \"None.\" if none.\n\nWrite the summary to /tmp/ob-summary-<basename>.md using the Write tool. Return ONLY the single line: WRITTEN:/tmp/ob-summary-<basename>.md"
    })
    ```
 
-3. If the sub-agent returns a valid summary, write it back via heredoc:
+3. If the sub-agent returns `WRITTEN:<path>`, write back via Python reading the temp file:
 
    ```bash
    cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -139,15 +139,14 @@ If the status starts with "Failed:", use the sub-agent fallback:
    import sys
    sys.path.insert(0, "hooks")
    from obsidian_utils import upgrade_note_with_summary
-   summary = sys.stdin.read()
+   with open(sys.argv[5], "r") as f:
+       summary = f.read()
    status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4])
    print(status)
-   ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" <<'SUMMARY_EOF'
-   <paste sub-agent summary here at column 0, no leading indentation>
-   SUMMARY_EOF
+   ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "/tmp/ob-summary-<basename>.md"
    ```
 
-   **Important:** Paste the sub-agent summary into the heredoc verbatim with NO leading indentation. Start `## Summary` at column 0, and keep the closing `SUMMARY_EOF` terminator at column 0 as well.
+   Then clean up: `rm -f /tmp/ob-summary-<basename>.md`
 
 Mark the sub-task and task #2 as completed. Report the result.
 
@@ -183,7 +182,7 @@ Parse each result:
 - `JSONL_PREPPED:<temp_path>:<note_path>` → sub-agent will read the temp file path; track `<note_path>` for Wave 3
 - `NO_CONTENT:<note_path>` → skip this note, report to user
 
-##### Wave 2 — Summarize (parallel sub-agents)
+##### Wave 2 — Summarize and write to temp files (parallel sub-agents)
 
 Create a summarize sub-task for each note (excluding NO_CONTENT):
 
@@ -191,32 +190,34 @@ Create a summarize sub-task for each note (excluding NO_CONTENT):
 TaskCreate: subject="Summarize: <basename>", activeForm="Summarizing <basename>"
 ```
 
-Spawn all sub-agents in a **single message turn** so they run in parallel:
+Spawn all sub-agents in a **single message turn** so they run in parallel. Each sub-agent writes its summary to a temp file instead of returning it — this keeps summary text out of the parent context (~800 tokens saved per note):
 
 ```
 Agent({
   description: "Summarize session note <basename>",
-  prompt: "Read the file at <READ_PATH>. Produce a structured summary with these exact markdown sections:\n\n## Summary\n1-3 sentence overview of what was accomplished.\n\n## Key Decisions\n- Bullet list of important technical decisions. Write \"None noted.\" if none.\n\n## Changes Made\n- Bullet list of files modified/created with brief description. Write \"None noted.\" if none.\n\n## Errors Encountered\n- Bullet list of errors and how resolved. Write \"None.\" if none.\n\n## Open Questions / Next Steps\n- [ ] Checkbox list of unresolved items. Write \"None.\" if none.\n\nReturn ONLY these markdown sections. No preamble, no commentary."
+  prompt: "Read the file at <READ_PATH>. Produce a structured summary with these exact markdown sections:\n\n## Summary\n1-3 sentence overview of what was accomplished.\n\n## Key Decisions\n- Bullet list of important technical decisions. Write \"None noted.\" if none.\n\n## Changes Made\n- Bullet list of files modified/created with brief description. Write \"None noted.\" if none.\n\n## Errors Encountered\n- Bullet list of errors and how resolved. Write \"None.\" if none.\n\n## Open Questions / Next Steps\n- [ ] Checkbox list of unresolved items. Write \"None.\" if none.\n\nWrite the summary to the file /tmp/ob-summary-<basename>.md using the Write tool. Return ONLY the single line: WRITTEN:/tmp/ob-summary-<basename>.md"
 })
 ```
 
 Where `<READ_PATH>` is:
 - For `RAW_OK` notes: the raw note path
-- For `JSONL_PREPPED` notes: the temp file path (e.g. `/tmp/ob-prep-{hash}.md`)
+- For `JSONL_PREPPED` notes: the temp file path (e.g. `/tmp/ob-prep-{session_id}.md`)
+
+And `<basename>` is the note filename without extension (e.g. `2026-04-09-obsidian-brain-2322`).
 
 When all sub-agents return, check each result:
-- If the sub-agent returned a valid summary (contains `## Summary`), update its summarize sub-task to completed.
-- If the sub-agent returned an error, empty output, or no `## Summary` section, update its summarize sub-task subject to `Failed: <basename>` and mark completed. Exclude this note from Wave 3 — it stays unsummarized for the next `/recall`. Report the failure to the user.
+- If the sub-agent returned `WRITTEN:<path>`, update its summarize sub-task to completed.
+- If the sub-agent returned an error, empty output, or anything else, update its summarize sub-task subject to `Failed: <basename>` and mark completed. Exclude this note from Wave 3 — it stays unsummarized for the next `/recall`. Report the failure to the user.
 
-##### Wave 3 — Write back (parallel Bash calls)
+##### Wave 3 — Write back from temp files (parallel Bash calls)
 
-Create a write-back sub-task for each note that got a valid summary:
+Create a write-back sub-task for each note that got a `WRITTEN:` status:
 
 ```
 TaskCreate: subject="Write back: <basename>", activeForm="Writing <basename>"
 ```
 
-For each sub-agent that returned a valid summary (contains `## Summary`), pipe it through `upgrade_note_with_summary()` via a heredoc:
+For each successful note, call Python to read the temp summary file and apply it — no heredoc needed, summary stays off parent context:
 
 ```bash
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -224,15 +225,14 @@ python3 -c '
 import sys
 sys.path.insert(0, "hooks")
 from obsidian_utils import upgrade_note_with_summary
-summary = sys.stdin.read()
+with open(sys.argv[6], "r") as f:
+    summary = f.read()
 status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
 print(status)
-' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "sub-agent" <<'SUMMARY_EOF'
-<paste sub-agent summary here at column 0>
-SUMMARY_EOF
+' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "sub-agent" "/tmp/ob-summary-<basename>.md"
 ```
 
-**Important:** The `$NOTE_PATH` here is always the **original vault note path** (not the temp file), even for JSONL_PREPPED notes.
+**Important:** `$NOTE_PATH` is always the **original vault note path** (not the temp file), even for JSONL_PREPPED notes.
 
 Launch all write-back Bash calls in a single message turn.
 
@@ -242,10 +242,10 @@ When all return, parse each result:
 
 ##### Cleanup
 
-Clean up only the specific temp files created in Wave 1 (not a glob — avoids racing with concurrent `/recall` invocations):
+Clean up all temp files created in Waves 1 and 2 (specific paths only — avoids racing with concurrent `/recall` invocations):
 
 ```bash
-rm -f /tmp/ob-prep-<session_id_1>.md /tmp/ob-prep-<session_id_2>.md ...
+rm -f /tmp/ob-prep-<session_id_1>.md /tmp/ob-prep-<session_id_2>.md /tmp/ob-summary-<basename_1>.md /tmp/ob-summary-<basename_2>.md ...
 ```
 
 Mark task #2 as completed. Report results: how many upgraded, how many skipped (NO_CONTENT), how many failed.

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -46,9 +46,7 @@ Stop here if config is missing.
 ```
 TaskCreate: subject="Find unsummarized notes", activeForm="Searching for unsummarized notes"
 TaskCreate: subject="Summarize unsummarized notes", activeForm="Summarizing notes"
-TaskCreate: subject="Search sessions and insights", activeForm="Searching vault"
-TaskCreate: subject="Read and rank notes", activeForm="Reading notes"
-TaskCreate: subject="Compose context brief", activeForm="Composing brief"
+TaskCreate: subject="Build context brief", activeForm="Building context brief"
 TaskCreate: subject="Present results and detect completed items", activeForm="Presenting results"
 ```
 
@@ -280,11 +278,7 @@ output_mode: files_with_matches
 
 Collect both result sets.
 
-Update task #3 to `completed`.
-
 ### Step 5 — Rank and select notes
-
-Update task #4 to `in_progress`.
 
 From the session files found, sort by date (extract from frontmatter `date:` field or filename). Select:
 
@@ -299,11 +293,7 @@ Read the selected files using the Read tool. For efficiency:
 - For older sessions, read only the first 50 lines (enough for frontmatter + summary + open questions)
 - Read all insight files in full (they are typically short)
 
-Update task #4 to `completed`.
-
 ### Step 6 — Compose context brief
-
-Update task #5 to `in_progress`.
 
 Build a context brief targeting approximately 2000 tokens. Structure it as follows:
 
@@ -330,11 +320,11 @@ $ALL_INSIGHTS_CONTENT
 
 If the brief exceeds ~2000 tokens, trim older session summaries first, then truncate insight bodies (keep titles).
 
-Update task #5 to `completed`.
+Update task #3 to `completed`.
 
 ### Step 7 — Present to user
 
-Update task #6 to `in_progress`.
+Update task #4 to `in_progress`.
 
 Display:
 
@@ -467,7 +457,7 @@ The session history table from Step 6 serves as a menu — if the user picks a s
 
 If the user says they're ready to work, the context is already loaded — proceed.
 
-Update task #6 to `completed`.
+Update task #4 to `completed`.
 
 ## Edge Cases
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -294,7 +294,7 @@ If unsummarized notes were upgraded in Step 2, also mention:
 
 ### Step 4 — Detect completed open items and show load manifest
 
-Parse the `OPEN_ITEM_CANDIDATES` section from the sub-agent return.
+Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
 1. **Skip if no candidates.** If the value is `NO_ITEMS` or `NO_CANDIDATES`, skip to Step 5 silently.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -63,39 +63,25 @@ Track the returned task IDs — you will update them as each step completes. Imm
 >
 > **Visibility requirement:** Before Step 3, emit a one-line status: `Step 2: processing N unsummarized note(s) for $PROJECT` (or `Step 2: no unsummarized notes for $PROJECT` if the intersection is empty). This makes the decision auditable in the tool trace.
 
-Search for raw/unsummarized session notes matching this project.
-
-Use Grep to find unsummarized notes via frontmatter status (NOT body text — body text matches cause false positives from logged tool usage):
-
-```
-pattern: "^status: auto-logged"
-path: $VAULT_PATH/$SESSIONS_FOLDER/
-output_mode: files_with_matches
-```
-
-For each file found, use Grep to confirm it matches the current project:
-
-```
-pattern: "project: $PROJECT"
-path: <each matched file>
-output_mode: content
-```
-
-**Defense-in-depth:** For each file matching both conditions, also verify it genuinely needs summarization by checking if it already has a real `## Summary` section. Use Grep:
-
-```
-pattern: "^## Summary"
-path: <each matched file>
-output_mode: count
-```
-
-If the note has `## Summary` AND does NOT contain `"AI summary unavailable"`, it was summarized by a legacy code path that forgot to flip the status. Skip it (it's already done) and fix the status field:
+Find unsummarized notes for this project in a single Python call (replaces multiple Grep rounds):
 
 ```bash
-sed -i '' 's/^status: auto-logged/status: summarized/' "$FILE_PATH"
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 -c '
+import sys
+sys.path.insert(0, "hooks")
+from obsidian_utils import find_unsummarized_notes
+print(find_unsummarized_notes(sys.argv[1], sys.argv[2], sys.argv[3]))
+' "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
 ```
 
-Count only the genuinely unsummarized files. Store as `N`.
+Parse the JSON output: `{"unsummarized": ["/path/to/note1.md", ...], "auto_fixed": N}`.
+
+The function handles project filtering, defense-in-depth (skips notes with real `## Summary` but stale `auto-logged` status, auto-fixes them), and returns only genuinely unsummarized note paths.
+
+If `auto_fixed > 0`, report: `Auto-fixed N note(s) with stale status.`
+
+Store the length of `unsummarized` as `N`.
 
 Update task #1 to completed. Update task #2 subject to `Summarize N unsummarized note(s)` and set to `in_progress`.
 
@@ -294,23 +280,19 @@ If the command fails (non-zero exit code), print the error and stop — do not f
 3. Extract `MOST_RECENT_SESSION_PATH:` — the full path for checkoff edits.
 4. Extract `OPEN_ITEM_CANDIDATES:` — either `NO_CANDIDATES`, `NO_ITEMS`, or a JSON array.
 
-Update task #3 to `completed`.
+Update task #3 to `completed`. Update task #4 to `in_progress`.
 
-### Step 4 — Present to user
-
-Update task #4 to `in_progress`.
-
-Display:
+**Present the brief immediately** (same turn — saves one parent round):
 
 > **Here's what I found from your Obsidian vault for `$PROJECT`:**
 
-Then output the `CONTEXT_BRIEF` section from the sub-agent return verbatim.
+Then output the `CONTEXT_BRIEF` section verbatim.
 
 If unsummarized notes were upgraded in Step 2, also mention:
 
 > _Upgraded N session note(s) with AI summaries._
 
-### Step 4.5 — Detect completed open items (from sub-agent data)
+### Step 4 — Detect completed open items and show load manifest
 
 Parse the `OPEN_ITEM_CANDIDATES` section from the sub-agent return.
 
@@ -366,11 +348,9 @@ Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
 
     Construct `$CHECKED_ITEMS_JSON` as a JSON array of the confirmed item texts. Report the cascade summary.
 
-Then proceed to Step 5.
+**Show load manifest** (same step — saves one parent round):
 
-### Step 5 — Show load manifest and offer options
-
-Use the `LOAD_MANIFEST` data from the sub-agent return to show:
+Use the `LOAD_MANIFEST` data to show:
 
 > **Loaded into this conversation:**
 > - Full session: *"<full_session_title>"* (<full_session_date>)

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -68,16 +68,16 @@ Store as `PROJECT`. Normalize: lowercase, hyphens for spaces.
 
 > ⚠️ **THIS STEP IS MANDATORY. DO NOT SKIP IT.**
 >
-> If Grep finds any file matching both "AI summary unavailable" AND `project: $PROJECT`, you **must** produce an upgraded summary for every such file before proceeding to Step 4. "Skipping to save context" or "the other session covers it" is a bug, not an optimization — the user ran `/recall` specifically to get current-session context, and stale unsummarized notes are exactly what they asked you to fix.
+> If Grep finds any file matching both `status: auto-logged` AND `project: $PROJECT`, you **must** produce an upgraded summary for every such file before proceeding to Step 4. "Skipping to save context" or "the other session covers it" is a bug, not an optimization — the user ran `/recall` specifically to get current-session context, and stale unsummarized notes are exactly what they asked you to fix.
 >
 > **Visibility requirement:** Before Step 4, emit a one-line status: `Step 3: processing N unsummarized note(s) for $PROJECT` (or `Step 3: no unsummarized notes for $PROJECT` if the intersection is empty). This makes the decision auditable in the tool trace.
 
 Search for raw/unsummarized session notes matching this project.
 
-Use Grep to find notes containing the "AI summary unavailable" marker in the sessions folder:
+Use Grep to find unsummarized notes via frontmatter status (NOT body text — body text matches cause false positives from logged tool usage):
 
 ```
-pattern: "AI summary unavailable"
+pattern: "^status: auto-logged"
 path: $VAULT_PATH/$SESSIONS_FOLDER/
 output_mode: files_with_matches
 ```

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -81,7 +81,21 @@ path: <each matched file>
 output_mode: content
 ```
 
-Count the files that match BOTH conditions (unsummarized AND belongs to this project). Store as `N`.
+**Defense-in-depth:** For each file matching both conditions, also verify it genuinely needs summarization by checking if it already has a real `## Summary` section. Use Grep:
+
+```
+pattern: "^## Summary"
+path: <each matched file>
+output_mode: count
+```
+
+If the note has `## Summary` AND does NOT contain `"AI summary unavailable"`, it was summarized by a legacy code path that forgot to flip the status. Skip it (it's already done) and fix the status field:
+
+```bash
+sed -i '' 's/^status: auto-logged/status: summarized/' "$FILE_PATH"
+```
+
+Count only the genuinely unsummarized files. Store as `N`.
 
 Update task #1 to completed. Update task #2 subject to `Summarize N unsummarized note(s)` and set to `in_progress`.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -15,25 +15,28 @@ Searches the Obsidian vault for session notes and insights matching the current 
 
 Follow these steps exactly. Do not skip steps or reorder them.
 
-### Step 1 — Load config
+### Step 1 — Load config and derive project
 
-Run:
+Run a single call that loads config and derives the project name (saves one parent round):
 
 ```bash
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
-import sys
+import sys, os
 sys.path.insert(0, "hooks")
 from obsidian_utils import load_config
 c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
+project = os.path.basename(os.getcwd()).lower().replace(" ", "-")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights") + " PROJECT=" + project)
 '
 ```
 
-Parse the output line to extract `VAULT_PATH`, `SESSIONS_FOLDER`, and `INSIGHTS_FOLDER`.
+Parse the output to extract `VAULT_PATH`, `SESSIONS_FOLDER`, `INSIGHTS_FOLDER`, and `PROJECT`.
+
+If the user passed a project name argument (e.g. `/recall my-project`), override `PROJECT` with that value.
 
 If the output is empty or errors, tell the user:
 
@@ -52,25 +55,13 @@ TaskCreate: subject="Present results and detect completed items", activeForm="Pr
 
 Track the returned task IDs — you will update them as each step completes. Immediately set task #1 to `in_progress` via TaskUpdate.
 
-### Step 2 — Derive project name
-
-If the user passed a project name argument (e.g. `/recall my-project`), use that.
-
-Otherwise, derive from the current working directory:
-
-```bash
-basename "$(pwd)"
-```
-
-Store as `PROJECT`. Normalize: lowercase, hyphens for spaces.
-
-### Step 3 — Summarize unsummarized notes (deferred summarization, truncation-aware)
+### Step 2 — Summarize unsummarized notes (deferred summarization, truncation-aware)
 
 > ⚠️ **THIS STEP IS MANDATORY. DO NOT SKIP IT.**
 >
-> If Grep finds any file matching both `status: auto-logged` AND `project: $PROJECT`, you **must** produce an upgraded summary for every such file before proceeding to Step 4. "Skipping to save context" or "the other session covers it" is a bug, not an optimization — the user ran `/recall` specifically to get current-session context, and stale unsummarized notes are exactly what they asked you to fix.
+> If Grep finds any file matching both `status: auto-logged` AND `project: $PROJECT`, you **must** produce an upgraded summary for every such file before proceeding to Step 3. "Skipping to save context" or "the other session covers it" is a bug, not an optimization — the user ran `/recall` specifically to get current-session context, and stale unsummarized notes are exactly what they asked you to fix.
 >
-> **Visibility requirement:** Before Step 4, emit a one-line status: `Step 3: processing N unsummarized note(s) for $PROJECT` (or `Step 3: no unsummarized notes for $PROJECT` if the intersection is empty). This makes the decision auditable in the tool trace.
+> **Visibility requirement:** Before Step 3, emit a one-line status: `Step 2: processing N unsummarized note(s) for $PROJECT` (or `Step 2: no unsummarized notes for $PROJECT` if the intersection is empty). This makes the decision auditable in the tool trace.
 
 Search for raw/unsummarized session notes matching this project.
 
@@ -96,7 +87,7 @@ Update task #1 to completed. Update task #2 subject to `Summarize N unsummarized
 
 #### Path A: N=0 (no unsummarized notes)
 
-Update task #2 subject to `No unsummarized notes found` and set to `completed`. Skip to Step 4.
+Update task #2 subject to `No unsummarized notes found` and set to `completed`. Skip to Step 3.
 
 #### Path B: N=1 (single note — Python pipeline)
 
@@ -264,7 +255,7 @@ If any sub-agents returned empty or invalid summaries, report those notes as sti
 
 For `NO_CONTENT` notes, inform the user: "Note `<basename>` has no session_id or conversation content. Manually edit it in Obsidian to add a summary, or delete it if it's empty."
 
-### Step 4 — Build context brief (sub-agent)
+### Step 3 — Build context brief (sub-agent)
 
 Update task #3 to `in_progress`.
 
@@ -279,7 +270,7 @@ VAULT_PATH: $VAULT_PATH
 SESSIONS_FOLDER: $SESSIONS_FOLDER
 INSIGHTS_FOLDER: $INSIGHTS_FOLDER
 PROJECT: $PROJECT
-UPGRADED_COUNT: <number of notes upgraded in Step 3, or 0>
+UPGRADED_COUNT: <number of notes upgraded in Step 2, or 0>
 
 ## Your task
 
@@ -416,7 +407,7 @@ OPEN_ITEM_CANDIDATES:
 
 Update task #3 to `completed`.
 
-### Step 5 — Present to user
+### Step 4 — Present to user
 
 Update task #4 to `in_progress`.
 
@@ -426,15 +417,15 @@ Display:
 
 Then output the `CONTEXT_BRIEF` section from the sub-agent return verbatim.
 
-If unsummarized notes were upgraded in Step 3, also mention:
+If unsummarized notes were upgraded in Step 2, also mention:
 
 > _Upgraded N session note(s) with AI summaries._
 
-### Step 5.5 — Detect completed open items (from sub-agent data)
+### Step 4.5 — Detect completed open items (from sub-agent data)
 
 Parse the `OPEN_ITEM_CANDIDATES` section from the sub-agent return.
 
-1. **Skip if no candidates.** If the value is `NO_ITEMS` or `NO_CANDIDATES`, skip to Step 6 silently.
+1. **Skip if no candidates.** If the value is `NO_ITEMS` or `NO_CANDIDATES`, skip to Step 5 silently.
 
 2. **Parse candidates.** The JSON array contains objects with `file`, `line`, `text`, `evidence`, `confidence`, `has_completion_phrase`.
 
@@ -454,7 +445,7 @@ Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
 ```
 
 4. **Wait for user response.** Parse the response:
-   - `none` or empty → skip checkoff entirely, proceed to Step 6
+   - `none` or empty → skip checkoff entirely, proceed to Step 5
    - `all` → check off all candidates
    - Comma-separated numbers (e.g. `1,3`) → check off only those
 
@@ -486,9 +477,9 @@ Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
 
     Construct `$CHECKED_ITEMS_JSON` as a JSON array of the confirmed item texts. Report the cascade summary.
 
-Then proceed to Step 6.
+Then proceed to Step 5.
 
-### Step 6 — Show load manifest and offer options
+### Step 5 — Show load manifest and offer options
 
 Use the `LOAD_MANIFEST` data from the sub-agent return to show:
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -152,9 +152,11 @@ Mark the sub-task and task #2 as completed. Report the result.
 
 #### Path C: N>=2 (batch — sub-agent-first, three waves)
 
+**Task management threshold:** If N <= 5, create per-note sub-tasks for each wave (prep, summarize, write-back). If N > 5, skip per-note sub-tasks — use a single progress update on task #2 per wave instead (e.g. `Summarize 10 notes: Wave 1 prep complete`). This saves ~15-20s of parent round-trip overhead at large N.
+
 ##### Wave 1 — Prep (parallel Bash calls)
 
-Create a prep sub-task for each note:
+If N <= 5, create a prep sub-task for each note:
 
 ```
 TaskCreate: subject="Prep: <basename>", activeForm="Prepping <basename>"
@@ -175,7 +177,9 @@ print(result)
 
 Launch all N Bash calls in a single message turn so they run in parallel.
 
-When all return, update each prep sub-task to completed (include result in subject: e.g. `Prep: ...2322.md (RAW_OK)` or `Prep: ...4653.md (JSONL_PREPPED)`).
+When all return:
+- If N <= 5: update each prep sub-task to completed (include result in subject: e.g. `Prep: ...2322.md (RAW_OK)`).
+- If N > 5: update task #2 subject to `Summarize N notes: Wave 1 prep complete`.
 
 Parse each result:
 - `RAW_OK:<note_path>` → sub-agent will read the raw note path
@@ -184,7 +188,7 @@ Parse each result:
 
 ##### Wave 2 — Summarize and write to temp files (parallel sub-agents)
 
-Create a summarize sub-task for each note (excluding NO_CONTENT):
+If N <= 5, create a summarize sub-task for each note (excluding NO_CONTENT):
 
 ```
 TaskCreate: subject="Summarize: <basename>", activeForm="Summarizing <basename>"
@@ -206,12 +210,15 @@ Where `<READ_PATH>` is:
 And `<basename>` is the note filename without extension (e.g. `2026-04-09-obsidian-brain-2322`).
 
 When all sub-agents return, check each result:
-- If the sub-agent returned `WRITTEN:<path>`, update its summarize sub-task to completed.
-- If the sub-agent returned an error, empty output, or anything else, update its summarize sub-task subject to `Failed: <basename>` and mark completed. Exclude this note from Wave 3 — it stays unsummarized for the next `/recall`. Report the failure to the user.
+- If the sub-agent returned `WRITTEN:<path>`, mark it as succeeded.
+- If the sub-agent returned an error, empty output, or anything else, mark it as failed. Exclude this note from Wave 3 — it stays unsummarized for the next `/recall`. Report the failure to the user.
+
+If N <= 5: update each summarize sub-task to completed (or `Failed: <basename>`).
+If N > 5: update task #2 subject to `Summarize N notes: Wave 2 complete (M succeeded, F failed)`.
 
 ##### Wave 3 — Write back from temp files (parallel Bash calls)
 
-Create a write-back sub-task for each note that got a `WRITTEN:` status:
+If N <= 5, create a write-back sub-task for each note that got a `WRITTEN:` status:
 
 ```
 TaskCreate: subject="Write back: <basename>", activeForm="Writing <basename>"
@@ -237,8 +244,11 @@ print(status)
 Launch all write-back Bash calls in a single message turn.
 
 When all return, parse each result:
-- If the status does NOT start with "Failed:", update the write-back sub-task to completed.
-- If the status starts with "Failed:", update the sub-task subject to `Failed: <basename>` and mark completed. Count it in the failure tally.
+- If the status does NOT start with "Failed:", mark as succeeded.
+- If the status starts with "Failed:", mark as failed. Count it in the failure tally.
+
+If N <= 5: update each write-back sub-task accordingly.
+If N > 5: update task #2 subject to `Summarize N notes: Wave 3 complete (M written, F failed)`.
 
 ##### Cleanup
 
@@ -292,9 +302,12 @@ Search B — Insights:
 From session files, sort by date (from frontmatter or filename). Select:
 - Most recent session — read in full. Store its path.
 - Second most recent — read first 50 lines (frontmatter + summary + open questions)
-- Last 5 sessions — collect titles, dates, branches for the history table
+- Last 5 sessions — read first 15 lines each (enough for frontmatter title/date/branch)
 
-From insight files, read ALL of them in full (they are short).
+From insight files, if 20 or fewer read ALL of them. If more than 20, read only the 20 most recent (by filename date prefix).
+
+**IMPORTANT — Maximize parallel reads to reduce wall time:**
+Read the most recent session, second session (50 lines), older sessions (15 lines each), and all insight files in a SINGLE message turn with all Read calls in parallel. Do NOT read files one at a time — sequential reads are the #1 wall-time bottleneck.
 
 ### 3. Compose context brief (~2000 tokens)
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -269,155 +269,30 @@ If any sub-agents returned empty or invalid summaries, report those notes as sti
 
 For `NO_CONTENT` notes, inform the user: "Note `<basename>` has no session_id or conversation content. Manually edit it in Obsidian to add a summary, or delete it if it's empty."
 
-### Step 3 — Build context brief (sub-agent)
+### Step 3 — Build context brief (Python)
 
 Update task #3 to `in_progress`.
 
-Dispatch a single sub-agent to search, read, rank, compose the context brief, and detect completed open items. The sub-agent does all the heavy file reading in its own context — the parent only receives the compact result.
+Run a single Python call that reads all session and insight files, composes the brief, and detects completed open items — no sub-agent needed:
 
-```
-Agent({
-  description: "Build recall context brief for $PROJECT",
-  prompt: "You are building a context brief for the obsidian-brain /recall skill.
-
-VAULT_PATH: $VAULT_PATH
-SESSIONS_FOLDER: $SESSIONS_FOLDER
-INSIGHTS_FOLDER: $INSIGHTS_FOLDER
-PROJECT: $PROJECT
-UPGRADED_COUNT: <number of notes upgraded in Step 2, or 0>
-
-## Your task
-
-### 1. Search for project sessions and insights (parallel Grep)
-
-Run these two searches in parallel:
-
-Search A — Sessions:
-  pattern: 'project: $PROJECT'
-  path: $VAULT_PATH/$SESSIONS_FOLDER/
-  output_mode: files_with_matches
-
-Search B — Insights:
-  pattern: 'project: $PROJECT'
-  path: $VAULT_PATH/$INSIGHTS_FOLDER/
-  output_mode: files_with_matches
-
-### 2. Rank and select notes
-
-From session files, sort by date (from frontmatter or filename). Select:
-- Most recent session — read in full. Store its path.
-- Second most recent — read first 50 lines (frontmatter + summary + open questions)
-- Last 5 sessions — read first 15 lines each (enough for frontmatter title/date/branch)
-
-From insight files, if 20 or fewer read ALL of them. If more than 20, read only the 20 most recent (by filename date prefix).
-
-**IMPORTANT — Maximize parallel reads to reduce wall time:**
-Read the most recent session, second session (50 lines), older sessions (15 lines each), and all insight files in a SINGLE message turn with all Read calls in parallel. Do NOT read files one at a time — sequential reads are the #1 wall-time bottleneck.
-
-### 3. Compose context brief (~2000 tokens)
-
-Build this structure:
-
-## Project Context: $PROJECT
-
-### Last Session ($DATE)
-$SUMMARY_FROM_MOST_RECENT_SESSION
-
-**Open Items / Next Steps:**
-$OPEN_QUESTIONS_FROM_MOST_RECENT_SESSION
-
-### Previous Session ($DATE)
-$BRIEF_SUMMARY_FROM_SECOND_SESSION
-
-### Curated Insights
-$ALL_INSIGHTS_CONTENT (titles + key points, trim if exceeding ~500 tokens)
-
-### Recent Session History
-| Date | Title | Branch |
-|------|-------|--------|
-| ... last 5 sessions ... |
-
-If the brief exceeds ~2000 tokens, trim older session summaries first, then truncate insight bodies (keep titles).
-
-### 4. Detect completed open items
-
-Run this Bash command:
-
-cd \"\$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
-import sys, json
-sys.path.insert(0, \"hooks\")
-from obsidian_utils import match_items_against_evidence
-from open_item_dedup import collect_open_items
-
-vault_path, sessions_folder, project = sys.argv[1], sys.argv[2], sys.argv[3]
-evidence_file = sys.argv[4]
-
-try:
-    with open(evidence_file, \"r\") as f:
-        content = f.read()
-    import re as _re
-    evidence_parts = []
-    for section in [\"Summary\", \"Key Decisions\", \"Changes Made\", \"Errors Encountered\"]:
-        m = _re.search(rf\"## {section}\n(.*?)(?=\n## |\Z)\", content, _re.DOTALL)
-        if m:
-            evidence_parts.append(m.group(1))
-    evidence = \"\n\".join(evidence_parts) if evidence_parts else content
-except OSError:
-    print(\"NO_CANDIDATES\")
-    sys.exit(0)
-
-items = collect_open_items(vault_path, sessions_folder, project)
-if not items:
-    print(\"NO_ITEMS\")
-    sys.exit(0)
-
-candidates = match_items_against_evidence(evidence, items)
-if not candidates:
-    print(\"NO_CANDIDATES\")
-else:
-    filtered = [c for c in candidates if c.get(\"confidence\", 0) >= 3]
-    print(json.dumps(filtered) if filtered else \"NO_CANDIDATES\")
-' \"$VAULT_PATH\" \"$SESSIONS_FOLDER\" \"$PROJECT\" \"<MOST_RECENT_SESSION_PATH>\"
-
-Where <MOST_RECENT_SESSION_PATH> is the full path of the most recent session note you read in step 2.
-
-### 5. Return format
-
-Return EXACTLY this structured format with labeled sections. Do NOT add preamble or commentary outside these sections:
-
-CONTEXT_BRIEF:
-<the composed brief from step 3>
-
-LOAD_MANIFEST:
-full_session_title: <title of most recent session>
-full_session_date: <date>
-full_session_path: <full file path>
-summary_session_title: <title of second session>
-summary_session_date: <date>
-insight_count: <number of insight files found>
-
-MOST_RECENT_SESSION_PATH:
-<full path of most recent session note>
-
-OPEN_ITEM_CANDIDATES:
-<output from step 4 — either NO_CANDIDATES, NO_ITEMS, or a JSON array>
-
-## Edge cases
-- No sessions found: set CONTEXT_BRIEF to 'No session history found for $PROJECT.'
-- No insights found: omit Curated Insights section from brief, set insight_count to 0
-- Very large vault (50+ sessions): only grep, never glob. Limit reads to 5 most recent sessions + all insights."
-})
+import sys
+sys.path.insert(0, "hooks")
+from obsidian_utils import build_context_brief
+print(build_context_brief(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]))
+' "$VAULT_PATH" "$SESSIONS_FOLDER" "$INSIGHTS_FOLDER" "$PROJECT"
 ```
 
-**Parse the sub-agent return.** Split the returned text on the section labels:
+If the command fails (non-zero exit code), print the error and stop — do not fall back to in-context reads.
+
+**Parse the output.** Split on section labels:
 
 1. Extract `CONTEXT_BRIEF:` — everything between `CONTEXT_BRIEF:` and `LOAD_MANIFEST:`. This is the brief to display.
 2. Extract `LOAD_MANIFEST:` — parse `full_session_title`, `full_session_date`, `full_session_path`, `summary_session_title`, `summary_session_date`, `insight_count`.
 3. Extract `MOST_RECENT_SESSION_PATH:` — the full path for checkoff edits.
 4. Extract `OPEN_ITEM_CANDIDATES:` — either `NO_CANDIDATES`, `NO_ITEMS`, or a JSON array.
-
-**Fallback:** If the sub-agent returns empty, errors, or the return does not contain `CONTEXT_BRIEF:`, fall back to performing Steps 4-6 in-context (the original flow: grep sessions + insights, read files, compose brief). Log a warning: "Context builder sub-agent failed, falling back to in-context reads."
 
 Update task #3 to `completed`.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -254,50 +254,52 @@ If any sub-agents returned empty or invalid summaries, report those notes as sti
 
 For `NO_CONTENT` notes, inform the user: "Note `<basename>` has no session_id or conversation content. Manually edit it in Obsidian to add a summary, or delete it if it's empty."
 
-### Step 4 — Search for project sessions and insights (parallel)
+### Step 4 — Build context brief (sub-agent)
 
 Update task #3 to `in_progress`.
 
-Run these two searches in parallel using Grep:
-
-**Search A — Sessions:**
+Dispatch a single sub-agent to search, read, rank, compose the context brief, and detect completed open items. The sub-agent does all the heavy file reading in its own context — the parent only receives the compact result.
 
 ```
-pattern: "project: $PROJECT"
-path: $VAULT_PATH/$SESSIONS_FOLDER/
-output_mode: files_with_matches
-```
+Agent({
+  description: "Build recall context brief for $PROJECT",
+  prompt: "You are building a context brief for the obsidian-brain /recall skill.
 
-**Search B — Insights:**
+VAULT_PATH: $VAULT_PATH
+SESSIONS_FOLDER: $SESSIONS_FOLDER
+INSIGHTS_FOLDER: $INSIGHTS_FOLDER
+PROJECT: $PROJECT
+UPGRADED_COUNT: <number of notes upgraded in Step 3, or 0>
 
-```
-pattern: "project: $PROJECT"
-path: $VAULT_PATH/$INSIGHTS_FOLDER/
-output_mode: files_with_matches
-```
+## Your task
 
-Collect both result sets.
+### 1. Search for project sessions and insights (parallel Grep)
 
-### Step 5 — Rank and select notes
+Run these two searches in parallel:
 
-From the session files found, sort by date (extract from frontmatter `date:` field or filename). Select:
+Search A — Sessions:
+  pattern: 'project: $PROJECT'
+  path: $VAULT_PATH/$SESSIONS_FOLDER/
+  output_mode: files_with_matches
 
-- **Most recent session** — read in full (this is the primary context). Store its full path as `MOST_RECENT_SESSION_PATH` for use in Step 7.5.
-- **Second most recent session** — read summary + open questions only
-- **Last 5 sessions** — collect titles and dates for the session list
+Search B — Insights:
+  pattern: 'project: $PROJECT'
+  path: $VAULT_PATH/$INSIGHTS_FOLDER/
+  output_mode: files_with_matches
 
-From the insights files found, include **all of them** — insights are curated and always relevant.
+### 2. Rank and select notes
 
-Read the selected files using the Read tool. For efficiency:
-- Read the most recent session in full
-- For older sessions, read only the first 50 lines (enough for frontmatter + summary + open questions)
-- Read all insight files in full (they are typically short)
+From session files, sort by date (from frontmatter or filename). Select:
+- Most recent session — read in full. Store its path.
+- Second most recent — read first 50 lines (frontmatter + summary + open questions)
+- Last 5 sessions — collect titles, dates, branches for the history table
 
-### Step 6 — Compose context brief
+From insight files, read ALL of them in full (they are short).
 
-Build a context brief targeting approximately 2000 tokens. Structure it as follows:
+### 3. Compose context brief (~2000 tokens)
 
-```
+Build this structure:
+
 ## Project Context: $PROJECT
 
 ### Last Session ($DATE)
@@ -310,137 +312,96 @@ $OPEN_QUESTIONS_FROM_MOST_RECENT_SESSION
 $BRIEF_SUMMARY_FROM_SECOND_SESSION
 
 ### Curated Insights
-$ALL_INSIGHTS_CONTENT
+$ALL_INSIGHTS_CONTENT (titles + key points, trim if exceeding ~500 tokens)
 
 ### Recent Session History
 | Date | Title | Branch |
 |------|-------|--------|
 | ... last 5 sessions ... |
-```
 
 If the brief exceeds ~2000 tokens, trim older session summaries first, then truncate insight bodies (keep titles).
 
+### 4. Detect completed open items
+
+Run this Bash command:
+
+cd \"\$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"
+python3 -c '
+import sys, json
+sys.path.insert(0, \"hooks\")
+from obsidian_utils import match_items_against_evidence
+from open_item_dedup import collect_open_items
+
+vault_path, sessions_folder, project = sys.argv[1], sys.argv[2], sys.argv[3]
+evidence_file = sys.argv[4]
+
+try:
+    with open(evidence_file, \"r\") as f:
+        content = f.read()
+    import re as _re
+    evidence_parts = []
+    for section in [\"Summary\", \"Key Decisions\", \"Changes Made\", \"Errors Encountered\"]:
+        m = _re.search(rf\"## {section}\n(.*?)(?=\n## |\Z)\", content, _re.DOTALL)
+        if m:
+            evidence_parts.append(m.group(1))
+    evidence = \"\n\".join(evidence_parts) if evidence_parts else content
+except OSError:
+    print(\"NO_CANDIDATES\")
+    sys.exit(0)
+
+items = collect_open_items(vault_path, sessions_folder, project)
+if not items:
+    print(\"NO_ITEMS\")
+    sys.exit(0)
+
+candidates = match_items_against_evidence(evidence, items)
+if not candidates:
+    print(\"NO_CANDIDATES\")
+else:
+    filtered = [c for c in candidates if c.get(\"confidence\", 0) >= 3]
+    print(json.dumps(filtered) if filtered else \"NO_CANDIDATES\")
+' \"$VAULT_PATH\" \"$SESSIONS_FOLDER\" \"$PROJECT\" \"<MOST_RECENT_SESSION_PATH>\"
+
+Where <MOST_RECENT_SESSION_PATH> is the full path of the most recent session note you read in step 2.
+
+### 5. Return format
+
+Return EXACTLY this structured format with labeled sections. Do NOT add preamble or commentary outside these sections:
+
+CONTEXT_BRIEF:
+<the composed brief from step 3>
+
+LOAD_MANIFEST:
+full_session_title: <title of most recent session>
+full_session_date: <date>
+full_session_path: <full file path>
+summary_session_title: <title of second session>
+summary_session_date: <date>
+insight_count: <number of insight files found>
+
+MOST_RECENT_SESSION_PATH:
+<full path of most recent session note>
+
+OPEN_ITEM_CANDIDATES:
+<output from step 4 — either NO_CANDIDATES, NO_ITEMS, or a JSON array>
+
+## Edge cases
+- No sessions found: set CONTEXT_BRIEF to 'No session history found for $PROJECT.'
+- No insights found: omit Curated Insights section from brief, set insight_count to 0
+- Very large vault (50+ sessions): only grep, never glob. Limit reads to 5 most recent sessions + all insights."
+})
+```
+
+**Parse the sub-agent return.** Split the returned text on the section labels:
+
+1. Extract `CONTEXT_BRIEF:` — everything between `CONTEXT_BRIEF:` and `LOAD_MANIFEST:`. This is the brief to display.
+2. Extract `LOAD_MANIFEST:` — parse `full_session_title`, `full_session_date`, `full_session_path`, `summary_session_title`, `summary_session_date`, `insight_count`.
+3. Extract `MOST_RECENT_SESSION_PATH:` — the full path for checkoff edits.
+4. Extract `OPEN_ITEM_CANDIDATES:` — either `NO_CANDIDATES`, `NO_ITEMS`, or a JSON array.
+
+**Fallback:** If the sub-agent returns empty, errors, or the return does not contain `CONTEXT_BRIEF:`, fall back to performing Steps 4-6 in-context (the original flow: grep sessions + insights, read files, compose brief). Log a warning: "Context builder sub-agent failed, falling back to in-context reads."
+
 Update task #3 to `completed`.
-
-### Step 7 — Present to user
-
-Update task #4 to `in_progress`.
-
-Display:
-
-> **Here's what I found from your Obsidian vault for `$PROJECT`:**
-
-Then output the context brief from Step 6.
-
-If unsummarized notes were upgraded in Step 3, also mention:
-
-> _Upgraded N session note(s) with AI summaries._
-
-### Step 7.5 — Detect completed open items (project-scoped auto-detect)
-
-After presenting the context brief, scan the loaded context for evidence that any open items have been completed.
-
-1. **Match open items against evidence in Python.** Run a single Bash call that collects open items and matches them against the most recent session note:
-
-   ```bash
-   cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-   python3 -c '
-   import sys, json
-   sys.path.insert(0, "hooks")
-   from obsidian_utils import match_items_against_evidence
-   from open_item_dedup import collect_open_items
-
-   vault_path, sessions_folder, project = sys.argv[1], sys.argv[2], sys.argv[3]
-   evidence_file = sys.argv[4]
-
-   try:
-       with open(evidence_file, "r") as f:
-           content = f.read()
-       # Extract only evidence sections (Summary, Changes, Errors) — exclude
-       # Open Questions to avoid self-matching open items as candidates
-       import re as _re
-       evidence_parts = []
-       for section in ["Summary", "Key Decisions", "Changes Made", "Errors Encountered"]:
-           m = _re.search(rf"## {section}\n(.*?)(?=\n## |\Z)", content, _re.DOTALL)
-           if m:
-               evidence_parts.append(m.group(1))
-       evidence = "\n".join(evidence_parts) if evidence_parts else content
-   except OSError as exc:
-       print("NO_CANDIDATES")
-       sys.exit(0)
-
-   items = collect_open_items(vault_path, sessions_folder, project)
-   if not items:
-       print("NO_ITEMS")
-       sys.exit(0)
-
-   candidates = match_items_against_evidence(evidence, items)
-   if not candidates:
-       print("NO_CANDIDATES")
-   else:
-       print(json.dumps(candidates))
-   ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "$MOST_RECENT_SESSION_PATH"
-   ```
-
-   Where `$MOST_RECENT_SESSION_PATH` is the path to the most recent session note (already read in Step 5).
-
-2. **Skip if no candidates.** If the output is `NO_ITEMS` or `NO_CANDIDATES`, skip to Step 8 silently.
-
-3. **Parse candidates.** The JSON array contains objects with `file`, `line`, `text`, `evidence`, `confidence`, `has_completion_phrase`. Only present items with `confidence >= 3` to the user.
-
-4. **Present candidates to user.** Print:
-
-```
-I noticed these open items may now be done:
-
-1. [x] <item text>
-     From: <basename of source file>
-     Evidence: "<short snippet from EVIDENCE_TEXT showing the match>"
-
-2. [x] <item text>
-     ...
-
-Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
-```
-
-5. **Wait for user response.** Parse the response:
-   - `none` or empty → skip checkoff entirely, proceed to Step 8
-   - `all` → check off all candidates
-   - Comma-separated numbers (e.g. `1,3`) → check off only those
-
-6. **For each confirmed checkoff, edit the source file.** Use Read to load the full source file. Find the exact line containing `- [ ] <item text>`. Replace it with `- [x] <item text>`. Use the Edit tool with `replace_all: false` and provide enough context (the full line plus the line before and after if available) to ensure uniqueness within the file. If the line is ambiguous (multiple matches), skip that item and warn:
-
-```
-⚠️  Could not check off item "<item text>" — line is not unique in <file>. Edit manually in Obsidian.
-```
-
-7. **Confirm checkoffs to user.** Print:
-
-```
-✅ Checked off N item(s) across <list of files>.
-```
-
-8. **Cascade check-offs to duplicate items in older notes.** Run a single Bash call that collects, matches, and edits files in Python:
-
-    ```bash
-    cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-    python3 -c '
-    import sys, json
-    sys.path.insert(0, "hooks")
-    from open_item_dedup import batch_cascade_checkoff
-    items = json.loads(sys.argv[4])
-    summary = batch_cascade_checkoff(sys.argv[1], sys.argv[2], sys.argv[3], items)
-    print(summary)
-    ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "$CHECKED_ITEMS_JSON"
-    ```
-
-    Before running, construct `$CHECKED_ITEMS_JSON` as a JSON array of the confirmed item texts from sub-step 5. Use a Bash heredoc or inline Python to build it:
-    ```bash
-    CHECKED_ITEMS_JSON=$(python3 -c "import json; print(json.dumps([\"Git-flow migration spec pending\", \"Land PR #14\"]))")
-    ```
-    Replace the example items with the actual confirmed item texts. Then run the cascade command above. Report the cascade summary to the user alongside the checkoff confirmation.
-
-Then proceed to Step 8.
 
 ### Step 8 — Show load manifest and offer options
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -2,7 +2,7 @@
 name: recall
 description: "Loads historical context from the Obsidian vault for the current project. Summarizes any unsummarized session notes, then presents a context brief with recent sessions, open items, and curated insights. Also auto-detects open items completed in the most recent loaded session and offers to check them off. Use when: (1) /recall command, (2) /recall <project-name>, (3) resuming work on a project and wanting prior context."
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 # Recall — Load Project Context from Obsidian Vault
@@ -403,18 +403,90 @@ OPEN_ITEM_CANDIDATES:
 
 Update task #3 to `completed`.
 
-### Step 8 — Show load manifest and offer options
+### Step 5 — Present to user
 
-After the context brief, explicitly list what was loaded into the conversation so the user knows exactly what context is available:
+Update task #4 to `in_progress`.
+
+Display:
+
+> **Here's what I found from your Obsidian vault for `$PROJECT`:**
+
+Then output the `CONTEXT_BRIEF` section from the sub-agent return verbatim.
+
+If unsummarized notes were upgraded in Step 3, also mention:
+
+> _Upgraded N session note(s) with AI summaries._
+
+### Step 5.5 — Detect completed open items (from sub-agent data)
+
+Parse the `OPEN_ITEM_CANDIDATES` section from the sub-agent return.
+
+1. **Skip if no candidates.** If the value is `NO_ITEMS` or `NO_CANDIDATES`, skip to Step 6 silently.
+
+2. **Parse candidates.** The JSON array contains objects with `file`, `line`, `text`, `evidence`, `confidence`, `has_completion_phrase`.
+
+3. **Present candidates to user.** Print:
+
+```
+I noticed these open items may now be done:
+
+1. [x] <item text>
+     From: <basename of source file>
+     Evidence: "<short snippet from evidence showing the match>"
+
+2. [x] <item text>
+     ...
+
+Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
+```
+
+4. **Wait for user response.** Parse the response:
+   - `none` or empty → skip checkoff entirely, proceed to Step 6
+   - `all` → check off all candidates
+   - Comma-separated numbers (e.g. `1,3`) → check off only those
+
+5. **For each confirmed checkoff, edit the source file.** Use Read to load the full source file. Find the exact line containing `- [ ] <item text>`. Replace it with `- [x] <item text>`. Use the Edit tool with `replace_all: false` and provide enough context to ensure uniqueness. If the line is ambiguous, skip and warn:
+
+```
+⚠️  Could not check off item "<item text>" — line is not unique in <file>. Edit manually in Obsidian.
+```
+
+6. **Confirm checkoffs to user.** Print:
+
+```
+✅ Checked off N item(s) across <list of files>.
+```
+
+7. **Cascade check-offs to duplicate items in older notes.** Run:
+
+    ```bash
+    cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    python3 -c '
+    import sys, json
+    sys.path.insert(0, "hooks")
+    from open_item_dedup import batch_cascade_checkoff
+    items = json.loads(sys.argv[4])
+    summary = batch_cascade_checkoff(sys.argv[1], sys.argv[2], sys.argv[3], items)
+    print(summary)
+    ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "$CHECKED_ITEMS_JSON"
+    ```
+
+    Construct `$CHECKED_ITEMS_JSON` as a JSON array of the confirmed item texts. Report the cascade summary.
+
+Then proceed to Step 6.
+
+### Step 6 — Show load manifest and offer options
+
+Use the `LOAD_MANIFEST` data from the sub-agent return to show:
 
 > **Loaded into this conversation:**
-> - Full session: *"[most recent session title]"* ([date])
-> - Summary only: *"[second session title]"* ([date])
-> - [N] curated insight(s)
+> - Full session: *"<full_session_title>"* (<full_session_date>)
+> - Summary only: *"<summary_session_title>"* (<summary_session_date>)
+> - <insight_count> curated insight(s)
 >
 > Pick any session from the history table above to load it, or ready to start working?
 
-The session history table from Step 6 serves as a menu — if the user picks a session by name or date, use the Read tool to load that specific file and present its full contents.
+The session history table from the context brief serves as a menu — if the user picks a session by name or date, use the Read tool to load that specific file from `$VAULT_PATH/$SESSIONS_FOLDER/` and present its full contents.
 
 If the user says they're ready to work, the context is already loaded — proceed.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -275,10 +275,10 @@ If the command fails (non-zero exit code), print the error and stop — do not f
 
 **Parse the output.** Split on section labels:
 
-1. Extract `CONTEXT_BRIEF:` — everything between `CONTEXT_BRIEF:` and `LOAD_MANIFEST:`. This is the brief to display.
-2. Extract `LOAD_MANIFEST:` — parse `full_session_title`, `full_session_date`, `full_session_path`, `summary_session_title`, `summary_session_date`, `insight_count`.
-3. Extract `MOST_RECENT_SESSION_PATH:` — the full path for checkoff edits.
-4. Extract `OPEN_ITEM_CANDIDATES:` — either `NO_CANDIDATES`, `NO_ITEMS`, or a JSON array.
+1. Extract `<<<OB_CONTEXT_BRIEF>>>` — everything between this delimiter and `<<<OB_LOAD_MANIFEST>>>`. This is the brief to display.
+2. Extract `<<<OB_LOAD_MANIFEST>>>` — parse `full_session_title`, `full_session_date`, `full_session_path`, `summary_session_title`, `summary_session_date`, `insight_count`.
+3. Extract `<<<OB_MOST_RECENT_SESSION_PATH>>>` — the full path for checkoff edits.
+4. Extract `<<<OB_OPEN_ITEM_CANDIDATES>>>` — either `NO_CANDIDATES`, `NO_ITEMS`, or a JSON array.
 
 Update task #3 to `completed`. Update task #4 to `in_progress`.
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 
@@ -103,7 +103,7 @@ sys.path.insert(0, "hooks")
 from obsidian_utils import load_config, get_session_context
 c = load_config()
 ctx = get_session_context(c["vault_path"], c.get("sessions_folder", "claude-sessions"))
-print(f"SID={ctx[\"session_id\"]} HASH={ctx[\"hash\"]} PROJECT={ctx[\"project\"]} SESSION_NOTE={ctx[\"session_note_name\"]}")
+print("SID=" + ctx["session_id"] + " HASH=" + ctx["hash"] + " PROJECT=" + ctx["project"] + " SESSION_NOTE=" + ctx["session_note_name"])
 '
 ```
 

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -162,9 +162,15 @@ path: <each session file>
 output_mode: files_with_matches
 ```
 
+**Defense-in-depth:** For each file matching `^status: auto-logged`, also check if it already has a real `## Summary` section (without `"AI summary unavailable"`). If so, the note was summarized by a legacy code path that never flipped the status. Skip it and fix the status:
+
+```bash
+sed -i '' 's/^status: auto-logged/status: summarized/' "$FILE_PATH"
+```
+
 Split into:
-- `UNSUMMARIZED` — session files with `status: auto-logged` in frontmatter
-- `SUMMARIZED` — all other matched files (sessions + insights)
+- `UNSUMMARIZED` — session files with `status: auto-logged` AND no real `## Summary`
+- `SUMMARIZED` — all other matched files (sessions + insights + auto-fixed legacy notes)
 
 ### Step 6 — Deferred summarization for unsummarized notes
 

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -154,16 +154,16 @@ Stop here.
 
 ### Step 5 — Identify unsummarized session notes
 
-From `MATCHED_FILES`, isolate those in `$SESSIONS_FOLDER/`. Use Grep to check each for the unsummarized marker:
+From `MATCHED_FILES`, isolate those in `$SESSIONS_FOLDER/`. Use Grep to check each for the unsummarized frontmatter status (NOT body text — body text matches cause false positives from logged tool usage):
 
 ```
-pattern: "AI summary unavailable"
+pattern: "^status: auto-logged"
 path: <each session file>
 output_mode: files_with_matches
 ```
 
 Split into:
-- `UNSUMMARIZED` — session files containing "AI summary unavailable"
+- `UNSUMMARIZED` — session files with `status: auto-logged` in frontmatter
 - `SUMMARIZED` — all other matched files (sessions + insights)
 
 ### Step 6 — Deferred summarization for unsummarized notes

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 

--- a/skills/vault-ask/SKILL.md
+++ b/skills/vault-ask/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 

--- a/skills/vault-import/SKILL.md
+++ b/skills/vault-import/SKILL.md
@@ -34,7 +34,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 

--- a/skills/vault-search/SKILL.md
+++ b/skills/vault-search/SKILL.md
@@ -29,7 +29,7 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print(f"VAULT={c[\"vault_path\"]} SESS={c.get(\"sessions_folder\",\"claude-sessions\")} INS={c.get(\"insights_folder\",\"claude-insights\")}")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
 '
 ```
 


### PR DESCRIPTION
## Summary
- Delegates `/recall` Steps 4-7.5 (search, read, rank, compose brief, open item detection) to a single context builder sub-agent
- Parent context drops from ~14k to ~6.5k tokens (~7.5k saved)
- Task manifest collapsed from 6 to 4 top-level tasks
- Graceful fallback to in-context reads if sub-agent fails
- Depends on PR #22 (already merged)

## Test plan
- [ ] Run `/recall` and verify brief content matches expected format
- [ ] Verify open item candidates detected and checkoff works
- [ ] Verify load manifest shows correct session/insight counts
- [ ] Verify task manifest shows 4 tasks (not 6)
- [ ] Verify fallback works with malformed sub-agent return
- [ ] Check token usage via context bar (~6.5k target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)