### PR TITLE
fix(obsidian-brain): stale source_session backlinks + /vault-doctor skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `/standup` Step 14: cascade completed open items across vault notes using `batch_cascade_checkoff()` — when items are marked done in standup, all matching `- [ ]` entries in other session notes are automatically checked off
+- `/vault-doctor` skill — diagnostic and repair tool for the Obsidian vault with a pluggable check-module registry. Ships with a `source-sessions` check that scans the last 7 days of insight/decision/error-fix/retro notes, detects stale `source_session` backlinks by matching note mtimes against JSONL session windows, and atomically rewrites only the affected frontmatter fields under `--apply` with per-project confirmation and automatic backups.
+- `~/.claude/obsidian-brain-hook.log` — rolling audit log of SessionStart hook invocations with the authoritative session id, rotated at 100 KB.
+- `scripts/verify-hooks.sh` — manual diagnostic that simulates a SessionStart hook invocation and confirms the bootstrap and log were written.
+- `/recall` brief now leads with a `[OK]`/`[WARN]` SessionStart hook status line.
+
+### Fixed
+- Session hint hook now writes the authoritative session id to the bootstrap cache, fixing stale `source_session` backlinks that pointed at previous sessions when `/compress`, `/decide`, `/error-log`, or `/retro` were run in a second-or-later session of a given project.
+- `_get_session_id_fast()` gains mtime-based validation as defense-in-depth against stale bootstrap files.
+
+### Changed
+- SessionEnd hook now cleans up the per-session disk cache file `/tmp/.ob-cache-<sid>.json` to prevent `/tmp` accumulation over time.
 
 ## [1.8.2] - 2026-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Session hint hook now writes the authoritative session id to the bootstrap cache, fixing stale `source_session` backlinks that pointed at previous sessions when `/compress`, `/decide`, `/error-log`, or `/retro` were run in a second-or-later session of a given project.
-- `_get_session_id_fast()` gains mtime-based validation as defense-in-depth against stale bootstrap files.
+- `_get_session_id_fast()` now detects a new session by comparing the newest JSONL's basename against the cached sid (with a same-second mtime tie-breaker that trusts the hook-written bootstrap), invalidating the cache when a different session has become authoritative. This is defense-in-depth against the rare case where the SessionStart hook did not fire.
 
 ### Changed
 - SessionEnd hook now cleans up the per-session disk cache file `/tmp/.ob-cache-<sid>.json` to prevent `/tmp` accumulation over time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `_get_session_id_fast()` now detects a new session by comparing the newest JSONL's basename against the cached sid (with a same-second mtime tie-breaker that trusts the hook-written bootstrap), invalidating the cache when a different session has become authoritative. This is defense-in-depth against the rare case where the SessionStart hook did not fire.
 
 ### Changed
-- SessionEnd hook now cleans up the per-session disk cache file `/tmp/.ob-cache-<sid>.json` to prevent `/tmp` accumulation over time.
+- SessionEnd hook now cleans up the per-session disk cache file `/tmp/.obsidian-brain-cache-<sid>.json` to prevent `/tmp` accumulation over time.
 
 ## [1.8.2] - 2026-04-10
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Run `/obsidian-setup` after installation. It will:
 | `/retro` | Session retrospective — what worked, what didn't, process improvements |
 | `/vault-ask` | Ask questions and get synthesized answers grounded in vault history |
 | `/check-items` | Cross-project sweep for completed open items — auto-checks off matches after user confirmation |
+| `/vault-doctor` | Audit and repair the vault — detects stale `source_session` backlinks and other health issues (dry-run by default) |
 
 ### Usage Examples
 

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -20,6 +20,7 @@ import tempfile
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from obsidian_utils import (  # noqa: E402
+    _bootstrap_prefix,
     find_latest_session,
     get_project_name,
     load_config,
@@ -30,18 +31,14 @@ from obsidian_utils import (  # noqa: E402
 # Bootstrap-file + audit-log helpers
 # ---------------------------------------------------------------------------
 
-_BOOTSTRAP_PREFIX_DEFAULT = "/tmp/.obsidian-brain-sid-"
 _HOOK_LOG_NAME = "obsidian-brain-hook.log"
 _HOOK_LOG_MAX_BYTES = 100 * 1024  # 100 KB
-
-
-def _bootstrap_prefix() -> str:
-    return os.environ.get("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", _BOOTSTRAP_PREFIX_DEFAULT)
 
 
 def _write_bootstrap_atomic(project: str, session_id: str) -> bool:
     """Write session_id to the project's bootstrap file. Returns True on success."""
     path = f"{_bootstrap_prefix()}{project}"
+    tmp = None
     try:
         dir_name = os.path.dirname(path) or "/tmp"
         os.makedirs(dir_name, exist_ok=True)
@@ -49,10 +46,17 @@ def _write_bootstrap_atomic(project: str, session_id: str) -> bool:
         with os.fdopen(fd, "w") as f:
             f.write(session_id)
         os.replace(tmp, path)
+        tmp = None  # consumed by replace
         return True
     except OSError as exc:
         print(f"[obsidian-brain] bootstrap write failed: {exc}", file=sys.stderr)
         return False
+    finally:
+        if tmp is not None:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
 
 
 def _append_hook_log(project: str, session_id: str, bootstrap_updated: bool) -> None:

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -37,10 +37,20 @@ _HOOK_LOG_MAX_BYTES = 100 * 1024  # 100 KB
 
 def _write_bootstrap_atomic(project: str, session_id: str) -> bool:
     """Write session_id to the project's bootstrap file. Returns True on success."""
-    path = f"{_bootstrap_prefix()}{project}"
+    # Force absolute path so os.path.dirname() always returns a real
+    # directory. If OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX is a relative path with
+    # no dir component, dirname() would return "" and we'd fall back to
+    # "/tmp" — but then os.replace(tmp, path) could raise EXDEV when /tmp
+    # is on a different filesystem (e.g., tmpfs) than the relative target.
+    # Making the target absolute keeps the temp file and target on the
+    # same filesystem, so os.replace() is always safe.
+    path = os.path.abspath(f"{_bootstrap_prefix()}{project}")
     tmp = None
     try:
-        dir_name = os.path.dirname(path) or "/tmp"
+        dir_name = os.path.dirname(path)
+        if not dir_name:
+            # Defensive fallback — should be unreachable after abspath().
+            dir_name = "/tmp"
         os.makedirs(dir_name, exist_ok=True)
         fd, tmp = tempfile.mkstemp(prefix=".ob-sid-", suffix=".tmp", dir=dir_name)
         with os.fdopen(fd, "w", encoding="utf-8") as f:

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -7,9 +7,11 @@ a context hint via additionalContext. No summarization at SessionStart
 (deferred to /recall skill). Always exits 0.
 """
 
+import datetime
 import json
 import os
 import sys
+import tempfile
 
 # ---------------------------------------------------------------------------
 # Import shared utilities
@@ -22,6 +24,58 @@ from obsidian_utils import (  # noqa: E402
     get_project_name,
     load_config,
 )
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap-file + audit-log helpers
+# ---------------------------------------------------------------------------
+
+_BOOTSTRAP_PREFIX_DEFAULT = "/tmp/.obsidian-brain-sid-"
+_HOOK_LOG_NAME = "obsidian-brain-hook.log"
+_HOOK_LOG_MAX_BYTES = 100 * 1024  # 100 KB
+
+
+def _bootstrap_prefix() -> str:
+    return os.environ.get("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", _BOOTSTRAP_PREFIX_DEFAULT)
+
+
+def _write_bootstrap_atomic(project: str, session_id: str) -> bool:
+    """Write session_id to the project's bootstrap file. Returns True on success."""
+    path = f"{_bootstrap_prefix()}{project}"
+    try:
+        dir_name = os.path.dirname(path) or "/tmp"
+        os.makedirs(dir_name, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".ob-sid-", suffix=".tmp", dir=dir_name)
+        with os.fdopen(fd, "w") as f:
+            f.write(session_id)
+        os.replace(tmp, path)
+        return True
+    except OSError as exc:
+        print(f"[obsidian-brain] bootstrap write failed: {exc}", file=sys.stderr)
+        return False
+
+
+def _append_hook_log(project: str, session_id: str, bootstrap_updated: bool) -> None:
+    """Append a one-line audit record; rotate the log when it exceeds the cap."""
+    log_dir = os.path.join(os.path.expanduser("~"), ".claude")
+    log_path = os.path.join(log_dir, _HOOK_LOG_NAME)
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+        try:
+            if os.path.getsize(log_path) > _HOOK_LOG_MAX_BYTES:
+                os.replace(log_path, log_path + ".1")
+        except OSError:
+            pass  # no existing log; nothing to rotate
+        timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+        short_sid = (session_id or "unknown")[:8]
+        line = (
+            f"{timestamp} SessionStart project={project} sid={short_sid} "
+            f"bootstrap_updated={'true' if bootstrap_updated else 'false'}\n"
+        )
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError as exc:
+        print(f"[obsidian-brain] hook log append failed: {exc}", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------
@@ -47,16 +101,25 @@ def _run() -> None:
 
     cwd = hook_input.get("cwd", os.getcwd())
 
-    # 2. Load config
+    # 2. Derive project name (needed for bootstrap before vault config).
+    project = get_project_name(cwd)
+
+    # 2a. Refresh the bootstrap file with the authoritative session_id from stdin.
+    # This runs regardless of vault configuration so the bootstrap stays current
+    # even when obsidian-brain is not fully configured.
+    session_id = hook_input.get("session_id", "")
+    bootstrap_updated = False
+    if session_id:
+        bootstrap_updated = _write_bootstrap_atomic(project, session_id)
+    _append_hook_log(project, session_id, bootstrap_updated)
+
+    # 3. Load config
     config = load_config()
     vault_path = config.get("vault_path", "")
     if not vault_path:
         return
 
     sessions_folder = config.get("sessions_folder", "claude-sessions")
-
-    # 3. Derive project name
-    project = get_project_name(cwd)
 
     # 4. Find latest session note for this project
     latest = find_latest_session(vault_path, sessions_folder, project)

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -43,7 +43,7 @@ def _write_bootstrap_atomic(project: str, session_id: str) -> bool:
         dir_name = os.path.dirname(path) or "/tmp"
         os.makedirs(dir_name, exist_ok=True)
         fd, tmp = tempfile.mkstemp(prefix=".ob-sid-", suffix=".tmp", dir=dir_name)
-        with os.fdopen(fd, "w") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(session_id)
         os.replace(tmp, path)
         tmp = None  # consumed by replace

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -49,7 +49,7 @@ def _cleanup_session_cache(session_id: str) -> None:
         cache_path = f"{obsidian_utils._CACHE_PREFIX}{session_id}.json"
         if os.path.exists(cache_path):
             os.unlink(cache_path)
-    except OSError as exc:
+    except Exception as exc:  # noqa: BLE001 — best-effort cleanup, never fatal
         print(f"[obsidian-brain] session cache cleanup failed: {exc}", file=sys.stderr)
 
 

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -36,6 +36,24 @@ from obsidian_utils import (  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
+# Session cache cleanup
+# ---------------------------------------------------------------------------
+
+
+def _cleanup_session_cache(session_id: str) -> None:
+    """Remove the per-session disk cache file for a finished session."""
+    if not session_id:
+        return
+    try:
+        import obsidian_utils
+        cache_path = f"{obsidian_utils._CACHE_PREFIX}{session_id}.json"
+        if os.path.exists(cache_path):
+            os.unlink(cache_path)
+    except OSError as exc:
+        print(f"[obsidian-brain] session cache cleanup failed: {exc}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
 # Note construction
 # ---------------------------------------------------------------------------
 
@@ -172,6 +190,9 @@ def _run() -> None:
         print("[obsidian-brain] failed to write raw note, aborting", file=sys.stderr)
         return
     print("[obsidian-brain] raw note written (summarization deferred to /recall)", file=sys.stderr)
+
+    # 10. Clean up per-session disk cache (best-effort, success path only)
+    _cleanup_session_cache(session_id)
 
 
 if __name__ == "__main__":

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -117,82 +117,91 @@ def _run() -> None:
     # 1. Read hook input from stdin
     try:
         raw = sys.stdin.read()
-        hook_input = json.loads(raw)
+        hook_input = json.loads(raw) if raw.strip() else {}
     except (json.JSONDecodeError, ValueError) as exc:
         print(f"[obsidian-brain] invalid stdin JSON: {exc}", file=sys.stderr)
-        return
+        hook_input = {}
 
+    # Extract session_id up front so the finally block can always clean up,
+    # regardless of which early-return path below we take.
     session_id = hook_input.get("session_id", "")
-    cwd = hook_input.get("cwd", "")
-    transcript_path = hook_input.get("transcript_path", "")
 
-    if not session_id or not transcript_path:
-        print("[obsidian-brain] missing session_id or transcript_path, skipping", file=sys.stderr)
-        return
+    try:
+        if not hook_input:
+            return
 
-    # 2. Load config
-    config = load_config()
-    if not config.get("auto_log_enabled", True):
-        print("[obsidian-brain] auto_log_enabled is False, skipping", file=sys.stderr)
-        return
+        cwd = hook_input.get("cwd", "")
+        transcript_path = hook_input.get("transcript_path", "")
 
-    vault_path = config.get("vault_path", "")
-    if not vault_path:
-        print("[obsidian-brain] no vault_path configured, skipping", file=sys.stderr)
-        return
+        if not session_id or not transcript_path:
+            print("[obsidian-brain] missing session_id or transcript_path, skipping", file=sys.stderr)
+            return
 
-    sessions_folder = config.get("sessions_folder", "claude-sessions")
-    min_messages = config.get("min_messages", 3)
-    min_duration = config.get("min_duration_minutes", 2)
+        # 2. Load config
+        config = load_config()
+        if not config.get("auto_log_enabled", True):
+            print("[obsidian-brain] auto_log_enabled is False, skipping", file=sys.stderr)
+            return
 
-    # 3. Read and parse transcript
-    messages = read_transcript(transcript_path)
-    if not messages:
-        print("[obsidian-brain] empty transcript, skipping", file=sys.stderr)
-        return
+        vault_path = config.get("vault_path", "")
+        if not vault_path:
+            print("[obsidian-brain] no vault_path configured, skipping", file=sys.stderr)
+            return
 
-    # 4. Extract user and assistant messages
-    user_msgs = extract_user_messages(messages)
-    assistant_msgs = extract_assistant_messages(messages)
+        sessions_folder = config.get("sessions_folder", "claude-sessions")
+        min_messages = config.get("min_messages", 3)
+        min_duration = config.get("min_duration_minutes", 2)
 
-    # 5. Skip check
-    if should_skip_session(user_msgs, 0, min_messages=min_messages, min_duration=min_duration):
-        # Duration not yet known; check message count only (duration=0 bypasses duration check)
-        print(f"[obsidian-brain] too few user messages ({len(user_msgs)}), skipping", file=sys.stderr)
-        return
+        # 3. Read and parse transcript
+        messages = read_transcript(transcript_path)
+        if not messages:
+            print("[obsidian-brain] empty transcript, skipping", file=sys.stderr)
+            return
 
-    # 6. Extract metadata
-    metadata = extract_session_metadata(messages, cwd)
-    metadata["vault_path"] = vault_path
-    metadata["sessions_folder"] = sessions_folder
+        # 4. Extract user and assistant messages
+        user_msgs = extract_user_messages(messages)
+        assistant_msgs = extract_assistant_messages(messages)
 
-    # Re-check with actual duration
-    if should_skip_session(user_msgs, metadata["duration_minutes"],
-                           min_messages=min_messages, min_duration=min_duration):
-        print(f"[obsidian-brain] session below thresholds, skipping", file=sys.stderr)
-        return
+        # 5. Skip check
+        if should_skip_session(user_msgs, 0, min_messages=min_messages, min_duration=min_duration):
+            # Duration not yet known; check message count only (duration=0 bypasses duration check)
+            print(f"[obsidian-brain] too few user messages ({len(user_msgs)}), skipping", file=sys.stderr)
+            return
 
-    # 7. Detect resumed session
-    resumed = is_resumed_session(vault_path, sessions_folder, session_id)
-    if resumed:
-        print(f"[obsidian-brain] resumed session detected", file=sys.stderr)
+        # 6. Extract metadata
+        metadata = extract_session_metadata(messages, cwd)
+        metadata["vault_path"] = vault_path
+        metadata["sessions_folder"] = sessions_folder
 
-    # 8. Build filename
-    date_str = datetime.date.today().isoformat()
-    project_slug = slugify(metadata.get("project", "session"))
-    filename = make_filename(date_str, project_slug, session_id)
+        # Re-check with actual duration
+        if should_skip_session(user_msgs, metadata["duration_minutes"],
+                               min_messages=min_messages, min_duration=min_duration):
+            print(f"[obsidian-brain] session below thresholds, skipping", file=sys.stderr)
+            return
 
-    # 9. Extract tool usage details and write raw note FIRST
-    tool_uses = extract_tool_uses(messages)
-    raw_body = build_raw_fallback(user_msgs, metadata, assistant_msgs=assistant_msgs, tool_uses=tool_uses)
-    raw_content = _build_note(session_id, metadata, raw_body, resumed=resumed)
-    if not write_vault_note(vault_path, sessions_folder, filename, raw_content):
-        print("[obsidian-brain] failed to write raw note, aborting", file=sys.stderr)
-        return
-    print("[obsidian-brain] raw note written (summarization deferred to /recall)", file=sys.stderr)
+        # 7. Detect resumed session
+        resumed = is_resumed_session(vault_path, sessions_folder, session_id)
+        if resumed:
+            print(f"[obsidian-brain] resumed session detected", file=sys.stderr)
 
-    # 10. Clean up per-session disk cache (best-effort, success path only)
-    _cleanup_session_cache(session_id)
+        # 8. Build filename
+        date_str = datetime.date.today().isoformat()
+        project_slug = slugify(metadata.get("project", "session"))
+        filename = make_filename(date_str, project_slug, session_id)
+
+        # 9. Extract tool usage details and write raw note FIRST
+        tool_uses = extract_tool_uses(messages)
+        raw_body = build_raw_fallback(user_msgs, metadata, assistant_msgs=assistant_msgs, tool_uses=tool_uses)
+        raw_content = _build_note(session_id, metadata, raw_body, resumed=resumed)
+        if not write_vault_note(vault_path, sessions_folder, filename, raw_content):
+            print("[obsidian-brain] failed to write raw note, aborting", file=sys.stderr)
+            return
+        print("[obsidian-brain] raw note written (summarization deferred to /recall)", file=sys.stderr)
+    finally:
+        # Run cache cleanup regardless of how _run() exits so /tmp does not
+        # accumulate stale cache files on any SessionEnd outcome — including
+        # threshold skips, missing config, auto_log_disabled, or errors.
+        _cleanup_session_cache(session_id)
 
 
 if __name__ == "__main__":

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -30,22 +30,29 @@ _CACHE_PREFIX = '/tmp/.obsidian-brain-cache-'
 _BOOTSTRAP_PREFIX = '/tmp/.obsidian-brain-sid-'
 
 
+def _bootstrap_prefix() -> str:
+    """Return the bootstrap file prefix, honoring OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX env override."""
+    return os.environ.get("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", _BOOTSTRAP_PREFIX)
+
+
 def _get_session_id_fast() -> str:
     """Derive session ID, using bootstrap file for speed on repeat calls.
 
     Validation strategy:
       1. Read bootstrap file (~0.1 ms)
       2. Verify cached JSONL still exists
-      3. Verify bootstrap mtime > newest JSONL mtime (~5 ms glob)
+      3. Verify the newest JSONL in the project dir has the SAME sid as the
+         bootstrap cache (compares basename, not mtime).
       If all checks pass, return cached sid; otherwise fall through to the
       full glob + mtime sort (authoritative slow path).
 
-    The mtime check ensures the bootstrap is invalidated when a new session
-    starts (which creates a newer JSONL) even if the SessionStart hook did
-    not get to refresh the bootstrap file.
+    Comparing basenames (not mtimes) is important because the active
+    session's JSONL file is appended throughout the session, so its mtime
+    increases continuously. A naive mtime comparison would invalidate the
+    bootstrap on every call after a few seconds, defeating the optimization.
     """
     project = os.path.basename(os.getcwd())
-    bootstrap = f"{_BOOTSTRAP_PREFIX}{project}"
+    bootstrap = f"{_bootstrap_prefix()}{project}"
 
     import glob as _glob
     pattern = os.path.expanduser(f"~/.claude/projects/*{project}/*.jsonl")
@@ -55,17 +62,20 @@ def _get_session_id_fast() -> str:
         with open(bootstrap, 'r') as f:
             cached_sid = f.read().strip()
         if cached_sid:
-            bootstrap_mtime = os.path.getmtime(bootstrap)
             cached_pattern = os.path.expanduser(
                 f"~/.claude/projects/*{project}/{cached_sid}.jsonl"
             )
             if _glob.glob(cached_pattern):
+                # Determine the newest JSONL; if its basename equals cached_sid,
+                # the cache is still authoritative. Otherwise a new session has
+                # started and we must fall through to the slow path.
                 all_matches = _glob.glob(pattern)
                 if all_matches:
-                    newest_mtime = max(os.path.getmtime(p) for p in all_matches)
-                    if bootstrap_mtime > newest_mtime:
+                    newest = max(all_matches, key=os.path.getmtime)
+                    newest_sid = os.path.splitext(os.path.basename(newest))[0]
+                    if newest_sid == cached_sid:
                         return cached_sid
-                    # else: a newer JSONL exists; bootstrap is stale, fall through
+                    # else: different session is newest; bootstrap is stale
                 else:
                     return cached_sid  # no other JSONLs; trust cache
     except OSError:
@@ -232,7 +242,7 @@ def check_hook_status() -> dict:
     path is returning a stale value).
     """
     project = os.path.basename(os.getcwd())
-    bootstrap = f"{_BOOTSTRAP_PREFIX}{project}"
+    bootstrap = f"{_bootstrap_prefix()}{project}"
 
     # Read bootstrap BEFORE calling _get_session_id_fast(), which may refresh
     # the bootstrap file as a side effect on its slow path.

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -41,15 +41,22 @@ def _get_session_id_fast() -> str:
     Validation strategy:
       1. Read bootstrap file (~0.1 ms)
       2. Verify cached JSONL still exists
-      3. Verify the newest JSONL in the project dir has the SAME sid as the
-         bootstrap cache (compares basename, not mtime).
-      If all checks pass, return cached sid; otherwise fall through to the
-      full glob + mtime sort (authoritative slow path).
+      3. Determine the newest JSONL deterministically via (mtime, path)
+         tuple comparison. Ties broken by path string so the result is
+         reproducible on filesystems with 1-second mtime resolution.
+      4. If the newest JSONL's basename equals the cached sid, trust the
+         cache. If the cached JSONL shares the newest mtime (same-second
+         race), also trust the cache — the SessionStart hook has already
+         authoritatively written the current sid and same-mtime ties
+         effectively mean "these happened simultaneously."
+      5. Otherwise fall through to the slow path (full glob + deterministic
+         max) which is the authoritative answer.
 
-    Comparing basenames (not mtimes) is important because the active
-    session's JSONL file is appended throughout the session, so its mtime
-    increases continuously. A naive mtime comparison would invalidate the
-    bootstrap on every call after a few seconds, defeating the optimization.
+    Comparing basenames rather than mtime values directly is important
+    because the active session's JSONL is appended throughout the session,
+    so its mtime increases continuously. A naive mtime comparison would
+    invalidate the bootstrap on every call after a few seconds, defeating
+    the optimization.
     """
     project = os.path.basename(os.getcwd())
     bootstrap = f"{_bootstrap_prefix()}{project}"
@@ -65,27 +72,40 @@ def _get_session_id_fast() -> str:
             cached_pattern = os.path.expanduser(
                 f"~/.claude/projects/*{project}/{cached_sid}.jsonl"
             )
-            if _glob.glob(cached_pattern):
-                # Determine the newest JSONL; if its basename equals cached_sid,
-                # the cache is still authoritative. Otherwise a new session has
-                # started and we must fall through to the slow path.
+            cached_matches = _glob.glob(cached_pattern)
+            if cached_matches:
+                # Determine the newest JSONL deterministically: order by
+                # (mtime, path). Ties broken by path string so results are
+                # reproducible across filesystems that report 1-second mtime
+                # resolution.
                 all_matches = _glob.glob(pattern)
                 if all_matches:
-                    newest = max(all_matches, key=os.path.getmtime)
-                    newest_sid = os.path.splitext(os.path.basename(newest))[0]
+                    newest_mtime, newest_path = max(
+                        ((os.path.getmtime(p), p) for p in all_matches),
+                    )
+                    newest_sid = os.path.splitext(os.path.basename(newest_path))[0]
                     if newest_sid == cached_sid:
                         return cached_sid
-                    # else: different session is newest; bootstrap is stale
+                    # Tie-breaker: if the cached JSONL's mtime equals the
+                    # newest mtime, trust the cached sid. This handles the
+                    # same-second race where the previous session's JSONL and
+                    # the current session's JSONL report identical mtimes on
+                    # coarse-resolution filesystems, and the SessionStart hook
+                    # has already authoritatively written the current sid.
+                    cached_mtime = os.path.getmtime(cached_matches[0])
+                    if cached_mtime == newest_mtime:
+                        return cached_sid
+                    # Otherwise a different session is strictly newer; fall through.
                 else:
                     return cached_sid  # no other JSONLs; trust cache
     except OSError:
         pass
 
-    # Slow path: full glob + mtime sort
+    # Slow path: full glob + mtime sort with deterministic tiebreaker
     matches = _glob.glob(pattern)
     if not matches:
         return "unknown"
-    newest = max(matches, key=os.path.getmtime)
+    _, newest = max(((os.path.getmtime(p), p) for p in matches))
     sid = os.path.splitext(os.path.basename(newest))[0]
 
     # Refresh bootstrap for next call

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -220,6 +220,57 @@ def load_config() -> dict:
     return config
 
 
+def check_hook_status() -> dict:
+    """Inspect the bootstrap file to report SessionStart hook health.
+
+    Returns:
+        {"ok": bool, "message": str, "bootstrap_sid": str, "current_sid": str}
+
+    "ok" is True if the bootstrap file exists and matches the current session.
+    "ok" is False if the bootstrap is missing or points at a different sid
+    (which would indicate the SessionStart hook did not fire, or the fast
+    path is returning a stale value).
+    """
+    project = os.path.basename(os.getcwd())
+    bootstrap = f"{_BOOTSTRAP_PREFIX}{project}"
+
+    # Read bootstrap BEFORE calling _get_session_id_fast(), which may refresh
+    # the bootstrap file as a side effect on its slow path.
+    try:
+        with open(bootstrap, "r") as f:
+            bootstrap_sid = f.read().strip()
+    except OSError:
+        bootstrap_sid = None
+
+    current_sid = _get_session_id_fast()
+
+    if bootstrap_sid is None:
+        return {
+            "ok": False,
+            "message": "bootstrap file missing — SessionStart hook may not have fired",
+            "bootstrap_sid": "",
+            "current_sid": current_sid,
+        }
+
+    if bootstrap_sid == current_sid:
+        return {
+            "ok": True,
+            "message": "SessionStart hook fired; bootstrap matches current session",
+            "bootstrap_sid": bootstrap_sid,
+            "current_sid": current_sid,
+        }
+
+    return {
+        "ok": False,
+        "message": (
+            f"bootstrap sid {bootstrap_sid[:8]} does not match current "
+            f"session {current_sid[:8]} — hook may be stale"
+        ),
+        "bootstrap_sid": bootstrap_sid,
+        "current_sid": current_sid,
+    }
+
+
 def get_session_context(vault_path: str | None = None, sessions_folder: str | None = None) -> dict:
     """Get session ID, hash, project, and session note name. Cached.
 
@@ -1046,11 +1097,21 @@ def build_context_brief(
     sessions_folder: str,
     insights_folder: str,
     project: str,
+    hook_status_line: str | None = None,
 ) -> str:
     """Build the /recall context brief entirely in Python.
 
     Reads session and insight files directly (no sub-agent), composes
     a structured markdown brief, and runs open-item detection.
+
+    Args:
+        vault_path: Obsidian vault root.
+        sessions_folder: Folder name (relative to vault) containing sessions.
+        insights_folder: Folder name (relative to vault) containing insights.
+        project: Project slug to filter on.
+        hook_status_line: Optional pre-formatted status line (e.g. "✓ …" or
+            "⚠ …") to prepend to the brief so /recall can surface SessionStart
+            hook health at a glance.
 
     Returns a structured string with labeled sections:
       CONTEXT_BRIEF: <markdown brief>
@@ -1236,7 +1297,11 @@ def build_context_brief(
     insights_section = "\n".join(insight_text_parts) if insight_text_parts else "No curated insights yet for this project."
 
     # --- 4. Compose brief ---
-    brief_parts: list[str] = [f"## Project Context: {project}"]
+    brief_parts: list[str] = []
+    if hook_status_line:
+        brief_parts.append(hook_status_line)
+        brief_parts.append("")
+    brief_parts.append(f"## Project Context: {project}")
 
     if most_recent_summary:
         brief_parts.append(f"\n### Last Session ({most_recent_date})")

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -36,7 +36,7 @@ def _get_session_id_fast() -> str:
     Validation strategy:
       1. Read bootstrap file (~0.1 ms)
       2. Verify cached JSONL still exists
-      3. Verify bootstrap mtime >= newest JSONL mtime (~5 ms glob)
+      3. Verify bootstrap mtime > newest JSONL mtime (~5 ms glob)
       If all checks pass, return cached sid; otherwise fall through to the
       full glob + mtime sort (authoritative slow path).
 
@@ -63,7 +63,7 @@ def _get_session_id_fast() -> str:
                 all_matches = _glob.glob(pattern)
                 if all_matches:
                     newest_mtime = max(os.path.getmtime(p) for p in all_matches)
-                    if bootstrap_mtime >= newest_mtime:
+                    if bootstrap_mtime > newest_mtime:
                         return cached_sid
                     # else: a newer JSONL exists; bootstrap is stale, fall through
                 else:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1109,8 +1109,8 @@ def build_context_brief(
         sessions_folder: Folder name (relative to vault) containing sessions.
         insights_folder: Folder name (relative to vault) containing insights.
         project: Project slug to filter on.
-        hook_status_line: Optional pre-formatted status line (e.g. "✓ …" or
-            "⚠ …") to prepend to the brief so /recall can surface SessionStart
+        hook_status_line: Optional pre-formatted status line (e.g. "[OK] …" or
+            "[WARN] …") to prepend to the brief so /recall can surface SessionStart
             hook health at a glance.
 
     Returns a structured string with labeled sections:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -48,6 +48,25 @@ def _safe_mtime(path: str) -> float:
         return -1.0
 
 
+def _slow_path_newest_sid() -> str:
+    """Determine the current session id by scanning JSONL files directly.
+
+    Bootstrap-independent — does NOT read, write, or trust the bootstrap
+    cache. Used by health checks that must not be fooled by stale cache
+    entries. Returns 'unknown' if no JSONLs are found for the current cwd.
+    """
+    project = os.path.basename(os.getcwd())
+    import glob as _glob
+    pattern = os.path.expanduser(f"~/.claude/projects/*{project}/*.jsonl")
+    matches = _glob.glob(pattern)
+    entries = [(_safe_mtime(p), p) for p in matches]
+    viable = [(m, p) for m, p in entries if m >= 0]
+    if not viable:
+        return "unknown"
+    _, newest = max(viable)
+    return os.path.splitext(os.path.basename(newest))[0]
+
+
 def _get_session_id_fast() -> str:
     """Derive session ID, using bootstrap file for speed on repeat calls.
 
@@ -287,15 +306,18 @@ def check_hook_status() -> dict:
     project = os.path.basename(os.getcwd())
     bootstrap = f"{_bootstrap_prefix()}{project}"
 
-    # Read bootstrap BEFORE calling _get_session_id_fast(), which may refresh
-    # the bootstrap file as a side effect on its slow path.
+    # Read bootstrap BEFORE deriving current_sid so we see its real state.
     try:
         with open(bootstrap, "r") as f:
             bootstrap_sid = f.read().strip()
     except OSError:
         bootstrap_sid = None
 
-    current_sid = _get_session_id_fast()
+    # Use the bootstrap-independent slow path so the check isn't circular.
+    # _get_session_id_fast() can return the cached bootstrap value, which
+    # would make this health check report OK even when the bootstrap is
+    # stale.
+    current_sid = _slow_path_newest_sid()
 
     if bootstrap_sid is None:
         return {

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -122,14 +122,23 @@ def _get_session_id_fast() -> str:
                         newest_sid = os.path.splitext(os.path.basename(newest_path))[0]
                         if newest_sid == cached_sid:
                             return cached_sid
-                        # Tie-breaker: if the cached JSONL's mtime equals the
-                        # newest mtime, trust the cached sid. This handles the
-                        # same-second race where the previous session's JSONL and
-                        # the current session's JSONL report identical mtimes on
-                        # coarse-resolution filesystems, and the SessionStart hook
-                        # has already authoritatively written the current sid.
-                        cached_mtime = _safe_mtime(cached_matches[0])
-                        if cached_mtime >= 0 and cached_mtime == newest_mtime:
+                        # Tie-breaker: if ANY cached JSONL matches the newest
+                        # mtime (across all worktree/project-dir matches), trust
+                        # the cache. When multiple project-dir variants exist
+                        # (e.g. worktrees), the cached sid's JSONL may appear in
+                        # several of them; comparing only cached_matches[0]
+                        # could miss the tie and cause an unnecessary
+                        # fall-through. This handles the same-second race where
+                        # the previous session's JSONL and the current
+                        # session's JSONL report identical mtimes on
+                        # coarse-resolution filesystems, and the SessionStart
+                        # hook has already authoritatively written the current
+                        # sid.
+                        cached_mtimes = [_safe_mtime(p) for p in cached_matches]
+                        cached_newest = max(
+                            (m for m in cached_mtimes if m >= 0), default=-1.0
+                        )
+                        if cached_newest == newest_mtime:
                             return cached_sid
                         # Otherwise a different session is strictly newer; fall through.
                     else:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -35,6 +35,19 @@ def _bootstrap_prefix() -> str:
     return os.environ.get("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", _BOOTSTRAP_PREFIX)
 
 
+def _safe_mtime(path: str) -> float:
+    """Return file mtime, or -1.0 if the path is missing/unstatable.
+
+    Used by _get_session_id_fast() and similar helpers that need best-effort
+    mtime comparison over globs — filesystem races (a JSONL rotated between
+    glob and stat) must not crash the caller.
+    """
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return -1.0
+
+
 def _get_session_id_fast() -> str:
     """Derive session ID, using bootstrap file for speed on repeat calls.
 
@@ -80,32 +93,42 @@ def _get_session_id_fast() -> str:
                 # resolution.
                 all_matches = _glob.glob(pattern)
                 if all_matches:
-                    newest_mtime, newest_path = max(
-                        ((os.path.getmtime(p), p) for p in all_matches),
-                    )
-                    newest_sid = os.path.splitext(os.path.basename(newest_path))[0]
-                    if newest_sid == cached_sid:
-                        return cached_sid
-                    # Tie-breaker: if the cached JSONL's mtime equals the
-                    # newest mtime, trust the cached sid. This handles the
-                    # same-second race where the previous session's JSONL and
-                    # the current session's JSONL report identical mtimes on
-                    # coarse-resolution filesystems, and the SessionStart hook
-                    # has already authoritatively written the current sid.
-                    cached_mtime = os.path.getmtime(cached_matches[0])
-                    if cached_mtime == newest_mtime:
-                        return cached_sid
-                    # Otherwise a different session is strictly newer; fall through.
+                    # Determine the newest JSONL deterministically via (mtime, path).
+                    # _safe_mtime returns -1.0 for files that disappear between glob
+                    # and stat, so transient races never crash the caller.
+                    entries = [(_safe_mtime(p), p) for p in all_matches]
+                    viable = [(m, p) for m, p in entries if m >= 0]
+                    if viable:
+                        newest_mtime, newest_path = max(viable)
+                        newest_sid = os.path.splitext(os.path.basename(newest_path))[0]
+                        if newest_sid == cached_sid:
+                            return cached_sid
+                        # Tie-breaker: if the cached JSONL's mtime equals the
+                        # newest mtime, trust the cached sid. This handles the
+                        # same-second race where the previous session's JSONL and
+                        # the current session's JSONL report identical mtimes on
+                        # coarse-resolution filesystems, and the SessionStart hook
+                        # has already authoritatively written the current sid.
+                        cached_mtime = _safe_mtime(cached_matches[0])
+                        if cached_mtime >= 0 and cached_mtime == newest_mtime:
+                            return cached_sid
+                        # Otherwise a different session is strictly newer; fall through.
+                    else:
+                        return cached_sid  # no viable JSONLs; trust cache
                 else:
                     return cached_sid  # no other JSONLs; trust cache
     except OSError:
         pass
 
-    # Slow path: full glob + mtime sort with deterministic tiebreaker
+    # Slow path: full glob + mtime sort with deterministic tiebreaker.
+    # Use _safe_mtime so a JSONL deleted or rotated between glob and stat
+    # cannot crash the caller (e.g. load_config).
     matches = _glob.glob(pattern)
-    if not matches:
+    entries = [(_safe_mtime(p), p) for p in matches]
+    viable = [(m, p) for m, p in entries if m >= 0]
+    if not viable:
         return "unknown"
-    _, newest = max(((os.path.getmtime(p), p) for p in matches))
+    _, newest = max(viable)
     sid = os.path.splitext(os.path.basename(newest))[0]
 
     # Refresh bootstrap for next call

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -90,6 +90,13 @@ def _get_session_id_fast() -> str:
     so its mtime increases continuously. A naive mtime comparison would
     invalidate the bootstrap on every call after a few seconds, defeating
     the optimization.
+
+    The slow path is strictly READ-ONLY — it never writes the bootstrap
+    file. The SessionStart hook is the sole authoritative writer of the
+    bootstrap. Writing from the slow path would clobber the hook's correct
+    write if the slow path ran during the hook's own invocation (which
+    happens whenever downstream hook code calls a function that triggers
+    this, before CC has flushed the new session's JSONL to disk).
     """
     project = os.path.basename(os.getcwd())
     bootstrap = f"{_bootstrap_prefix()}{project}"
@@ -152,24 +159,20 @@ def _get_session_id_fast() -> str:
         pass
 
     # Slow path: full glob + mtime sort with deterministic tiebreaker.
-    # Use _safe_mtime so a JSONL deleted or rotated between glob and stat
-    # cannot crash the caller (e.g. load_config).
+    # This path is READ-ONLY — never writes the bootstrap file. The
+    # SessionStart hook is the sole authoritative writer. Writing here
+    # would clobber the hook's correct write if the slow path ran
+    # during the hook's own invocation (which happens whenever the
+    # hook's downstream code calls a function that triggers this).
+    # Use _safe_mtime so a JSONL deleted or rotated between glob and
+    # stat cannot crash the caller (e.g. load_config).
     matches = _glob.glob(pattern)
     entries = [(_safe_mtime(p), p) for p in matches]
     viable = [(m, p) for m, p in entries if m >= 0]
     if not viable:
         return "unknown"
     _, newest = max(viable)
-    sid = os.path.splitext(os.path.basename(newest))[0]
-
-    # Refresh bootstrap for next call
-    try:
-        with open(bootstrap, 'w') as f:
-            f.write(sid)
-    except OSError:
-        pass
-
-    return sid
+    return os.path.splitext(os.path.basename(newest))[0]
 
 
 def cache_get(session_id: str, key: str):

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -57,7 +57,8 @@ def _slow_path_newest_sid() -> str:
     """
     project = os.path.basename(os.getcwd())
     import glob as _glob
-    pattern = os.path.expanduser(f"~/.claude/projects/*{project}/*.jsonl")
+    safe_project = _glob.escape(project)
+    pattern = os.path.expanduser(f"~/.claude/projects/*{safe_project}/*.jsonl")
     matches = _glob.glob(pattern)
     entries = [(_safe_mtime(p), p) for p in matches]
     viable = [(m, p) for m, p in entries if m >= 0]
@@ -94,15 +95,17 @@ def _get_session_id_fast() -> str:
     bootstrap = f"{_bootstrap_prefix()}{project}"
 
     import glob as _glob
-    pattern = os.path.expanduser(f"~/.claude/projects/*{project}/*.jsonl")
+    safe_project = _glob.escape(project)
+    pattern = os.path.expanduser(f"~/.claude/projects/*{safe_project}/*.jsonl")
 
     # Fast path: bootstrap file
     try:
         with open(bootstrap, 'r') as f:
             cached_sid = f.read().strip()
         if cached_sid:
+            safe_cached = _glob.escape(cached_sid)
             cached_pattern = os.path.expanduser(
-                f"~/.claude/projects/*{project}/{cached_sid}.jsonl"
+                f"~/.claude/projects/*{safe_project}/{safe_cached}.jsonl"
             )
             cached_matches = _glob.glob(cached_pattern)
             if cached_matches:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -342,6 +342,17 @@ def check_hook_status() -> dict:
             "current_sid": current_sid,
         }
 
+    if current_sid == "unknown":
+        return {
+            "ok": False,
+            "message": (
+                "could not determine current session id from JSONLs "
+                "(no session files found)"
+            ),
+            "bootstrap_sid": bootstrap_sid,
+            "current_sid": current_sid,
+        }
+
     if bootstrap_sid == current_sid:
         return {
             "ok": True,

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -31,33 +31,54 @@ _BOOTSTRAP_PREFIX = '/tmp/.obsidian-brain-sid-'
 
 
 def _get_session_id_fast() -> str:
-    """Derive session ID, using bootstrap file for speed on repeat calls."""
+    """Derive session ID, using bootstrap file for speed on repeat calls.
+
+    Validation strategy:
+      1. Read bootstrap file (~0.1 ms)
+      2. Verify cached JSONL still exists
+      3. Verify bootstrap mtime >= newest JSONL mtime (~5 ms glob)
+      If all checks pass, return cached sid; otherwise fall through to the
+      full glob + mtime sort (authoritative slow path).
+
+    The mtime check ensures the bootstrap is invalidated when a new session
+    starts (which creates a newer JSONL) even if the SessionStart hook did
+    not get to refresh the bootstrap file.
+    """
     project = os.path.basename(os.getcwd())
     bootstrap = f"{_BOOTSTRAP_PREFIX}{project}"
 
-    # Try bootstrap file first (~0.1ms)
+    import glob as _glob
+    pattern = os.path.expanduser(f"~/.claude/projects/*{project}/*.jsonl")
+
+    # Fast path: bootstrap file
     try:
         with open(bootstrap, 'r') as f:
             cached_sid = f.read().strip()
         if cached_sid:
-            # Cheap validation: check the JSONL file still exists (~0.1ms stat)
-            import glob as _glob
-            pattern = os.path.expanduser(f"~/.claude/projects/*{project}/{cached_sid}.jsonl")
-            if _glob.glob(pattern):
-                return cached_sid
+            bootstrap_mtime = os.path.getmtime(bootstrap)
+            cached_pattern = os.path.expanduser(
+                f"~/.claude/projects/*{project}/{cached_sid}.jsonl"
+            )
+            if _glob.glob(cached_pattern):
+                all_matches = _glob.glob(pattern)
+                if all_matches:
+                    newest_mtime = max(os.path.getmtime(p) for p in all_matches)
+                    if bootstrap_mtime >= newest_mtime:
+                        return cached_sid
+                    # else: a newer JSONL exists; bootstrap is stale, fall through
+                else:
+                    return cached_sid  # no other JSONLs; trust cache
     except OSError:
         pass
 
-    # Fall back to full glob + mtime sort (~5ms)
-    import glob as _glob
-    pattern = os.path.expanduser(f"~/.claude/projects/*{project}/*.jsonl")
+    # Slow path: full glob + mtime sort
     matches = _glob.glob(pattern)
     if not matches:
         return "unknown"
     newest = max(matches, key=os.path.getmtime)
     sid = os.path.splitext(os.path.basename(newest))[0]
 
-    # Write bootstrap for next call
+    # Refresh bootstrap for next call
     try:
         with open(bootstrap, 'w') as f:
             f.write(sid)

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -36,30 +36,37 @@ import vault_doctor_checks  # noqa: E402
 
 
 def _load_config(args) -> dict:
-    """Resolve vault path + folders from args → env → obsidian-brain config."""
-    vault = args.vault or os.environ.get("OBSIDIAN_BRAIN_VAULT")
-    sessions = args.sessions_folder or os.environ.get(
-        "OBSIDIAN_BRAIN_SESSIONS_FOLDER", "claude-sessions"
-    )
-    insights = args.insights_folder or os.environ.get(
-        "OBSIDIAN_BRAIN_INSIGHTS_FOLDER", "claude-insights"
-    )
+    """Resolve vault path + folders from args → env → obsidian-brain config file.
 
-    if not vault:
-        # Read the config file directly (bypass obsidian_utils.load_config's
-        # session cache, which can return stale values from previous runs).
+    Precedence (strict): CLI arg > env var > config file > default.
+    """
+    vault = args.vault or os.environ.get("OBSIDIAN_BRAIN_VAULT")
+    env_sessions = os.environ.get("OBSIDIAN_BRAIN_SESSIONS_FOLDER")
+    env_insights = os.environ.get("OBSIDIAN_BRAIN_INSIGHTS_FOLDER")
+    sessions = args.sessions_folder or env_sessions
+    insights = args.insights_folder or env_insights
+
+    if not vault or not sessions or not insights:
+        # Fall back to config file only for values not yet resolved.
+        # Read directly (bypass obsidian_utils.load_config's session cache,
+        # which can be stale when the CLI runs outside a live session).
         cfg_path = Path.home() / ".claude" / "obsidian-brain-config.json"
         try:
             with open(cfg_path, "r", encoding="utf-8") as fh:
                 cfg = json.load(fh)
             if isinstance(cfg, dict):
-                vault = cfg.get("vault_path", "") or vault
-                if not args.sessions_folder:
-                    sessions = cfg.get("sessions_folder", sessions)
-                if not args.insights_folder:
-                    insights = cfg.get("insights_folder", insights)
+                if not vault:
+                    vault = cfg.get("vault_path", "")
+                if not sessions:
+                    sessions = cfg.get("sessions_folder", "claude-sessions")
+                if not insights:
+                    insights = cfg.get("insights_folder", "claude-insights")
         except (OSError, json.JSONDecodeError):
             pass
+
+    # Apply defaults for any unresolved folders
+    sessions = sessions or "claude-sessions"
+    insights = insights or "claude-insights"
 
     if not vault:
         print(

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -105,21 +105,21 @@ def _run_scan(mod, cfg: dict, days: int, project: str | None) -> list:
     )
 
 
-def _print_report_human(issues_by_check: dict, stderr=sys.stderr) -> None:
+def _print_report_human(issues_by_check: dict) -> None:
     total = sum(len(v) for v in issues_by_check.values())
-    print(f"\nvault_doctor report — {total} issue(s) across {len(issues_by_check)} check(s)", file=stderr)
+    print(f"\nvault_doctor report — {total} issue(s) across {len(issues_by_check)} check(s)", file=sys.stderr)
     for check_name, issues in issues_by_check.items():
         by_project: dict[str, list] = {}
         for i in issues:
             by_project.setdefault(i.project, []).append(i)
         for proj, proj_issues in sorted(by_project.items()):
-            print(f"\n  Project: {proj}  [{check_name}]", file=stderr)
+            print(f"\n  Project: {proj}  [{check_name}]", file=sys.stderr)
             for i in proj_issues:
                 mark = "!" if i.extra.get("unresolved") else "x"
-                print(f"    {mark} {Path(i.note_path).name}", file=stderr)
-                print(f"      current:  {i.current_source}", file=stderr)
-                print(f"      proposed: {i.proposed_source or '(unresolved)'}", file=stderr)
-                print(f"      reason:   {i.reason}", file=stderr)
+                print(f"    {mark} {Path(i.note_path).name}", file=sys.stderr)
+                print(f"      current:  {i.current_source}", file=sys.stderr)
+                print(f"      proposed: {i.proposed_source or '(unresolved)'}", file=sys.stderr)
+                print(f"      reason:   {i.reason}", file=sys.stderr)
 
 
 def main() -> int:

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -134,6 +134,14 @@ def _print_report_human(issues_by_check: dict) -> None:
 
 def main() -> int:
     args = _build_parser().parse_args()
+
+    if args.days is not None and args.days <= 0:
+        print(
+            f"error: --days must be positive, got {args.days}",
+            file=sys.stderr,
+        )
+        return 3
+
     cfg = _load_config(args)
 
     if args.check:

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""vault_doctor — audit and repair the Obsidian vault.
+
+Dispatches to check modules under scripts/vault_doctor_checks/.
+Dry-run by default — requires --apply to write anything.
+
+Config priority:
+  1. CLI args (--vault, --sessions-folder, --insights-folder)
+  2. Env vars (OBSIDIAN_BRAIN_VAULT, *_SESSIONS_FOLDER, *_INSIGHTS_FOLDER)
+  3. ~/.claude/obsidian-brain-config.json via hooks/obsidian_utils.load_config()
+
+Exit codes:
+  0 — clean, no issues
+  1 — issues found (dry-run or successful apply)
+  2 — apply errors (one or more fixes failed)
+  3 — usage error (bad args, no config)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Make the check package importable
+_SCRIPTS_DIR = Path(__file__).parent
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import vault_doctor_checks  # noqa: E402
+
+
+def _load_config(args) -> dict:
+    """Resolve vault path + folders from args → env → obsidian-brain config."""
+    vault = args.vault or os.environ.get("OBSIDIAN_BRAIN_VAULT")
+    sessions = args.sessions_folder or os.environ.get(
+        "OBSIDIAN_BRAIN_SESSIONS_FOLDER", "claude-sessions"
+    )
+    insights = args.insights_folder or os.environ.get(
+        "OBSIDIAN_BRAIN_INSIGHTS_FOLDER", "claude-insights"
+    )
+
+    if not vault:
+        # Read the config file directly (bypass obsidian_utils.load_config's
+        # session cache, which can return stale values from previous runs).
+        cfg_path = Path.home() / ".claude" / "obsidian-brain-config.json"
+        try:
+            with open(cfg_path, "r", encoding="utf-8") as fh:
+                cfg = json.load(fh)
+            if isinstance(cfg, dict):
+                vault = cfg.get("vault_path", "") or vault
+                if not args.sessions_folder:
+                    sessions = cfg.get("sessions_folder", sessions)
+                if not args.insights_folder:
+                    insights = cfg.get("insights_folder", insights)
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    if not vault:
+        print(
+            "error: no vault_path configured; set OBSIDIAN_BRAIN_VAULT "
+            "or run /obsidian-setup",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+
+    if not Path(vault).is_dir():
+        print(
+            f"error: vault_path does not exist or is not a directory: {vault}",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+
+    return {"vault": vault, "sessions_folder": sessions, "insights_folder": insights}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="vault_doctor")
+    p.add_argument("--check", dest="check", default=None, help="run only this check by name")
+    p.add_argument("--days", type=int, default=None, help="override default window (days)")
+    p.add_argument("--project", default=None, help="limit scan to this project name")
+    p.add_argument("--vault", default=None, help="override vault path")
+    p.add_argument("--sessions-folder", default=None)
+    p.add_argument("--insights-folder", default=None)
+    p.add_argument("--apply", action="store_true", help="apply fixes (default: dry-run)")
+    p.add_argument("--yes", action="store_true", help="assume yes for all confirmations")
+    p.add_argument("--json", dest="json_out", action="store_true",
+                   help="emit JSON on stdout (for skill integration)")
+    return p
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _run_scan(mod, cfg: dict, days: int, project: str | None) -> list:
+    return mod.scan(
+        cfg["vault"],
+        cfg["sessions_folder"],
+        cfg["insights_folder"],
+        days,
+        project=project,
+    )
+
+
+def _print_report_human(issues_by_check: dict, stderr=sys.stderr) -> None:
+    total = sum(len(v) for v in issues_by_check.values())
+    print(f"\nvault_doctor report — {total} issue(s) across {len(issues_by_check)} check(s)", file=stderr)
+    for check_name, issues in issues_by_check.items():
+        by_project: dict[str, list] = {}
+        for i in issues:
+            by_project.setdefault(i.project, []).append(i)
+        for proj, proj_issues in sorted(by_project.items()):
+            print(f"\n  Project: {proj}  [{check_name}]", file=stderr)
+            for i in proj_issues:
+                mark = "!" if i.extra.get("unresolved") else "x"
+                print(f"    {mark} {Path(i.note_path).name}", file=stderr)
+                print(f"      current:  {i.current_source}", file=stderr)
+                print(f"      proposed: {i.proposed_source or '(unresolved)'}", file=stderr)
+                print(f"      reason:   {i.reason}", file=stderr)
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    cfg = _load_config(args)
+
+    if args.check:
+        try:
+            modules = [vault_doctor_checks.get_check(args.check)]
+        except KeyError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 3
+    else:
+        modules = vault_doctor_checks.all_checks()
+
+    if not modules:
+        print("error: no checks registered", file=sys.stderr)
+        return 3
+
+    issues_by_check: dict = {}
+    for mod in modules:
+        days = args.days if args.days is not None else getattr(mod, "DEFAULT_WINDOW_DAYS", 7)
+        issues = _run_scan(mod, cfg, days, args.project)
+        if issues:
+            issues_by_check[mod.NAME] = issues
+
+    total_issues = sum(len(v) for v in issues_by_check.values())
+
+    # JSON output for skill consumption
+    if args.json_out:
+        payload = {
+            "timestamp": _iso_now(),
+            "total_issues": total_issues,
+            "issues": [
+                {
+                    "check": i.check,
+                    "note_path": i.note_path,
+                    "project": i.project,
+                    "current_source": i.current_source,
+                    "proposed_source": i.proposed_source,
+                    "reason": i.reason,
+                    "confidence": i.confidence,
+                    "unresolved": i.extra.get("unresolved", False),
+                }
+                for issues in issues_by_check.values() for i in issues
+            ],
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        _print_report_human(issues_by_check)
+
+    if total_issues == 0:
+        print("vault_doctor: clean", file=sys.stderr)
+        return 0
+
+    if not args.apply:
+        return 1  # issues found, not applied (dry-run default)
+
+    # --apply: per-project confirmation
+    backup_root = os.path.expanduser(
+        f"~/.claude/obsidian-brain-doctor-backup/{_iso_now().replace(':', '-')}"
+    )
+    print(f"\nBackup root: {backup_root}", file=sys.stderr)
+
+    any_errors = False
+    for mod in modules:
+        issues = issues_by_check.get(mod.NAME, [])
+        if not issues:
+            continue
+        by_project: dict[str, list] = {}
+        for i in issues:
+            by_project.setdefault(i.project, []).append(i)
+        for proj, proj_issues in sorted(by_project.items()):
+            resolvable = [i for i in proj_issues if not i.extra.get("unresolved")]
+            if not resolvable:
+                continue
+            if not args.yes:
+                sys.stderr.write(
+                    f"Apply {len(resolvable)} fix(es) for project '{proj}' "
+                    f"in check '{mod.NAME}'? [y/N] "
+                )
+                sys.stderr.flush()
+                answer = sys.stdin.readline().strip().lower()
+                if answer not in ("y", "yes"):
+                    print(f"  skipped {proj}", file=sys.stderr)
+                    continue
+            results = mod.apply(resolvable, backup_root)
+            for r in results:
+                status_mark = {"applied": "+", "unresolved": "!", "error": "x", "skipped": "-"}.get(
+                    r.status, "?"
+                )
+                print(f"  {status_mark} {r.status}  {Path(r.note_path).name}", file=sys.stderr)
+                if r.status == "error":
+                    any_errors = True
+
+    return 2 if any_errors else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -7,7 +7,10 @@ Dry-run by default — requires --apply to write anything.
 Config priority:
   1. CLI args (--vault, --sessions-folder, --insights-folder)
   2. Env vars (OBSIDIAN_BRAIN_VAULT, *_SESSIONS_FOLDER, *_INSIGHTS_FOLDER)
-  3. ~/.claude/obsidian-brain-config.json via hooks/obsidian_utils.load_config()
+  3. ~/.claude/obsidian-brain-config.json (read directly via json.load
+     to avoid hooks/obsidian_utils.load_config()'s session-scoped cache,
+     which can be stale when the CLI runs outside a live Claude Code
+     session)
 
 Exit codes:
   0 — clean, no issues

--- a/scripts/vault_doctor_checks/__init__.py
+++ b/scripts/vault_doctor_checks/__init__.py
@@ -43,12 +43,26 @@ _CHECKS: dict[str, object] = {}
 
 
 def _discover() -> None:
-    """Import every submodule and register ones that expose the check interface."""
+    """Import every submodule and register ones that expose the check interface.
+
+    Per-module exceptions (ImportError, SyntaxError, etc.) are logged to
+    stderr and the offending module is skipped, so one broken check cannot
+    take down the whole dispatcher. This keeps the system pluggable.
+    """
     if _CHECKS:
         return
     package = __name__
+    import sys as _sys
     for mod_info in pkgutil.iter_modules(__path__):
-        mod = importlib.import_module(f"{package}.{mod_info.name}")
+        try:
+            mod = importlib.import_module(f"{package}.{mod_info.name}")
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"[vault_doctor] failed to load check '{mod_info.name}': "
+                f"{type(exc).__name__}: {exc}",
+                file=_sys.stderr,
+            )
+            continue
         name = getattr(mod, "NAME", None)
         if name and callable(getattr(mod, "scan", None)) and callable(getattr(mod, "apply", None)):
             _CHECKS[name] = mod

--- a/scripts/vault_doctor_checks/__init__.py
+++ b/scripts/vault_doctor_checks/__init__.py
@@ -1,0 +1,71 @@
+"""vault_doctor check module registry and shared types.
+
+Each check module in this package must export:
+  - NAME: str (kebab-case identifier used on the CLI)
+  - DESCRIPTION: str
+  - DEFAULT_WINDOW_DAYS: int
+  - scan(vault_path, sessions_folder, insights_folder, days, project=None) -> list[Issue]
+  - apply(issues, backup_root) -> list[Result]
+
+The registry auto-discovers modules in this package directory on first access.
+"""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class Issue:
+    check: str
+    note_path: str
+    project: str
+    current_source: str
+    proposed_source: str
+    reason: str
+    confidence: float = 1.0
+    extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class Result:
+    check: str
+    note_path: str
+    status: str  # "applied" | "skipped" | "error" | "unresolved"
+    backup_path: Optional[str] = None
+    error: Optional[str] = None
+
+
+_CHECKS: dict[str, object] = {}
+
+
+def _discover() -> None:
+    """Import every submodule and register ones that expose the check interface."""
+    if _CHECKS:
+        return
+    package = __name__
+    for mod_info in pkgutil.iter_modules(__path__):
+        mod = importlib.import_module(f"{package}.{mod_info.name}")
+        name = getattr(mod, "NAME", None)
+        if name and callable(getattr(mod, "scan", None)) and callable(getattr(mod, "apply", None)):
+            _CHECKS[name] = mod
+
+
+def list_checks() -> list[str]:
+    _discover()
+    return sorted(_CHECKS.keys())
+
+
+def get_check(name: str):
+    _discover()
+    if name not in _CHECKS:
+        raise KeyError(f"unknown check: {name!r}; available: {list_checks()}")
+    return _CHECKS[name]
+
+
+def all_checks() -> list:
+    _discover()
+    return list(_CHECKS.values())

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -39,6 +39,34 @@ _EXTRA_INSIGHT_FOLDERS = [
 _FRONT_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
 _WIKI_RE = re.compile(r"\[\[([^\]]+)\]\]")
 
+# Character class used to sanitize a project name into a filesystem-safe
+# path component. Anything outside [A-Za-z0-9_-] is replaced with '_'.
+_SAFE_PROJECT_RE = re.compile(r"[^a-zA-Z0-9_-]")
+
+
+def _safe_project_slug(project: str) -> str:
+    """Sanitize a project name for use as a filesystem path component.
+
+    Replaces any character that isn't alphanumeric, underscore, or hyphen
+    with an underscore. Empty or dot-only results become 'unknown' so the
+    resulting path can never escape the parent directory via '..' tricks.
+    This is used when joining an untrusted frontmatter `project` value onto
+    a backup directory root in apply().
+    """
+    if not project:
+        return "unknown"
+    # Strip dots FIRST, before the regex replacement. A dot-only input like
+    # "..." would otherwise become "___" after sub() and the subsequent
+    # strip(".") would be a no-op, leaving an ugly placeholder instead of
+    # collapsing to "unknown". Stripping dots first also defeats any
+    # leading/trailing '..' path-traversal pattern regardless of how the
+    # character class evolves.
+    stripped = project.strip(".")
+    if not stripped:
+        return "unknown"
+    slug = _SAFE_PROJECT_RE.sub("_", stripped)
+    return slug or "unknown"
+
 
 def _parse_frontmatter(text: str) -> dict:
     """Parse a flat key: value YAML frontmatter block. Nested blocks ignored."""
@@ -117,7 +145,13 @@ def _jsonl_dir_for_project(project: str) -> Path | None:
     the scan. Directories that disappear mid-scan are treated as missing.
     """
     home = os.environ.get("HOME", os.path.expanduser("~"))
-    pattern = os.path.join(home, ".claude", "projects", f"*{project}")
+    # glob.escape() neutralizes '*', '?', and '[' inside the project name so a
+    # project called e.g. "foo[bar]" cannot cause the glob to match unintended
+    # directories under ~/.claude/projects/. The leading '*' before the
+    # (escaped) project remains a real wildcard — that's how we match the
+    # path-encoded prefix Claude Code adds to the directory name.
+    safe_project = glob.escape(project)
+    pattern = os.path.join(home, ".claude", "projects", f"*{safe_project}")
     matches = glob.glob(pattern)
     if not matches:
         return None
@@ -391,12 +425,22 @@ def apply(issues, backup_root) -> list[Result]:
             continue
 
         # Stage 1: backup (failure → note unchanged, no backup)
+        # issue.project comes from untrusted frontmatter; sanitize it through
+        # _safe_project_slug() before joining so a value like "../../../etc"
+        # cannot cause the backup write to escape backup_root. The resolved
+        # post-check below is defense-in-depth against any future helper bug.
         try:
-            project_backup_dir = Path(backup_root) / issue.project
+            project_backup_dir = Path(backup_root) / _safe_project_slug(issue.project)
             project_backup_dir.mkdir(parents=True, exist_ok=True)
             backup_path = project_backup_dir / Path(issue.note_path).name
+            resolved_root = Path(backup_root).resolve()
+            resolved_backup = backup_path.resolve()
+            if resolved_root not in resolved_backup.parents:
+                raise ValueError(
+                    f"backup path {backup_path} would escape backup_root {backup_root}"
+                )
             shutil.copy2(issue.note_path, backup_path)
-        except OSError as exc:
+        except (OSError, ValueError) as exc:
             results.append(
                 Result(
                     check=NAME,

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -258,5 +258,112 @@ def scan(
     return issues
 
 
+def _rewrite_frontmatter(text: str, new_sid: str, new_basename: str) -> str:
+    """Rewrite only source_session and source_session_note in the frontmatter block.
+
+    Body, tags, and all other frontmatter fields are preserved byte-identically.
+    If either field is missing from the block, append it.
+    """
+    m = _FRONT_RE.match(text)
+    if not m:
+        raise ValueError("no frontmatter block found")
+    fm_block = m.group(1)
+    body = text[m.end():]
+
+    new_lines: list[str] = []
+    saw_sid = False
+    saw_src_note = False
+    for line in fm_block.splitlines():
+        if line.startswith("source_session:"):
+            new_lines.append(f"source_session: {new_sid}")
+            saw_sid = True
+        elif line.startswith("source_session_note:"):
+            new_lines.append(f'source_session_note: "[[{new_basename}]]"')
+            saw_src_note = True
+        else:
+            new_lines.append(line)
+
+    if not saw_sid:
+        new_lines.append(f"source_session: {new_sid}")
+    if not saw_src_note:
+        new_lines.append(f'source_session_note: "[[{new_basename}]]"')
+
+    return "---\n" + "\n".join(new_lines) + "\n---\n" + body
+
+
 def apply(issues, backup_root) -> list[Result]:
-    raise NotImplementedError("implemented in Task 8")
+    """Apply fixes: back up each file, then atomically rewrite frontmatter.
+
+    Unresolved issues are skipped. Missing proposed_sid in extra yields
+    status='error'. All writes are atomic (temp file + os.replace).
+    """
+    import shutil
+    import tempfile
+
+    results: list[Result] = []
+    os.makedirs(backup_root, exist_ok=True)
+
+    for issue in issues:
+        if issue.extra.get("unresolved"):
+            results.append(
+                Result(
+                    check=NAME,
+                    note_path=issue.note_path,
+                    status="unresolved",
+                    backup_path=None,
+                    error=None,
+                )
+            )
+            continue
+
+        proposed_sid = issue.extra.get("proposed_sid", "")
+        proposed_basename = issue.proposed_source.strip().lstrip("[").rstrip("]")
+        if not proposed_sid or not proposed_basename:
+            results.append(
+                Result(
+                    check=NAME,
+                    note_path=issue.note_path,
+                    status="error",
+                    error="missing proposed_sid or proposed_source",
+                )
+            )
+            continue
+
+        try:
+            # Backup before modifying
+            project_backup_dir = Path(backup_root) / issue.project
+            project_backup_dir.mkdir(parents=True, exist_ok=True)
+            backup_path = project_backup_dir / Path(issue.note_path).name
+            shutil.copy2(issue.note_path, backup_path)
+
+            # Read, patch, atomic write
+            with open(issue.note_path, "r", encoding="utf-8") as f:
+                text = f.read()
+            new_text = _rewrite_frontmatter(text, proposed_sid, proposed_basename)
+
+            fd, tmp = tempfile.mkstemp(
+                prefix=".vd-", suffix=".md.tmp", dir=os.path.dirname(issue.note_path)
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(new_text)
+            os.replace(tmp, issue.note_path)
+
+            results.append(
+                Result(
+                    check=NAME,
+                    note_path=issue.note_path,
+                    status="applied",
+                    backup_path=str(backup_path),
+                )
+            )
+        except (OSError, ValueError) as exc:
+            results.append(
+                Result(
+                    check=NAME,
+                    note_path=issue.note_path,
+                    status="error",
+                    error=str(exc),
+                )
+            )
+
+    return results

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -1,0 +1,21 @@
+"""vault_doctor check: detect and repair stale source_session backlinks.
+
+Full implementation comes in Tasks 7-8. This stub exists so the registry
+has a module to discover for Task 6 tests.
+"""
+
+from __future__ import annotations
+
+from . import Issue, Result
+
+NAME = "source-sessions"
+DESCRIPTION = "Detect and repair stale source_session backlinks"
+DEFAULT_WINDOW_DAYS = 7
+
+
+def scan(vault_path, sessions_folder, insights_folder, days, project=None) -> list[Issue]:
+    raise NotImplementedError("implemented in Task 7")
+
+
+def apply(issues, backup_root) -> list[Result]:
+    raise NotImplementedError("implemented in Task 8")

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -26,9 +26,10 @@ NAME = "source-sessions"
 DESCRIPTION = "Detect and repair stale source_session backlinks"
 DEFAULT_WINDOW_DAYS = 7
 
-# Insight-type folders we scan. Each is relative to vault root.
-_INSIGHT_FOLDERS = [
-    "claude-insights",
+# Auxiliary insight-type folders we always scan in addition to the
+# user-configured insights folder. These are conventional names; if a user
+# customizes them, they can add a follow-up feature request.
+_EXTRA_INSIGHT_FOLDERS = [
     "claude-decisions",
     "claude-error-fixes",
     "claude-retros",
@@ -109,14 +110,30 @@ def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
 
 
 def _jsonl_dir_for_project(project: str) -> Path | None:
-    """Find ~/.claude/projects/*<project>/ directory for this project name."""
+    """Find ~/.claude/projects/*<project>/ directory for this project name.
+
+    Wraps os.path.getmtime in a try/except so a transient filesystem race
+    (a matched directory being deleted between glob and stat) cannot crash
+    the scan. Directories that disappear mid-scan are treated as missing.
+    """
     home = os.environ.get("HOME", os.path.expanduser("~"))
     pattern = os.path.join(home, ".claude", "projects", f"*{project}")
     matches = glob.glob(pattern)
     if not matches:
         return None
+
+    def _safe_mtime(p: str) -> float:
+        try:
+            return os.path.getmtime(p)
+        except OSError:
+            return -1.0  # treat as effectively-missing
+
+    scored = [(m, _safe_mtime(m)) for m in matches]
+    viable = [(m, t) for m, t in scored if t >= 0]
+    if not viable:
+        return None
     # Pick the most recently modified directory if multiple match (path encoding variants)
-    return Path(max(matches, key=os.path.getmtime))
+    return Path(max(viable, key=lambda pair: pair[1])[0])
 
 
 def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
@@ -186,21 +203,28 @@ def _find_matching_session(
 def scan(
     vault_path: str,
     sessions_folder: str,
-    insights_folder: str,  # kept for signature uniformity; we iterate all _INSIGHT_FOLDERS
+    insights_folder: str,
     days: int,
     project: str | None = None,
 ) -> list[Issue]:
     """Detect stale source_session backlinks modified within the last `days` days."""
-    _ = insights_folder  # explicitly unused; we scan all _INSIGHT_FOLDERS
     vault = Path(vault_path)
     cutoff = time.time() - days * 86400
     sessions_dir = vault / sessions_folder
+
+    # Honor the user's configured insights folder as the primary, then scan
+    # the conventional auxiliary folders (decisions, error-fixes, retros)
+    # alongside it. Avoid duplicating the primary folder if a user happens
+    # to configure it to one of the extras.
+    scan_folders = [insights_folder] + [
+        f for f in _EXTRA_INSIGHT_FOLDERS if f != insights_folder
+    ]
 
     issues: list[Issue] = []
     session_index_cache: dict[str, dict[str, dict]] = {}
     jsonl_dir_cache: dict[str, Path | None] = {}
 
-    for folder in _INSIGHT_FOLDERS:
+    for folder in scan_folders:
         folder_path = vault / folder
         if not folder_path.is_dir():
             continue
@@ -234,8 +258,19 @@ def scan(
             jsonl_dir = jsonl_dir_cache[note_project]
 
             current_sid = fm.get("source_session", "")
-            m = _WIKI_RE.search(fm.get("source_session_note", ""))
+            raw_src_note = fm.get("source_session_note", "")
+            m = _WIKI_RE.search(raw_src_note)
             current_src_basename = m.group(1) if m else ""
+
+            # Build a clean current_source display string. Avoid emitting
+            # a bare "[[]]" when the frontmatter is missing or malformed —
+            # fall back to the raw value, or an empty string.
+            if current_src_basename:
+                current_source_display = f"[[{current_src_basename}]]"
+            elif raw_src_note:
+                current_source_display = raw_src_note
+            else:
+                current_source_display = ""
 
             match = _find_matching_session(mtime, jsonl_dir, idx)
             if match is None:
@@ -249,7 +284,7 @@ def scan(
                             check=NAME,
                             note_path=str(note),
                             project=note_project,
-                            current_source=f"[[{current_src_basename}]]" if current_src_basename else "",
+                            current_source=current_source_display,
                             proposed_source="",
                             reason="no session window contains note mtime",
                             confidence=0.0,
@@ -266,7 +301,7 @@ def scan(
                     check=NAME,
                     note_path=str(note),
                     project=note_project,
-                    current_source=f"[[{current_src_basename}]]",
+                    current_source=current_source_display,
                     proposed_source=f"[[{match['basename']}]]",
                     reason=(
                         f"note mtime {datetime.fromtimestamp(mtime, timezone.utc).isoformat(timespec='seconds')}"

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -134,19 +134,31 @@ def _find_matching_session(
     jsonl_dir: Path | None,
     session_note_index: dict[str, dict],
 ) -> dict | None:
-    """Return the session note dict (+ 'sid' key) whose JSONL window contains capture_time."""
+    """Return the session note dict (+ 'sid' key) whose JSONL window contains capture_time.
+
+    Iteration is deterministic (sorted by filename). When multiple windows
+    contain capture_time (boundary tie between a previous session's end and
+    a new session's start), the session with the LATEST first_ts wins — the
+    most recently started session is the one actively capturing insights.
+    """
     if not jsonl_dir or not jsonl_dir.is_dir():
         return None
-    for jsonl in jsonl_dir.glob("*.jsonl"):
+    candidates: list[tuple[float, str]] = []
+    for jsonl in sorted(jsonl_dir.glob("*.jsonl")):
         sid = jsonl.stem
+        if sid not in session_note_index:
+            continue
         window = _jsonl_window(str(jsonl))
         if window is None:
             continue
         first_ts, last_ts = window
         if first_ts <= capture_time <= last_ts:
-            if sid in session_note_index:
-                return {**session_note_index[sid], "sid": sid}
-    return None
+            candidates.append((first_ts, sid))
+    if not candidates:
+        return None
+    # Latest-start wins on boundary ties
+    _, best_sid = max(candidates)
+    return {**session_note_index[best_sid], "sid": best_sid}
 
 
 def scan(

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -132,8 +132,12 @@ def _jsonl_dir_for_project(project: str) -> Path | None:
     viable = [(m, t) for m, t in scored if t >= 0]
     if not viable:
         return None
-    # Pick the most recently modified directory if multiple match (path encoding variants)
-    return Path(max(viable, key=lambda pair: pair[1])[0])
+    # Pick the most recently modified directory if multiple match (path
+    # encoding variants). Deterministic tiebreak: sort by (mtime, path) so
+    # same-mtime dirs pick the same winner across runs instead of depending
+    # on glob order. Matches the (mtime, path) pattern used for JSONL
+    # selection elsewhere in the fast path.
+    return Path(max(viable, key=lambda pair: (pair[1], pair[0]))[0])
 
 
 def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -15,6 +15,7 @@ import glob
 import json
 import os
 import re
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -67,12 +68,21 @@ def _parse_iso_ts(ts: str) -> float | None:
 
 
 def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
-    """Return (first_entry_ts, mtime) for a JSONL session file, or None."""
+    """Return (first_entry_ts, mtime) for a JSONL session file, or None.
+
+    Returns None when the file is unreadable or every line fails to parse.
+    Falls back to `mtime - 3600` ONLY when lines parsed successfully but no
+    entry had a 'timestamp' field — this is a known JSONL schema variant.
+    A fully corrupt file returns None so `_find_matching_session` skips it
+    rather than fabricating a window that could produce false-positive
+    stale flags.
+    """
     try:
         mtime = os.path.getmtime(jsonl_path)
     except OSError:
         return None
     first_ts: float | None = None
+    parsed_any = False
     try:
         with open(jsonl_path, "r", encoding="utf-8") as f:
             for line in f:
@@ -80,6 +90,7 @@ def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
                     entry = json.loads(line)
                 except json.JSONDecodeError:
                     continue
+                parsed_any = True
                 ts = _parse_iso_ts(entry.get("timestamp", ""))
                 if ts is not None:
                     first_ts = ts
@@ -87,7 +98,12 @@ def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
     except OSError:
         return None
     if first_ts is None:
-        # Fallback: loose 1-hour lower bound before mtime
+        if not parsed_any:
+            print(
+                f"[vault_doctor] JSONL has no parseable lines: {jsonl_path}",
+                file=sys.stderr,
+            )
+            return None
         first_ts = mtime - 3600
     return (first_ts, mtime)
 
@@ -116,6 +132,12 @@ def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
         except OSError:
             continue
         fm = _parse_frontmatter(text)
+        if not fm and text.startswith("---"):
+            print(
+                f"[vault_doctor] malformed frontmatter, skipped: {entry}",
+                file=sys.stderr,
+            )
+            continue
         if fm.get("project") != project:
             continue
         sid = fm.get("session_id", "")
@@ -329,14 +351,26 @@ def apply(issues, backup_root) -> list[Result]:
             )
             continue
 
+        # Stage 1: backup (failure → note unchanged, no backup)
         try:
-            # Backup before modifying
             project_backup_dir = Path(backup_root) / issue.project
             project_backup_dir.mkdir(parents=True, exist_ok=True)
             backup_path = project_backup_dir / Path(issue.note_path).name
             shutil.copy2(issue.note_path, backup_path)
+        except OSError as exc:
+            results.append(
+                Result(
+                    check=NAME,
+                    note_path=issue.note_path,
+                    status="error",
+                    error=f"backup failed (note unchanged): {exc}",
+                )
+            )
+            continue
 
-            # Read, patch, atomic write
+        # Stage 2: read/patch/atomic-write (failure → note may or may not be
+        # patched; backup exists so the user can recover)
+        try:
             with open(issue.note_path, "r", encoding="utf-8") as f:
                 text = f.read()
             new_text = _rewrite_frontmatter(text, proposed_sid, proposed_basename)
@@ -356,13 +390,14 @@ def apply(issues, backup_root) -> list[Result]:
                     backup_path=str(backup_path),
                 )
             )
-        except (OSError, ValueError) as exc:
+        except Exception as exc:  # per-issue isolation; don't abort the loop
             results.append(
                 Result(
                     check=NAME,
                     note_path=issue.note_path,
                     status="error",
-                    error=str(exc),
+                    backup_path=str(backup_path),  # user can recover from this
+                    error=f"rewrite failed (backup preserved): {type(exc).__name__}: {exc}",
                 )
             )
 

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -1,10 +1,23 @@
 """vault_doctor check: detect and repair stale source_session backlinks.
 
-Full implementation comes in Tasks 7-8. This stub exists so the registry
-has a module to discover for Task 6 tests.
+Detection strategy:
+  For each insight-type note with a `source_session` frontmatter field,
+  read the note's file mtime as the "capture time." For each JSONL file
+  under ~/.claude/projects/*<project>/*.jsonl, determine its activity
+  window (first entry timestamp → file mtime). The correct source session
+  is the JSONL whose window contains the note's capture time. Flag as
+  stale whenever the note's current source_session does not match.
 """
 
 from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import time
+from datetime import datetime, timezone
+from pathlib import Path
 
 from . import Issue, Result
 
@@ -12,9 +25,225 @@ NAME = "source-sessions"
 DESCRIPTION = "Detect and repair stale source_session backlinks"
 DEFAULT_WINDOW_DAYS = 7
 
+# Insight-type folders we scan. Each is relative to vault root.
+_INSIGHT_FOLDERS = [
+    "claude-insights",
+    "claude-decisions",
+    "claude-error-fixes",
+    "claude-retros",
+]
 
-def scan(vault_path, sessions_folder, insights_folder, days, project=None) -> list[Issue]:
-    raise NotImplementedError("implemented in Task 7")
+# Regex helpers for minimal frontmatter parsing (stdlib only — no yaml dep)
+_FRONT_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+_WIKI_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def _parse_frontmatter(text: str) -> dict:
+    """Parse a flat key: value YAML frontmatter block. Nested blocks ignored."""
+    m = _FRONT_RE.match(text)
+    if not m:
+        return {}
+    out: dict = {}
+    for line in m.group(1).splitlines():
+        if not line or line.startswith(" ") or line.startswith("-"):
+            continue  # skip list items and nested keys
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        out[key.strip()] = value.strip().strip('"').strip("'")
+    return out
+
+
+def _parse_iso_ts(ts: str) -> float | None:
+    """Parse ISO 8601 timestamp to a POSIX float, or None on failure."""
+    if not ts:
+        return None
+    try:
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        return datetime.fromisoformat(ts).timestamp()
+    except ValueError:
+        return None
+
+
+def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
+    """Return (first_entry_ts, mtime) for a JSONL session file, or None."""
+    try:
+        mtime = os.path.getmtime(jsonl_path)
+    except OSError:
+        return None
+    first_ts: float | None = None
+    try:
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ts = _parse_iso_ts(entry.get("timestamp", ""))
+                if ts is not None:
+                    first_ts = ts
+                    break
+    except OSError:
+        return None
+    if first_ts is None:
+        # Fallback: loose 1-hour lower bound before mtime
+        first_ts = mtime - 3600
+    return (first_ts, mtime)
+
+
+def _jsonl_dir_for_project(project: str) -> Path | None:
+    """Find ~/.claude/projects/*<project>/ directory for this project name."""
+    home = os.environ.get("HOME", os.path.expanduser("~"))
+    pattern = os.path.join(home, ".claude", "projects", f"*{project}")
+    matches = glob.glob(pattern)
+    if not matches:
+        return None
+    # Pick the most recently modified directory if multiple match (path encoding variants)
+    return Path(max(matches, key=os.path.getmtime))
+
+
+def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
+    """Map session_id → {path, basename, date} for a project's session notes."""
+    out: dict[str, dict] = {}
+    if not sessions_dir.is_dir():
+        return out
+    for entry in sessions_dir.iterdir():
+        if not entry.name.endswith(".md"):
+            continue
+        try:
+            text = entry.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        fm = _parse_frontmatter(text)
+        if fm.get("project") != project:
+            continue
+        sid = fm.get("session_id", "")
+        if not sid:
+            continue
+        out[sid] = {
+            "path": entry,
+            "basename": entry.name[:-3],
+            "date": fm.get("date", ""),
+        }
+    return out
+
+
+def _find_matching_session(
+    capture_time: float,
+    jsonl_dir: Path | None,
+    session_note_index: dict[str, dict],
+) -> dict | None:
+    """Return the session note dict (+ 'sid' key) whose JSONL window contains capture_time."""
+    if not jsonl_dir or not jsonl_dir.is_dir():
+        return None
+    for jsonl in jsonl_dir.glob("*.jsonl"):
+        sid = jsonl.stem
+        window = _jsonl_window(str(jsonl))
+        if window is None:
+            continue
+        first_ts, last_ts = window
+        if first_ts <= capture_time <= last_ts:
+            if sid in session_note_index:
+                return {**session_note_index[sid], "sid": sid}
+    return None
+
+
+def scan(
+    vault_path: str,
+    sessions_folder: str,
+    insights_folder: str,  # kept for signature uniformity; we iterate all _INSIGHT_FOLDERS
+    days: int,
+    project: str | None = None,
+) -> list[Issue]:
+    """Detect stale source_session backlinks modified within the last `days` days."""
+    _ = insights_folder  # explicitly unused; we scan all _INSIGHT_FOLDERS
+    vault = Path(vault_path)
+    cutoff = time.time() - days * 86400
+    sessions_dir = vault / sessions_folder
+
+    issues: list[Issue] = []
+    session_index_cache: dict[str, dict[str, dict]] = {}
+    jsonl_dir_cache: dict[str, Path | None] = {}
+
+    for folder in _INSIGHT_FOLDERS:
+        folder_path = vault / folder
+        if not folder_path.is_dir():
+            continue
+        for note in folder_path.iterdir():
+            if not note.name.endswith(".md"):
+                continue
+            try:
+                mtime = os.path.getmtime(note)
+            except OSError:
+                continue
+            if mtime < cutoff:
+                continue
+            try:
+                text = note.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            fm = _parse_frontmatter(text)
+            if "source_session" not in fm:
+                continue  # non-source-session note type (e.g., standups with source_notes[])
+            note_project = fm.get("project", "")
+            if not note_project:
+                continue
+            if project and note_project != project:
+                continue
+
+            if note_project not in session_index_cache:
+                session_index_cache[note_project] = _list_session_notes(sessions_dir, note_project)
+                jsonl_dir_cache[note_project] = _jsonl_dir_for_project(note_project)
+
+            idx = session_index_cache[note_project]
+            jsonl_dir = jsonl_dir_cache[note_project]
+
+            current_sid = fm.get("source_session", "")
+            m = _WIKI_RE.search(fm.get("source_session_note", ""))
+            current_src_basename = m.group(1) if m else ""
+
+            match = _find_matching_session(mtime, jsonl_dir, idx)
+            if match is None:
+                # No JSONL window contains this mtime. Flag as unresolved ONLY if
+                # the current source doesn't resolve to any known session note — that
+                # way we don't get false positives on notes whose current source is
+                # correct but just doesn't have a matching JSONL window locally.
+                if current_sid not in idx:
+                    issues.append(
+                        Issue(
+                            check=NAME,
+                            note_path=str(note),
+                            project=note_project,
+                            current_source=f"[[{current_src_basename}]]" if current_src_basename else "",
+                            proposed_source="",
+                            reason="no session window contains note mtime",
+                            confidence=0.0,
+                            extra={"unresolved": True},
+                        )
+                    )
+                continue
+
+            if match["sid"] == current_sid:
+                continue  # correct
+
+            issues.append(
+                Issue(
+                    check=NAME,
+                    note_path=str(note),
+                    project=note_project,
+                    current_source=f"[[{current_src_basename}]]",
+                    proposed_source=f"[[{match['basename']}]]",
+                    reason=(
+                        f"note mtime {datetime.fromtimestamp(mtime, timezone.utc).isoformat(timespec='seconds')}"
+                        f" matches session {match['sid'][:8]} window, not current source {current_sid[:8]}"
+                    ),
+                    confidence=0.95,
+                    extra={"proposed_sid": match["sid"]},
+                )
+            )
+
+    return issues
 
 
 def apply(issues, backup_root) -> list[Result]:

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -430,9 +430,18 @@ def apply(issues, backup_root) -> list[Result]:
         # cannot cause the backup write to escape backup_root. The resolved
         # post-check below is defense-in-depth against any future helper bug.
         try:
-            project_backup_dir = Path(backup_root) / _safe_project_slug(issue.project)
+            # Preserve the source folder name in the backup path to prevent
+            # basename collisions across insight-type folders (e.g., an
+            # insight and a retro both named 2026-04-10-foo.md would otherwise
+            # clobber each other's backups). The resulting layout is
+            # <backup_root>/<project>/<folder>/<basename>.
+            note_path = Path(issue.note_path)
+            source_folder = note_path.parent.name  # e.g., "claude-insights"
+            project_backup_dir = (
+                Path(backup_root) / _safe_project_slug(issue.project) / source_folder
+            )
             project_backup_dir.mkdir(parents=True, exist_ok=True)
-            backup_path = project_backup_dir / Path(issue.note_path).name
+            backup_path = project_backup_dir / note_path.name
             resolved_root = Path(backup_root).resolve()
             resolved_backup = backup_path.resolve()
             if resolved_root not in resolved_backup.parents:

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -403,8 +403,26 @@ def apply(issues, backup_root) -> list[Result]:
             )
             continue
 
+        # Capture original stat so we can preserve mtime across the rewrite.
+        # scan() uses note mtime as capture_time for JSONL window matching —
+        # updating mtime on apply would cause re-runs to re-flag fixed notes.
+        try:
+            original_stat = os.stat(issue.note_path)
+        except OSError as exc:
+            results.append(
+                Result(
+                    check=NAME,
+                    note_path=issue.note_path,
+                    status="error",
+                    backup_path=str(backup_path),
+                    error=f"stat failed: {exc}",
+                )
+            )
+            continue
+
         # Stage 2: read/patch/atomic-write (failure → note may or may not be
         # patched; backup exists so the user can recover)
+        tmp = None
         try:
             with open(issue.note_path, "r", encoding="utf-8") as f:
                 text = f.read()
@@ -416,6 +434,23 @@ def apply(issues, backup_root) -> list[Result]:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(new_text)
             os.replace(tmp, issue.note_path)
+            tmp = None  # replaced successfully; nothing to clean up
+
+            # Restore original atime/mtime so future scans see the same
+            # capture_time the scan that flagged this note saw.
+            try:
+                os.utime(
+                    issue.note_path,
+                    (original_stat.st_atime, original_stat.st_mtime),
+                )
+            except OSError as exc:
+                # Non-fatal: the rewrite succeeded, but mtime preservation failed.
+                # Log to stderr but still mark as applied (backup exists for recovery).
+                print(
+                    f"[vault_doctor] warning: failed to restore mtime on "
+                    f"{issue.note_path}: {exc}",
+                    file=sys.stderr,
+                )
 
             results.append(
                 Result(
@@ -435,5 +470,13 @@ def apply(issues, backup_root) -> list[Result]:
                     error=f"rewrite failed (backup preserved): {type(exc).__name__}: {exc}",
                 )
             )
+        finally:
+            # Best-effort cleanup of any orphaned temp file left behind when
+            # os.replace didn't consume it (e.g., exception before/during replace).
+            if tmp is not None:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
 
     return results

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -62,8 +62,9 @@ if ! tail -5 "$LOG" 2>/dev/null | grep -q "bootstrap_updated=true"; then
     exit 1
 fi
 
-# Advisory: the bootstrap file should exist (it may have been overwritten
-# with the real session sid by load_config(); that is expected).
+# Advisory: the bootstrap file should exist. After commit f26d93c, the
+# slow path no longer writes the bootstrap, so this check should
+# consistently match the dummy sid we just wrote (no racing overwrite).
 if [[ ! -f "$BOOTSTRAP" ]]; then
     echo "[WARN] bootstrap file $BOOTSTRAP does not exist"
     echo "  the hook log shows bootstrap_updated=true, so this is unusual"

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -9,13 +9,16 @@
 # Exit:  0 on success, non-zero on any failure.
 #
 # Note on the bootstrap check:
-#   load_config() inside the hook calls _get_session_id_fast(), which
-#   refreshes the bootstrap file with the authoritative session_id
-#   derived from ~/.claude/projects/*. When this script runs inside a
-#   live Claude Code session, that overwrite races with our dummy-sid
-#   write, so the bootstrap file may end up containing the real sid by
-#   the time we read it. The append-only hook log is the authoritative
-#   signal that our invocation ran; the bootstrap check is advisory.
+#   After commit f26d93c, only the SessionStart hook writes the
+#   bootstrap file. The previous slow-path "refresh" behavior in
+#   _get_session_id_fast() was removed because it could clobber the
+#   hook's authoritative write within the same hook invocation when
+#   Claude Code fires SessionStart before flushing the new session's
+#   JSONL to disk. This script verifies the hook fired via the
+#   append-only hook log at ~/.claude/obsidian-brain-hook.log — that
+#   is the authoritative signal. The bootstrap file check is advisory
+#   and should now also show the dummy sid (no racing slow path
+#   overwriting it).
 
 set -euo pipefail
 

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -35,7 +35,11 @@ BOOTSTRAP="/tmp/.obsidian-brain-sid-$PROJECT"
 LOG="$HOME/.claude/obsidian-brain-hook.log"
 
 echo "→ Simulating SessionStart hook for project=$PROJECT"
-printf '{"cwd": "%s", "session_id": "%s"}' "$(pwd)" "$DUMMY_SID" \
+# Build the JSON payload via json.dumps so a cwd containing quotes,
+# backslashes, or newlines cannot produce an invalid-JSON stdin that
+# the hook would reject as malformed.
+python3 -c 'import json,sys; print(json.dumps({"cwd": sys.argv[1], "session_id": sys.argv[2]}))' \
+    "$(pwd)" "$DUMMY_SID" \
     | python3 "$HOOK" >/dev/null
 
 # Log is append-only and the authoritative proof the hook fired.

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -21,7 +21,10 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 HOOK="$REPO_ROOT/hooks/obsidian_session_hint.py"
-PROJECT="$(basename "$(pwd)" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')"
+HOOKS_DIR="$REPO_ROOT/hooks"
+# Derive PROJECT via the same helper the hook uses, so the bootstrap path
+# agrees with the hook regardless of how get_project_name() evolves.
+PROJECT="$(python3 -c "import sys; sys.path.insert(0, '$HOOKS_DIR'); from obsidian_utils import get_project_name; print(get_project_name('$(pwd)'))")"
 DUMMY_SID="verify-hooks-$(date +%s)"
 BOOTSTRAP="/tmp/.obsidian-brain-sid-$PROJECT"
 LOG="$HOME/.claude/obsidian-brain-hook.log"

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -24,7 +24,12 @@ HOOK="$REPO_ROOT/hooks/obsidian_session_hint.py"
 HOOKS_DIR="$REPO_ROOT/hooks"
 # Derive PROJECT via the same helper the hook uses, so the bootstrap path
 # agrees with the hook regardless of how get_project_name() evolves.
-PROJECT="$(python3 -c "import sys; sys.path.insert(0, '$HOOKS_DIR'); from obsidian_utils import get_project_name; print(get_project_name('$(pwd)'))")"
+PROJECT="$(python3 -c "
+import sys
+sys.path.insert(0, sys.argv[1])
+from obsidian_utils import get_project_name
+print(get_project_name(sys.argv[2]))
+" "$HOOKS_DIR" "$(pwd)")"
 DUMMY_SID="verify-hooks-$(date +%s)"
 BOOTSTRAP="/tmp/.obsidian-brain-sid-$PROJECT"
 LOG="$HOME/.claude/obsidian-brain-hook.log"

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# verify-hooks.sh — manual diagnostic for obsidian-brain SessionStart hook.
+#
+# Simulates a SessionStart hook invocation with a dummy session_id and
+# verifies that the bootstrap file and hook log were written. Does NOT
+# need a running Claude Code session.
+#
+# Usage: ./scripts/verify-hooks.sh
+# Exit:  0 on success, non-zero on any failure.
+#
+# Note on the bootstrap check:
+#   load_config() inside the hook calls _get_session_id_fast(), which
+#   refreshes the bootstrap file with the authoritative session_id
+#   derived from ~/.claude/projects/*. When this script runs inside a
+#   live Claude Code session, that overwrite races with our dummy-sid
+#   write, so the bootstrap file may end up containing the real sid by
+#   the time we read it. The append-only hook log is the authoritative
+#   signal that our invocation ran; the bootstrap check is advisory.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$REPO_ROOT/hooks/obsidian_session_hint.py"
+PROJECT="$(basename "$(pwd)" | tr ' ' '-' | tr '[:upper:]' '[:lower:]')"
+DUMMY_SID="verify-hooks-$(date +%s)"
+BOOTSTRAP="/tmp/.obsidian-brain-sid-$PROJECT"
+LOG="$HOME/.claude/obsidian-brain-hook.log"
+
+echo "→ Simulating SessionStart hook for project=$PROJECT"
+printf '{"cwd": "%s", "session_id": "%s"}' "$(pwd)" "$DUMMY_SID" \
+    | python3 "$HOOK" >/dev/null
+
+# Log is append-only and the authoritative proof the hook fired.
+# The dummy sid is truncated to 8 chars in the log ("verify-h").
+if ! tail -5 "$LOG" 2>/dev/null | grep -q "sid=verify-h"; then
+    echo "✗ FAIL: hook log does not contain a verify-hooks entry" >&2
+    echo "  log path: $LOG" >&2
+    echo "  last 5 lines:" >&2
+    tail -5 "$LOG" >&2 || true
+    exit 1
+fi
+
+if ! tail -5 "$LOG" 2>/dev/null | grep -q "bootstrap_updated=true"; then
+    echo "✗ FAIL: hook log does not show bootstrap_updated=true" >&2
+    echo "  log path: $LOG" >&2
+    tail -5 "$LOG" >&2 || true
+    exit 1
+fi
+
+# Advisory: the bootstrap file should exist (it may have been overwritten
+# with the real session sid by load_config(); that is expected).
+if [[ ! -f "$BOOTSTRAP" ]]; then
+    echo "⚠ WARN: bootstrap file $BOOTSTRAP does not exist"
+    echo "  the hook log shows bootstrap_updated=true, so this is unusual"
+fi
+
+echo "✓ Hook fired, bootstrap written, log updated."
+echo "  bootstrap: $BOOTSTRAP"
+echo "  log:       $LOG"

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -33,7 +33,7 @@ printf '{"cwd": "%s", "session_id": "%s"}' "$(pwd)" "$DUMMY_SID" \
 # Log is append-only and the authoritative proof the hook fired.
 # The dummy sid is truncated to 8 chars in the log ("verify-h").
 if ! tail -5 "$LOG" 2>/dev/null | grep -q "sid=verify-h"; then
-    echo "✗ FAIL: hook log does not contain a verify-hooks entry" >&2
+    echo "[FAIL] hook log does not contain a verify-hooks entry" >&2
     echo "  log path: $LOG" >&2
     echo "  last 5 lines:" >&2
     tail -5 "$LOG" >&2 || true
@@ -41,7 +41,7 @@ if ! tail -5 "$LOG" 2>/dev/null | grep -q "sid=verify-h"; then
 fi
 
 if ! tail -5 "$LOG" 2>/dev/null | grep -q "bootstrap_updated=true"; then
-    echo "✗ FAIL: hook log does not show bootstrap_updated=true" >&2
+    echo "[FAIL] hook log does not show bootstrap_updated=true" >&2
     echo "  log path: $LOG" >&2
     tail -5 "$LOG" >&2 || true
     exit 1
@@ -50,10 +50,10 @@ fi
 # Advisory: the bootstrap file should exist (it may have been overwritten
 # with the real session sid by load_config(); that is expected).
 if [[ ! -f "$BOOTSTRAP" ]]; then
-    echo "⚠ WARN: bootstrap file $BOOTSTRAP does not exist"
+    echo "[WARN] bootstrap file $BOOTSTRAP does not exist"
     echo "  the hook log shows bootstrap_updated=true, so this is unusual"
 fi
 
-echo "✓ Hook fired, bootstrap written, log updated."
+echo "[OK] Hook fired, bootstrap written, log updated."
 echo "  bootstrap: $BOOTSTRAP"
 echo "  log:       $LOG"

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -268,12 +268,12 @@ import sys, os
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
 from obsidian_utils import build_context_brief, check_hook_status
 hs = check_hook_status()
-status_line = ("✓ " if hs["ok"] else "⚠ ") + hs["message"]
+status_line = ("[OK] " if hs["ok"] else "[WARN] ") + hs["message"]
 print(build_context_brief(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], hook_status_line=status_line))
 ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$INSIGHTS_FOLDER" "$PROJECT"
 ```
 
-The first line of the emitted `CONTEXT_BRIEF` is always the hook-status line (prefixed `✓` when the SessionStart hook fired and bootstrap matches the current sid, `⚠` otherwise). Preserve it verbatim when displaying the brief — it is the user's only visible signal that hooks are alive.
+The first line of the emitted `CONTEXT_BRIEF` is always the hook-status line (prefixed `[OK]` when the SessionStart hook fired and bootstrap matches the current sid, `[WARN]` otherwise). Preserve it verbatim when displaying the brief — it is the user's only visible signal that hooks are alive.
 
 If the command fails (non-zero exit code), print the error and stop — do not fall back to in-context reads.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -266,10 +266,14 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
 import sys, os
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from obsidian_utils import build_context_brief
-print(build_context_brief(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]))
+from obsidian_utils import build_context_brief, check_hook_status
+hs = check_hook_status()
+status_line = ("✓ " if hs["ok"] else "⚠ ") + hs["message"]
+print(build_context_brief(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], hook_status_line=status_line))
 ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$INSIGHTS_FOLDER" "$PROJECT"
 ```
+
+The first line of the emitted `CONTEXT_BRIEF` is always the hook-status line (prefixed `✓` when the SessionStart hook fired and bootstrap matches the current sid, `⚠` otherwise). Preserve it verbatim when displaying the brief — it is the user's only visible signal that hooks are alive.
 
 If the command fails (non-zero exit code), print the error and stop — do not fall back to in-context reads.
 

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: vault-doctor
+description: "Diagnostic and repair skill for the Obsidian vault. Runs a battery of checks against vault notes and offers to fix detected issues. Dry-run by default — requires 'fix' to write. Use when: (1) /vault-doctor command to scan for vault health issues, (2) /vault-doctor fix to apply repairs, (3) /vault-doctor --check <name> for a specific check, (4) user reports stale backlinks or wants to audit vault integrity."
+metadata:
+  version: 1.0.0
+---
+
+# vault-doctor — Audit and Repair the Obsidian Vault
+
+Audit and repair the Obsidian vault. Ships with one check initially (`source-sessions`); more can be added as separate modules under `scripts/vault_doctor_checks/` without changing this skill.
+
+**Tools needed:** Bash, Read
+
+## Invocation
+
+- `/vault-doctor` — run all checks, report only (dry-run)
+- `/vault-doctor fix` — run all checks, apply after per-project confirmation
+- `/vault-doctor --check source-sessions` — run one specific check
+- `/vault-doctor --days 14` — override default window (default: 7 days)
+- `/vault-doctor --project obsidian-brain` — limit to one project
+- `/vault-doctor fix --check source-sessions --days 7` — combine flags
+
+## Procedure
+
+Follow these steps exactly. Do not skip steps or reorder them.
+
+### Step 1 — Parse arguments and locate the dispatcher
+
+Parse the user's invocation into flags:
+
+- No args → dry-run mode, all checks
+- `fix` → apply mode, all checks
+- `--check <name>` → specific check only
+- `--days <N>` → window override
+- `--project <name>` → project filter
+
+Locate the Python dispatcher via the standard plugin cache glob, with a fallback for local dev sessions where the repo is checked out as `$PWD`:
+
+```bash
+DISPATCHER="$(ls -d ~/.claude/plugins/cache/*/obsidian-brain/*/scripts/vault_doctor.py 2>/dev/null | tail -1)"
+if [[ -z "$DISPATCHER" ]]; then
+    if [[ -f "$(pwd)/scripts/vault_doctor.py" ]]; then
+        DISPATCHER="$(pwd)/scripts/vault_doctor.py"
+    fi
+fi
+if [[ -z "$DISPATCHER" || ! -f "$DISPATCHER" ]]; then
+    echo "ERROR: could not find scripts/vault_doctor.py" >&2
+    exit 1
+fi
+```
+
+If the dispatcher cannot be located, tell the user:
+
+> Could not find `scripts/vault_doctor.py`. Make sure the obsidian-brain plugin is installed via `/dev-test install` (for local dev) or the marketplace.
+
+Stop here if the dispatcher is missing.
+
+### Step 2 — Run the dispatcher in JSON report mode
+
+Always run with `--json` first so you can parse the output deterministically. Pass through only the flags the user provided:
+
+```bash
+python3 "$DISPATCHER" \
+    ${CHECK:+--check "$CHECK"} \
+    ${DAYS:+--days "$DAYS"} \
+    ${PROJECT:+--project "$PROJECT"} \
+    --json
+```
+
+Capture stdout as the JSON report. Exit codes:
+
+- `0` — clean vault, nothing to do
+- `1` — issues found (expected for a dry-run that finds things)
+- `2` — apply errors
+- `3` — usage error (bad args, missing config)
+
+If exit code is `3`, surface the stderr message directly to the user and stop.
+
+### Step 3 — Present the report to the user
+
+Parse the JSON and present a grouped-by-project table. Example:
+
+```
+vault_doctor report — 3 issue(s) across 1 check(s)
+
+## source-sessions
+
+### Project: obsidian-brain (2 issues)
+[FAIL] 2026-04-10-recall-profiling.md
+  current:  [[2026-04-09-obsidian-brain-abcd]]
+  proposed: [[2026-04-10-obsidian-brain-ef01]]
+  reason:   note mtime 2026-04-10T14:22 matches session ef010000 window...
+
+### Project: tiny-vacation-agent (1 issue)
+[FAIL] 2026-04-11-enrichment-scope.md
+  current:  [[2026-04-10-tiny-vacation-agent-aaaa]]
+  proposed: [[2026-04-11-tiny-vacation-agent-bbbb]]
+  reason:   note mtime 2026-04-11T09:15 matches session bbbb0000 window...
+```
+
+Use `[FAIL]` for actionable issues (those with a proposed fix) and `[WARN]` for unresolved ones (those the check could not auto-repair). Always include a one-line summary at the top with the total count.
+
+If the report is empty (exit code 0), tell the user:
+
+> Vault is clean. No issues found.
+
+Stop here.
+
+### Step 4 — Ask whether to apply (only if `fix` was requested)
+
+If the user did NOT pass `fix`:
+
+> Dry-run complete. Found **N** stale backlink(s) across **K** project(s).
+> Run `/vault-doctor fix` to apply repairs. Backups will be written to `~/.claude/obsidian-brain-doctor-backup/<timestamp>/`.
+
+Stop here.
+
+If the user DID pass `fix`:
+
+> Found **N** repairable issue(s) across **K** project(s). I'll apply per project with confirmation.
+
+Re-run the dispatcher with `--apply` (do NOT pass `--yes` — let the dispatcher prompt per project interactively):
+
+```bash
+python3 "$DISPATCHER" \
+    ${CHECK:+--check "$CHECK"} \
+    ${DAYS:+--days "$DAYS"} \
+    ${PROJECT:+--project "$PROJECT"} \
+    --apply
+```
+
+The dispatcher will prompt `Apply N fix(es) for project 'X' in check 'Y'? [y/N]` on stderr for each project. Relay each prompt to the user and pipe their response to the dispatcher's stdin.
+
+### Step 5 — Report the outcome
+
+Parse the final stderr output from the dispatcher and summarize:
+
+```
+vault_doctor apply complete
+  obsidian-brain: 3 applied, 0 unresolved, 0 errors
+  tiny-vacation-agent: 1 applied, 0 unresolved, 0 errors
+
+Backups saved to: ~/.claude/obsidian-brain-doctor-backup/2026-04-11T17-04-22+00-00/
+```
+
+If any errors occurred (exit code 2), surface them prominently and recommend the user diff one of the backup files under the backup root to understand what went wrong.
+
+### Step 6 — Offer next steps
+
+After a successful fix run:
+
+> Repairs applied. You can diff any fixed note against its backup under the backup root.
+> Re-run `/vault-doctor` to confirm the vault is clean.
+
+## Notes for the model
+
+- All detection and repair logic lives in `scripts/vault_doctor.py` and `scripts/vault_doctor_checks/*.py`. **Do not re-implement any of it in this skill.** The skill is pure orchestration and presentation.
+- The dispatcher is dry-run by default. Pass `--apply` only when the user explicitly requests `fix`.
+- Unresolved issues are never automatically repaired. Surface them in the report but do not try to guess a replacement.
+- Backups are written automatically by the dispatcher to `~/.claude/obsidian-brain-doctor-backup/<ISO-timestamp>/<project>/<basename>`. Always mention the backup path in your summary so the user knows where to look.

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -37,7 +37,7 @@ Parse the user's invocation into flags:
 Locate the Python dispatcher via the standard plugin cache glob, with a fallback for local dev sessions where the repo is checked out as `$PWD`:
 
 ```bash
-DISPATCHER="$(ls -d ~/.claude/plugins/cache/*/obsidian-brain/*/scripts/vault_doctor.py 2>/dev/null | tail -1)"
+DISPATCHER="$(ls -dt ~/.claude/plugins/cache/*/obsidian-brain/*/scripts/vault_doctor.py 2>/dev/null | head -1)"
 if [[ -z "$DISPATCHER" ]]; then
     if [[ -f "$(pwd)/scripts/vault_doctor.py" ]]; then
         DISPATCHER="$(pwd)/scripts/vault_doctor.py"

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -60,11 +60,12 @@ Stop here if the dispatcher is missing.
 Always run with `--json` first so you can parse the output deterministically. Pass through only the flags the user provided:
 
 ```bash
-python3 "$DISPATCHER" \
-    ${CHECK:+--check "$CHECK"} \
-    ${DAYS:+--days "$DAYS"} \
-    ${PROJECT:+--project "$PROJECT"} \
-    --json
+ARGS=()
+[[ -n "${CHECK:-}" ]] && ARGS+=(--check "$CHECK")
+[[ -n "${DAYS:-}" ]] && ARGS+=(--days "$DAYS")
+[[ -n "${PROJECT:-}" ]] && ARGS+=(--project "$PROJECT")
+ARGS+=(--json)
+python3 "$DISPATCHER" "${ARGS[@]}"
 ```
 
 Capture stdout as the JSON report. Exit codes:
@@ -122,11 +123,12 @@ If the user DID pass `fix`:
 Re-run the dispatcher with `--apply` (do NOT pass `--yes` — let the dispatcher prompt per project interactively):
 
 ```bash
-python3 "$DISPATCHER" \
-    ${CHECK:+--check "$CHECK"} \
-    ${DAYS:+--days "$DAYS"} \
-    ${PROJECT:+--project "$PROJECT"} \
-    --apply
+ARGS=()
+[[ -n "${CHECK:-}" ]] && ARGS+=(--check "$CHECK")
+[[ -n "${DAYS:-}" ]] && ARGS+=(--days "$DAYS")
+[[ -n "${PROJECT:-}" ]] && ARGS+=(--project "$PROJECT")
+ARGS+=(--apply)
+python3 "$DISPATCHER" "${ARGS[@]}"
 ```
 
 The dispatcher will prompt `Apply N fix(es) for project 'X' in check 'Y'? [y/N]` on stderr for each project. Relay each prompt to the user and pipe their response to the dispatcher's stdin.

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -989,3 +989,88 @@ def test_get_session_id_fast_multiple_cached_matches_tiebreak(tmp_path, monkeypa
     assert result == cached_sid, (
         f"expected cached sid to win via multi-match tiebreaker, got {result}"
     )
+
+
+def test_get_session_id_fast_slow_path_is_readonly(tmp_path, monkeypatch):
+    """Slow path must NOT write to the bootstrap file.
+
+    Regression test for the SessionStart-hook race: the hook writes the
+    authoritative sid, then downstream hook code can trigger
+    _get_session_id_fast() before CC has flushed the new session's JSONL.
+    In that window, the cached_pattern glob misses and the slow path fires.
+    If the slow path writes back to the bootstrap, it clobbers the hook's
+    authoritative write with a stale result.
+    """
+    import obsidian_utils
+    import os
+    import time
+
+    project_basename = "readonly-proj"
+    cc_projects = tmp_path / ".claude" / "projects" / f"-foo-{project_basename}"
+    cc_projects.mkdir(parents=True)
+
+    # Previous session's JSONL exists (what the hook race would find as 'newest')
+    old_jsonl = cc_projects / "old-sid-0000.jsonl"
+    old_jsonl.write_text("{}", encoding="utf-8")
+    os.utime(old_jsonl, (time.time() - 600, time.time() - 600))
+
+    # New session's JSONL does NOT exist yet — this is the race window
+    # (CC hasn't flushed it yet when the hook fires)
+
+    proj_dir = tmp_path / project_basename
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
+
+    # Bootstrap contains the NEW authoritative sid (just written by the hook)
+    bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
+    bootstrap.write_text("new-sid-9999", encoding="utf-8")
+    bootstrap_mtime_before = os.path.getmtime(bootstrap)
+    bootstrap_contents_before = bootstrap.read_text(encoding="utf-8").strip()
+
+    # Trigger _get_session_id_fast: cached JSONL doesn't exist yet, fall
+    # through to slow path which finds old-sid-0000 as newest.
+    result = obsidian_utils._get_session_id_fast()
+
+    # The function may return either value — the return value is not what
+    # we're testing. What matters: the bootstrap file MUST NOT be clobbered.
+    bootstrap_contents_after = bootstrap.read_text(encoding="utf-8").strip()
+    assert bootstrap_contents_after == bootstrap_contents_before, (
+        f"slow path clobbered the bootstrap: before={bootstrap_contents_before!r} "
+        f"after={bootstrap_contents_after!r}"
+    )
+    # And the mtime must be unchanged
+    assert os.path.getmtime(bootstrap) == bootstrap_mtime_before
+
+
+def test_get_session_id_fast_slow_path_returns_without_writing(tmp_path, monkeypatch):
+    """When no bootstrap exists, slow path returns newest sid but creates no bootstrap file."""
+    import obsidian_utils
+    import os
+    import time
+
+    project_basename = "nobootstrap-proj"
+    cc_projects = tmp_path / ".claude" / "projects" / f"-foo-{project_basename}"
+    cc_projects.mkdir(parents=True)
+
+    only_jsonl = cc_projects / "only-sid-abcd.jsonl"
+    only_jsonl.write_text("{}", encoding="utf-8")
+    os.utime(only_jsonl, (time.time() - 60, time.time() - 60))
+
+    proj_dir = tmp_path / project_basename
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
+
+    bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
+    assert not bootstrap.exists()
+
+    result = obsidian_utils._get_session_id_fast()
+    assert result == "only-sid-abcd"
+
+    # Slow path must NOT have created a bootstrap file
+    assert not bootstrap.exists(), (
+        "slow path should be read-only and not create the bootstrap file"
+    )

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -705,3 +705,65 @@ class TestBuildContextBriefSort:
         )
 
         assert "| 1h 0m |" in output
+
+
+def test_get_session_id_fast_rejects_stale_bootstrap(tmp_path, monkeypatch):
+    """Fast path must fall through to slow path when a newer JSONL exists."""
+    import obsidian_utils
+    import os
+    import time
+
+    # Fake ~/.claude/projects/<project>/ with two JSONL files
+    project_basename = "fake-proj-abc"
+    cc_projects = tmp_path / ".claude" / "projects" / f"-foo-{project_basename}"
+    cc_projects.mkdir(parents=True)
+
+    old_jsonl = cc_projects / "old-sid-0000.jsonl"
+    new_jsonl = cc_projects / "new-sid-9999.jsonl"
+    old_jsonl.write_text("{}", encoding="utf-8")
+    new_jsonl.write_text("{}", encoding="utf-8")
+    os.utime(old_jsonl, (time.time() - 7200, time.time() - 7200))
+    os.utime(new_jsonl, (time.time() - 60, time.time() - 60))
+
+    proj_dir = tmp_path / project_basename
+    proj_dir.mkdir(exist_ok=True)
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
+    bootstrap.write_text("old-sid-0000", encoding="utf-8")
+    os.utime(bootstrap, (time.time() - 3600, time.time() - 3600))
+
+    monkeypatch.setattr(obsidian_utils, "_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
+
+    result = obsidian_utils._get_session_id_fast()
+    assert result == "new-sid-9999", f"expected newest sid, got {result}"
+
+
+def test_get_session_id_fast_trusts_fresh_bootstrap(tmp_path, monkeypatch):
+    """Fast path must return bootstrap sid when bootstrap is newer than all JSONLs."""
+    import obsidian_utils
+    import os
+    import time
+
+    project_basename = "fresh-proj-xyz"
+    cc_projects = tmp_path / ".claude" / "projects" / f"-foo-{project_basename}"
+    cc_projects.mkdir(parents=True)
+
+    jsonl = cc_projects / "fresh-sid-1234.jsonl"
+    jsonl.write_text("{}", encoding="utf-8")
+    os.utime(jsonl, (time.time() - 3600, time.time() - 3600))
+
+    proj_dir = tmp_path / project_basename
+    proj_dir.mkdir(exist_ok=True)
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
+    bootstrap.write_text("fresh-sid-1234", encoding="utf-8")
+    os.utime(bootstrap, (time.time() - 60, time.time() - 60))
+
+    monkeypatch.setattr(obsidian_utils, "_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
+
+    result = obsidian_utils._get_session_id_fast()
+    assert result == "fresh-sid-1234"

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -726,7 +726,7 @@ def test_get_session_id_fast_rejects_stale_bootstrap(tmp_path, monkeypatch):
     os.utime(new_jsonl, (time.time() - 60, time.time() - 60))
 
     proj_dir = tmp_path / project_basename
-    proj_dir.mkdir(exist_ok=True)
+    proj_dir.mkdir()
     monkeypatch.chdir(proj_dir)
     monkeypatch.setenv("HOME", str(tmp_path))
 
@@ -755,7 +755,7 @@ def test_get_session_id_fast_trusts_fresh_bootstrap(tmp_path, monkeypatch):
     os.utime(jsonl, (time.time() - 3600, time.time() - 3600))
 
     proj_dir = tmp_path / project_basename
-    proj_dir.mkdir(exist_ok=True)
+    proj_dir.mkdir()
     monkeypatch.chdir(proj_dir)
     monkeypatch.setenv("HOME", str(tmp_path))
 

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -767,3 +767,109 @@ def test_get_session_id_fast_trusts_fresh_bootstrap(tmp_path, monkeypatch):
 
     result = obsidian_utils._get_session_id_fast()
     assert result == "fresh-sid-1234"
+
+
+def test_check_hook_status_matches(tmp_path, monkeypatch):
+    """check_hook_status returns ok=True when bootstrap matches current sid."""
+    import obsidian_utils
+    import os
+
+    project_basename = "stat-proj"
+    cc_projects = tmp_path / ".claude" / "projects" / f"-foo-{project_basename}"
+    cc_projects.mkdir(parents=True)
+    jsonl = cc_projects / "live-sid-1111.jsonl"
+    jsonl.write_text("{}", encoding="utf-8")
+
+    proj_dir = tmp_path / project_basename
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    bootstrap_prefix = str(tmp_path / ".obsidian-brain-sid-")
+    monkeypatch.setattr(obsidian_utils, "_BOOTSTRAP_PREFIX", bootstrap_prefix)
+    bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
+    bootstrap.write_text("live-sid-1111", encoding="utf-8")
+    # Make bootstrap newer than the JSONL so the fast path trusts it
+    import time
+    os.utime(jsonl, (time.time() - 3600, time.time() - 3600))
+    os.utime(bootstrap, (time.time() - 60, time.time() - 60))
+
+    status = obsidian_utils.check_hook_status()
+    assert status["ok"] is True
+    assert status["bootstrap_sid"] == "live-sid-1111"
+    assert status["current_sid"] == "live-sid-1111"
+
+
+def test_check_hook_status_missing_bootstrap(tmp_path, monkeypatch):
+    """check_hook_status returns ok=False when bootstrap file is absent."""
+    import obsidian_utils
+
+    project_basename = "missing-proj"
+    cc_projects = tmp_path / ".claude" / "projects" / f"-foo-{project_basename}"
+    cc_projects.mkdir(parents=True)
+    (cc_projects / "sid-xxxx.jsonl").write_text("{}", encoding="utf-8")
+
+    proj_dir = tmp_path / project_basename
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    monkeypatch.setattr(
+        obsidian_utils, "_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-")
+    )
+
+    status = obsidian_utils.check_hook_status()
+    assert status["ok"] is False
+    assert "missing" in status["message"]
+
+
+def test_build_context_brief_prepends_hook_status(tmp_path):
+    """build_context_brief prepends the hook_status_line when provided."""
+    import obsidian_utils
+
+    vault = tmp_path / "vault"
+    (vault / "sessions").mkdir(parents=True)
+    (vault / "insights").mkdir(parents=True)
+
+    status_line = "✓ SessionStart hook fired; bootstrap matches current session"
+    output = obsidian_utils.build_context_brief(
+        str(vault),
+        "sessions",
+        "insights",
+        "nonexistent-project",
+        hook_status_line=status_line,
+    )
+
+    # Extract the CONTEXT_BRIEF section and verify the first content line
+    # is the status line, appearing before the "## Project Context" header.
+    assert "<<<OB_CONTEXT_BRIEF>>>" in output
+    brief_section = output.split("<<<OB_CONTEXT_BRIEF>>>", 1)[1].split("<<<OB_LOAD_MANIFEST>>>", 1)[0]
+    brief_lines = [ln for ln in brief_section.split("\n") if ln.strip()]
+    assert brief_lines[0] == status_line
+    # Header should still exist after the status line
+    assert any(ln.startswith("## Project Context") for ln in brief_lines)
+    # Ensure the status line appears BEFORE the header
+    status_idx = brief_lines.index(status_line)
+    header_idx = next(i for i, ln in enumerate(brief_lines) if ln.startswith("## Project Context"))
+    assert status_idx < header_idx
+
+
+def test_build_context_brief_without_hook_status(tmp_path):
+    """build_context_brief omits the status line when not provided (default)."""
+    import obsidian_utils
+
+    vault = tmp_path / "vault"
+    (vault / "sessions").mkdir(parents=True)
+    (vault / "insights").mkdir(parents=True)
+
+    output = obsidian_utils.build_context_brief(
+        str(vault),
+        "sessions",
+        "insights",
+        "nonexistent-project",
+    )
+
+    brief_section = output.split("<<<OB_CONTEXT_BRIEF>>>", 1)[1].split("<<<OB_LOAD_MANIFEST>>>", 1)[0]
+    brief_lines = [ln for ln in brief_section.split("\n") if ln.strip()]
+    # First non-empty line should be the Project Context header, not a status line
+    assert brief_lines[0].startswith("## Project Context")

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -769,6 +769,39 @@ def test_get_session_id_fast_trusts_fresh_bootstrap(tmp_path, monkeypatch):
     assert result == "fresh-sid-1234"
 
 
+def test_get_session_id_fast_invalidates_when_cached_jsonl_deleted(tmp_path, monkeypatch):
+    """Bootstrap points at a sid whose JSONL has been removed — slow path picks newest survivor."""
+    import obsidian_utils
+    import os
+    import time
+
+    project_basename = "deleted-proj"
+    cc_projects = tmp_path / ".claude" / "projects" / f"-foo-{project_basename}"
+    cc_projects.mkdir(parents=True)
+
+    # Create only the "surviving" JSONL; the cached one in the bootstrap doesn't exist on disk
+    survivor = cc_projects / "survivor-sid-ffff.jsonl"
+    survivor.write_text("{}", encoding="utf-8")
+    os.utime(survivor, (time.time() - 60, time.time() - 60))
+
+    proj_dir = tmp_path / project_basename
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
+    bootstrap.write_text("deleted-sid-0000", encoding="utf-8")
+
+    monkeypatch.setattr(
+        obsidian_utils, "_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-")
+    )
+
+    result = obsidian_utils._get_session_id_fast()
+    assert result == "survivor-sid-ffff", (
+        f"expected fast path to fall through and return newest survivor, got {result}"
+    )
+
+
 def test_check_hook_status_matches(tmp_path, monkeypatch):
     """check_hook_status returns ok=True when bootstrap matches current sid."""
     import obsidian_utils

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -943,3 +943,49 @@ def test_get_session_id_fast_same_second_tiebreaker(tmp_path, monkeypatch):
     assert result == "aaa-previous", (
         f"expected cached sid to win same-mtime tie, got {result}"
     )
+
+
+def test_get_session_id_fast_multiple_cached_matches_tiebreak(tmp_path, monkeypatch):
+    """When multiple project dirs contain the cached sid's JSONL, at least one
+    must tie the newest mtime for the cache to be trusted."""
+    import obsidian_utils
+    import os
+    import time
+
+    project_basename = "multi-proj"
+    # Two project-dir variants (like worktrees)
+    dir_a = tmp_path / ".claude" / "projects" / f"-alpha-{project_basename}"
+    dir_b = tmp_path / ".claude" / "projects" / f"-beta-{project_basename}"
+    dir_a.mkdir(parents=True)
+    dir_b.mkdir(parents=True)
+
+    cached_sid = "shared-sid-1234"
+    # Put the cached sid's jsonl in BOTH project dirs
+    a_jsonl = dir_a / f"{cached_sid}.jsonl"
+    b_jsonl = dir_b / f"{cached_sid}.jsonl"
+    other_jsonl = dir_b / "other-sid-5678.jsonl"
+    a_jsonl.write_text("{}", encoding="utf-8")
+    b_jsonl.write_text("{}", encoding="utf-8")
+    other_jsonl.write_text("{}", encoding="utf-8")
+
+    # Scenario: a_jsonl is OLDER, b_jsonl matches newest mtime, other_jsonl
+    # is also at newest mtime. Tiebreaker MUST trust the cache because
+    # at least one cached match (b_jsonl) ties newest mtime.
+    now = time.time()
+    os.utime(a_jsonl, (now - 3600, now - 3600))  # old
+    os.utime(b_jsonl, (now, now))  # tied with other
+    os.utime(other_jsonl, (now, now))  # tied with b
+
+    proj_dir = tmp_path / project_basename
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
+
+    bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
+    bootstrap.write_text(cached_sid, encoding="utf-8")
+
+    result = obsidian_utils._get_session_id_fast()
+    assert result == cached_sid, (
+        f"expected cached sid to win via multi-match tiebreaker, got {result}"
+    )

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -906,3 +906,40 @@ def test_build_context_brief_without_hook_status(tmp_path):
     brief_lines = [ln for ln in brief_section.split("\n") if ln.strip()]
     # First non-empty line should be the Project Context header, not a status line
     assert brief_lines[0].startswith("## Project Context")
+
+
+def test_get_session_id_fast_same_second_tiebreaker(tmp_path, monkeypatch):
+    """Same-second mtime ties: cached sid wins when its JSONL is tied for newest."""
+    import obsidian_utils
+    import os
+    import time
+
+    project_basename = "tie-proj"
+    cc_projects = tmp_path / ".claude" / "projects" / f"-foo-{project_basename}"
+    cc_projects.mkdir(parents=True)
+
+    # Two JSONLs with IDENTICAL mtimes
+    now = time.time()
+    old_jsonl = cc_projects / "aaa-previous.jsonl"
+    current_jsonl = cc_projects / "zzz-current.jsonl"
+    old_jsonl.write_text("{}", encoding="utf-8")
+    current_jsonl.write_text("{}", encoding="utf-8")
+    os.utime(old_jsonl, (now, now))
+    os.utime(current_jsonl, (now, now))
+
+    proj_dir = tmp_path / project_basename
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
+
+    # Bootstrap claims "aaa-previous" is current. Because path-sort tiebreak
+    # would otherwise pick "zzz-current" (lexicographically larger) as the
+    # newest, the cached sid must win via the same-mtime tie-breaker.
+    bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
+    bootstrap.write_text("aaa-previous", encoding="utf-8")
+
+    result = obsidian_utils._get_session_id_fast()
+    assert result == "aaa-previous", (
+        f"expected cached sid to win same-mtime tie, got {result}"
+    )

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -831,7 +831,7 @@ def test_build_context_brief_prepends_hook_status(tmp_path):
     (vault / "sessions").mkdir(parents=True)
     (vault / "insights").mkdir(parents=True)
 
-    status_line = "✓ SessionStart hook fired; bootstrap matches current session"
+    status_line = "[OK] SessionStart hook fired; bootstrap matches current session"
     output = obsidian_utils.build_context_brief(
         str(vault),
         "sessions",

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -734,7 +734,7 @@ def test_get_session_id_fast_rejects_stale_bootstrap(tmp_path, monkeypatch):
     bootstrap.write_text("old-sid-0000", encoding="utf-8")
     os.utime(bootstrap, (time.time() - 3600, time.time() - 3600))
 
-    monkeypatch.setattr(obsidian_utils, "_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
 
     result = obsidian_utils._get_session_id_fast()
     assert result == "new-sid-9999", f"expected newest sid, got {result}"
@@ -763,7 +763,7 @@ def test_get_session_id_fast_trusts_fresh_bootstrap(tmp_path, monkeypatch):
     bootstrap.write_text("fresh-sid-1234", encoding="utf-8")
     os.utime(bootstrap, (time.time() - 60, time.time() - 60))
 
-    monkeypatch.setattr(obsidian_utils, "_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-"))
 
     result = obsidian_utils._get_session_id_fast()
     assert result == "fresh-sid-1234"
@@ -792,8 +792,8 @@ def test_get_session_id_fast_invalidates_when_cached_jsonl_deleted(tmp_path, mon
     bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
     bootstrap.write_text("deleted-sid-0000", encoding="utf-8")
 
-    monkeypatch.setattr(
-        obsidian_utils, "_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-")
+    monkeypatch.setenv(
+        "OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-")
     )
 
     result = obsidian_utils._get_session_id_fast()
@@ -819,7 +819,7 @@ def test_check_hook_status_matches(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
 
     bootstrap_prefix = str(tmp_path / ".obsidian-brain-sid-")
-    monkeypatch.setattr(obsidian_utils, "_BOOTSTRAP_PREFIX", bootstrap_prefix)
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", bootstrap_prefix)
     bootstrap = tmp_path / f".obsidian-brain-sid-{project_basename}"
     bootstrap.write_text("live-sid-1111", encoding="utf-8")
     # Make bootstrap newer than the JSONL so the fast path trusts it
@@ -847,8 +847,8 @@ def test_check_hook_status_missing_bootstrap(tmp_path, monkeypatch):
     monkeypatch.chdir(proj_dir)
     monkeypatch.setenv("HOME", str(tmp_path))
 
-    monkeypatch.setattr(
-        obsidian_utils, "_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-")
+    monkeypatch.setenv(
+        "OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / ".obsidian-brain-sid-")
     )
 
     status = obsidian_utils.check_hook_status()

--- a/tests/test_session_hint_bootstrap.py
+++ b/tests/test_session_hint_bootstrap.py
@@ -1,0 +1,210 @@
+"""Tests for bootstrap-file refresh in obsidian_session_hint hook."""
+
+import importlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Make the hooks module importable for in-process tests.
+_HOOKS_DIR = str(Path(__file__).parent.parent / "hooks")
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+
+def _hook_script_path() -> str:
+    return str(Path(__file__).parent.parent / "hooks" / "obsidian_session_hint.py")
+
+
+def _import_hook_module():
+    """Import obsidian_session_hint fresh so env vars take effect."""
+    if "obsidian_session_hint" in sys.modules:
+        return importlib.reload(sys.modules["obsidian_session_hint"])
+    return importlib.import_module("obsidian_session_hint")
+
+
+def test_hook_writes_bootstrap_file(tmp_path):
+    """Hook writes the authoritative session_id to the bootstrap file."""
+    project_dir = tmp_path / "fake-project"
+    project_dir.mkdir()
+    bootstrap_path = tmp_path / ".obsidian-brain-sid-fake-project"
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX"] = str(tmp_path / ".obsidian-brain-sid-")
+
+    payload = {
+        "cwd": str(project_dir),
+        "session_id": "test-sid-aaaaaaaa",
+    }
+    result = subprocess.run(
+        [sys.executable, _hook_script_path()],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, f"hook exited {result.returncode}: {result.stderr}"
+    assert bootstrap_path.exists(), "bootstrap file was not written"
+    assert bootstrap_path.read_text(encoding="utf-8").strip() == "test-sid-aaaaaaaa"
+
+
+def test_hook_handles_missing_session_id(tmp_path):
+    """Hook does not crash when stdin JSON omits session_id and does not write bootstrap."""
+    project_dir = tmp_path / "proj-nosid"
+    project_dir.mkdir()
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX"] = str(tmp_path / ".obsidian-brain-sid-")
+
+    payload = {"cwd": str(project_dir)}  # no session_id
+    result = subprocess.run(
+        [sys.executable, _hook_script_path()],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, f"hook exited {result.returncode}: {result.stderr}"
+    bootstrap_path = tmp_path / ".obsidian-brain-sid-proj-nosid"
+    assert not bootstrap_path.exists(), "bootstrap should not be written without session_id"
+
+
+def test_hook_writes_log_line(tmp_path):
+    """Hook appends an audit line to ~/.claude/obsidian-brain-hook.log."""
+    project_dir = tmp_path / "proj-log"
+    project_dir.mkdir()
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX"] = str(tmp_path / ".obsidian-brain-sid-")
+
+    payload = {"cwd": str(project_dir), "session_id": "log-sid-bbbb"}
+    result = subprocess.run(
+        [sys.executable, _hook_script_path()],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, f"hook exited {result.returncode}: {result.stderr}"
+
+    log_path = claude_dir / "obsidian-brain-hook.log"
+    assert log_path.exists(), "hook log was not written"
+    content = log_path.read_text(encoding="utf-8")
+    assert "SessionStart" in content
+    assert "proj-log" in content
+    assert "log-sid-" in content
+    assert "bootstrap_updated=true" in content
+
+
+def test_hook_log_rotates_when_large(tmp_path):
+    """Hook rotates the log file when it exceeds ~100 KB."""
+    project_dir = tmp_path / "proj-rotate"
+    project_dir.mkdir()
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    log_path = claude_dir / "obsidian-brain-hook.log"
+    log_path.write_text("x" * (150 * 1024), encoding="utf-8")
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX"] = str(tmp_path / ".obsidian-brain-sid-")
+
+    payload = {"cwd": str(project_dir), "session_id": "rot-sid-cccc"}
+    subprocess.run(
+        [sys.executable, _hook_script_path()],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    rotated = claude_dir / "obsidian-brain-hook.log.1"
+    assert rotated.exists(), "log should have been rotated to .log.1"
+    assert "rot-sid-" in log_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# In-process unit tests for the helper functions (for coverage).
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_prefix_default(monkeypatch):
+    monkeypatch.delenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", raising=False)
+    mod = _import_hook_module()
+    assert mod._bootstrap_prefix() == "/tmp/.obsidian-brain-sid-"
+
+
+def test_bootstrap_prefix_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / "pref-"))
+    mod = _import_hook_module()
+    assert mod._bootstrap_prefix() == str(tmp_path / "pref-")
+
+
+def test_write_bootstrap_atomic_success(monkeypatch, tmp_path):
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(tmp_path / ".sid-"))
+    mod = _import_hook_module()
+    assert mod._write_bootstrap_atomic("proj1", "sid-123") is True
+    target = tmp_path / ".sid-proj1"
+    assert target.read_text(encoding="utf-8") == "sid-123"
+
+
+def test_write_bootstrap_atomic_failure(monkeypatch, tmp_path, capsys):
+    # Point to an unwritable location inside a file (not a dir) to force OSError.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+    monkeypatch.setenv("OBSIDIAN_BRAIN_BOOTSTRAP_PREFIX", str(blocker / "child-"))
+    mod = _import_hook_module()
+    assert mod._write_bootstrap_atomic("proj2", "sid-456") is False
+    err = capsys.readouterr().err
+    assert "bootstrap write failed" in err
+
+
+def test_append_hook_log_creates_file(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mod = _import_hook_module()
+    mod._append_hook_log("projA", "sid-abcdefgh", True)
+    log_path = tmp_path / ".claude" / "obsidian-brain-hook.log"
+    assert log_path.exists()
+    content = log_path.read_text(encoding="utf-8")
+    assert "SessionStart" in content
+    assert "project=projA" in content
+    assert "sid=sid-abcd" in content  # truncated to 8 chars
+    assert "bootstrap_updated=true" in content
+
+
+def test_append_hook_log_false_flag(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    mod = _import_hook_module()
+    mod._append_hook_log("projB", "", False)
+    log_path = tmp_path / ".claude" / "obsidian-brain-hook.log"
+    content = log_path.read_text(encoding="utf-8")
+    assert "sid=unknown" in content
+    assert "bootstrap_updated=false" in content
+
+
+def test_append_hook_log_rotates(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    log_path = claude_dir / "obsidian-brain-hook.log"
+    log_path.write_text("y" * (150 * 1024), encoding="utf-8")
+    mod = _import_hook_module()
+    mod._append_hook_log("projC", "sid-rotate1", True)
+    assert (claude_dir / "obsidian-brain-hook.log.1").exists()
+    assert "projC" in log_path.read_text(encoding="utf-8")
+
+
+def test_append_hook_log_handles_oserror(monkeypatch, tmp_path, capsys):
+    # Point HOME at a non-writable file so os.makedirs fails.
+    blocker = tmp_path / "notadir"
+    blocker.write_text("blocker", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(blocker))
+    mod = _import_hook_module()
+    mod._append_hook_log("projD", "sid-xyz", False)
+    err = capsys.readouterr().err
+    assert "hook log append failed" in err

--- a/tests/test_session_log.py
+++ b/tests/test_session_log.py
@@ -96,15 +96,15 @@ class TestBuildNote:
 
 
 def test_cleanup_session_cache_removes_file(tmp_path, monkeypatch):
-    """_cleanup_session_cache removes /tmp/.ob-cache-<sid>.json for the ended session."""
+    """_cleanup_session_cache removes /tmp/.obsidian-brain-cache-<sid>.json for the ended session."""
     import obsidian_utils
     from pathlib import Path
 
     sid = "cleanup-sid-9999"
-    cache_path = tmp_path / f".ob-cache-{sid}.json"
+    cache_path = tmp_path / f".obsidian-brain-cache-{sid}.json"
     cache_path.write_text("{}", encoding="utf-8")
 
-    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / ".ob-cache-"))
+    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / ".obsidian-brain-cache-"))
 
     # Import the session_log module (it lives in hooks/ which is on sys.path via conftest)
     import importlib.util
@@ -124,7 +124,7 @@ def test_cleanup_session_cache_handles_missing_file(tmp_path, monkeypatch):
     import obsidian_utils
     from pathlib import Path
 
-    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / ".ob-cache-"))
+    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / ".obsidian-brain-cache-"))
 
     import importlib.util
     spec = importlib.util.spec_from_file_location(
@@ -144,10 +144,10 @@ def test_cleanup_session_cache_empty_sid_noop(tmp_path, monkeypatch):
     from pathlib import Path
 
     # Create a file that would match an empty-sid pattern to make sure we DON'T touch it
-    canary = tmp_path / ".ob-cache-.json"
+    canary = tmp_path / ".obsidian-brain-cache-.json"
     canary.write_text("{}", encoding="utf-8")
 
-    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / ".ob-cache-"))
+    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / ".obsidian-brain-cache-"))
 
     import importlib.util
     spec = importlib.util.spec_from_file_location(

--- a/tests/test_session_log.py
+++ b/tests/test_session_log.py
@@ -93,3 +93,69 @@ class TestBuildNote:
 
         # Must have title
         assert "# Session: x" in result
+
+
+def test_cleanup_session_cache_removes_file(tmp_path, monkeypatch):
+    """_cleanup_session_cache removes /tmp/.ob-cache-<sid>.json for the ended session."""
+    import obsidian_utils
+    from pathlib import Path
+
+    sid = "cleanup-sid-9999"
+    cache_path = tmp_path / f".ob-cache-{sid}.json"
+    cache_path.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / ".ob-cache-"))
+
+    # Import the session_log module (it lives in hooks/ which is on sys.path via conftest)
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "obsidian_session_log",
+        str(Path(__file__).parent.parent / "hooks" / "obsidian_session_log.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mod._cleanup_session_cache(sid)
+    assert not cache_path.exists(), "cache file should have been removed"
+
+
+def test_cleanup_session_cache_handles_missing_file(tmp_path, monkeypatch):
+    """_cleanup_session_cache is a no-op when the cache file doesn't exist."""
+    import obsidian_utils
+    from pathlib import Path
+
+    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / ".ob-cache-"))
+
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "obsidian_session_log",
+        str(Path(__file__).parent.parent / "hooks" / "obsidian_session_log.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    # Should not raise even when the file doesn't exist
+    mod._cleanup_session_cache("nonexistent-sid")
+
+
+def test_cleanup_session_cache_empty_sid_noop(tmp_path, monkeypatch):
+    """_cleanup_session_cache with empty sid does nothing."""
+    import obsidian_utils
+    from pathlib import Path
+
+    # Create a file that would match an empty-sid pattern to make sure we DON'T touch it
+    canary = tmp_path / ".ob-cache-.json"
+    canary.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / ".ob-cache-"))
+
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "obsidian_session_log",
+        str(Path(__file__).parent.parent / "hooks" / "obsidian_session_log.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    mod._cleanup_session_cache("")
+    assert canary.exists(), "empty sid should not touch any files"

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -1,0 +1,43 @@
+"""Tests for scripts/vault_doctor.py and the check registry."""
+
+import importlib
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+def test_registry_lists_source_sessions_check():
+    """The registry auto-discovers the source_sessions check module."""
+    import vault_doctor_checks
+    importlib.reload(vault_doctor_checks)
+    names = vault_doctor_checks.list_checks()
+    assert "source-sessions" in names
+
+
+def test_issue_and_result_dataclasses_importable():
+    """Shared Issue and Result types are importable from the registry."""
+    from vault_doctor_checks import Issue, Result
+    issue = Issue(
+        check="source-sessions",
+        note_path="/tmp/foo.md",
+        project="testproj",
+        current_source="[[old]]",
+        proposed_source="[[new]]",
+        reason="mtime falls inside different session window",
+        confidence=0.95,
+    )
+    assert issue.check == "source-sessions"
+    assert issue.confidence == 0.95
+    assert issue.extra == {}  # default empty dict
+
+    result = Result(
+        check="source-sessions",
+        note_path="/tmp/foo.md",
+        status="applied",
+        backup_path="/tmp/backup/foo.md",
+        error=None,
+    )
+    assert result.status == "applied"
+    assert result.backup_path == "/tmp/backup/foo.md"

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -45,7 +45,7 @@ def test_issue_and_result_dataclasses_importable():
 
 def test_cli_dry_run_reports_issues(tmp_path):
     """vault_doctor.py --check source-sessions reports without applying."""
-    import subprocess, json, sys, os, time, calendar, json as _json
+    import subprocess, json, sys, os, time, calendar
     from pathlib import Path
 
     vault = tmp_path / "vault"
@@ -56,7 +56,7 @@ def test_cli_dry_run_reports_issues(tmp_path):
 
     b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
     (claude_home / "sid-b.jsonl").write_text(
-        _json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
         encoding="utf-8",
     )
     os.utime(claude_home / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
@@ -97,7 +97,7 @@ def test_cli_dry_run_reports_issues(tmp_path):
 
 def test_cli_apply_with_yes(tmp_path):
     """vault_doctor.py --apply --yes patches the file non-interactively."""
-    import subprocess, json, sys, os, time, calendar, json as _json
+    import subprocess, json, sys, os, time, calendar
     from pathlib import Path
 
     vault = tmp_path / "vault"
@@ -108,7 +108,7 @@ def test_cli_apply_with_yes(tmp_path):
 
     b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
     (claude_home / "sid-b.jsonl").write_text(
-        _json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
         encoding="utf-8",
     )
     os.utime(claude_home / "sid-b.jsonl", (b_start + 3600, b_start + 3600))

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -41,3 +41,148 @@ def test_issue_and_result_dataclasses_importable():
     )
     assert result.status == "applied"
     assert result.backup_path == "/tmp/backup/foo.md"
+
+
+def test_cli_dry_run_reports_issues(tmp_path):
+    """vault_doctor.py --check source-sessions reports without applying."""
+    import subprocess, json, sys, os, time, json as _json
+    from pathlib import Path
+
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+    claude_home = tmp_path / ".claude" / "projects" / "-x-proj1"
+    claude_home.mkdir(parents=True)
+
+    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    (claude_home / "sid-b.jsonl").write_text(
+        _json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    os.utime(claude_home / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
+
+    (vault / "claude-sessions" / "2026-04-10-proj1-bbbb.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\nproject: proj1\nstatus: summarized\n---\n# s\n",
+        encoding="utf-8",
+    )
+    insight = vault / "claude-insights" / "2026-04-10-stale.md"
+    insight.write_text(
+        '---\ntype: claude-insight\ndate: 2026-04-10\nsource_session: sid-a\nsource_session_note: "[[2026-04-09-proj1-aaaa]]"\nproject: proj1\n---\n# x\n',
+        encoding="utf-8",
+    )
+    os.utime(insight, (b_start + 1800, b_start + 1800))
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["OBSIDIAN_BRAIN_VAULT"] = str(vault)
+    env["OBSIDIAN_BRAIN_SESSIONS_FOLDER"] = "claude-sessions"
+    env["OBSIDIAN_BRAIN_INSIGHTS_FOLDER"] = "claude-insights"
+
+    script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+         "--project", "proj1", "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 1, f"expected exit 1 (issues found), got {result.returncode}: {result.stderr}"
+    payload = json.loads(result.stdout)
+    assert payload["total_issues"] >= 1
+    assert any(i["check"] == "source-sessions" for i in payload["issues"])
+    # File was NOT modified (dry-run default)
+    assert "source_session: sid-a" in insight.read_text(encoding="utf-8")
+
+
+def test_cli_apply_with_yes(tmp_path):
+    """vault_doctor.py --apply --yes patches the file non-interactively."""
+    import subprocess, json, sys, os, time, json as _json
+    from pathlib import Path
+
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+    claude_home = tmp_path / ".claude" / "projects" / "-x-proj1"
+    claude_home.mkdir(parents=True)
+
+    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    (claude_home / "sid-b.jsonl").write_text(
+        _json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    os.utime(claude_home / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
+
+    (vault / "claude-sessions" / "2026-04-10-proj1-bbbb.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\nproject: proj1\nstatus: summarized\n---\n# s\n",
+        encoding="utf-8",
+    )
+    insight = vault / "claude-insights" / "2026-04-10-apply.md"
+    insight.write_text(
+        '---\ntype: claude-insight\ndate: 2026-04-10\nsource_session: sid-a\nsource_session_note: "[[2026-04-09-proj1-aaaa]]"\nproject: proj1\n---\n# x\n',
+        encoding="utf-8",
+    )
+    os.utime(insight, (b_start + 1800, b_start + 1800))
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["OBSIDIAN_BRAIN_VAULT"] = str(vault)
+    env["OBSIDIAN_BRAIN_SESSIONS_FOLDER"] = "claude-sessions"
+    env["OBSIDIAN_BRAIN_INSIGHTS_FOLDER"] = "claude-insights"
+
+    script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+         "--project", "proj1", "--apply", "--yes"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 1, f"expected exit 1 after successful apply, got {result.returncode}: {result.stderr}"
+    patched = insight.read_text(encoding="utf-8")
+    assert "source_session: sid-b" in patched
+    assert 'source_session_note: "[[2026-04-10-proj1-bbbb]]"' in patched
+
+
+def test_cli_unknown_check_errors(tmp_path):
+    """Unknown --check name returns exit code 3."""
+    import subprocess, sys, os
+    from pathlib import Path
+
+    env = os.environ.copy()
+    env["OBSIDIAN_BRAIN_VAULT"] = str(tmp_path)
+
+    script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--check", "nonexistent-check", "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 3, f"expected exit 3, got {result.returncode}"
+
+
+def test_cli_missing_vault_errors(tmp_path, monkeypatch):
+    """Missing vault config → exit 3."""
+    import subprocess, sys, os
+    from pathlib import Path
+
+    env = os.environ.copy()
+    env.pop("OBSIDIAN_BRAIN_VAULT", None)
+    # Point HOME at tmp_path so load_config() can't find a real config file.
+    # Run cwd from tmp_path so the per-project session cache in /tmp doesn't
+    # collide with a cache entry from the real obsidian-brain project.
+    env["HOME"] = str(tmp_path)
+    isolated_cwd = tmp_path / "isolated-project-xyz"
+    isolated_cwd.mkdir()
+
+    script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(isolated_cwd),
+    )
+    assert result.returncode == 3, f"expected exit 3, got {result.returncode}: {result.stderr}"

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -45,7 +45,7 @@ def test_issue_and_result_dataclasses_importable():
 
 def test_cli_dry_run_reports_issues(tmp_path):
     """vault_doctor.py --check source-sessions reports without applying."""
-    import subprocess, json, sys, os, time, json as _json
+    import subprocess, json, sys, os, time, calendar, json as _json
     from pathlib import Path
 
     vault = tmp_path / "vault"
@@ -54,7 +54,7 @@ def test_cli_dry_run_reports_issues(tmp_path):
     claude_home = tmp_path / ".claude" / "projects" / "-x-proj1"
     claude_home.mkdir(parents=True)
 
-    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
     (claude_home / "sid-b.jsonl").write_text(
         _json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
         encoding="utf-8",
@@ -97,7 +97,7 @@ def test_cli_dry_run_reports_issues(tmp_path):
 
 def test_cli_apply_with_yes(tmp_path):
     """vault_doctor.py --apply --yes patches the file non-interactively."""
-    import subprocess, json, sys, os, time, json as _json
+    import subprocess, json, sys, os, time, calendar, json as _json
     from pathlib import Path
 
     vault = tmp_path / "vault"
@@ -106,7 +106,7 @@ def test_cli_apply_with_yes(tmp_path):
     claude_home = tmp_path / ".claude" / "projects" / "-x-proj1"
     claude_home.mkdir(parents=True)
 
-    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
     (claude_home / "sid-b.jsonl").write_text(
         _json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
         encoding="utf-8",

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -1,5 +1,6 @@
 """End-to-end integration test for /vault-doctor source-sessions flow."""
 
+import calendar
 import json
 import os
 import subprocess
@@ -21,8 +22,8 @@ def test_end_to_end_scan_apply_verify(tmp_path):
     cc_projects.mkdir(parents=True)
 
     # Two sessions on different days
-    a_start = time.mktime(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
-    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
 
     (cc_projects / "sid-a.jsonl").write_text(
         json.dumps({"type": "user", "timestamp": "2026-04-09T10:00:00Z"}) + "\n",

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -1,0 +1,125 @@
+"""End-to-end integration test for /vault-doctor source-sessions flow."""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def test_end_to_end_scan_apply_verify(tmp_path):
+    """Full flow: seed vault → scan → apply → verify fixes and backups."""
+    # --- Build vault ---
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+
+    # --- JSONL home for project ---
+    home = tmp_path
+    cc_projects = home / ".claude" / "projects" / "-Users-foo-proj1"
+    cc_projects.mkdir(parents=True)
+
+    # Two sessions on different days
+    a_start = time.mktime(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+
+    (cc_projects / "sid-a.jsonl").write_text(
+        json.dumps({"type": "user", "timestamp": "2026-04-09T10:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    os.utime(cc_projects / "sid-a.jsonl", (a_start + 3600, a_start + 3600))
+    (cc_projects / "sid-b.jsonl").write_text(
+        json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    os.utime(cc_projects / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
+
+    # Session notes
+    (vault / "claude-sessions" / "2026-04-09-proj1-aaaa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-09\nsession_id: sid-a\nproject: proj1\nstatus: summarized\n---\n# s\n",
+        encoding="utf-8",
+    )
+    (vault / "claude-sessions" / "2026-04-10-proj1-bbbb.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\nproject: proj1\nstatus: summarized\n---\n# s\n",
+        encoding="utf-8",
+    )
+
+    # Stale insight (captured in session B but stamped with session A)
+    insight = vault / "claude-insights" / "2026-04-10-stale-e2e.md"
+    insight.write_text(
+        '---\n'
+        'type: claude-insight\n'
+        'date: 2026-04-10\n'
+        'source_session: sid-a\n'
+        'source_session_note: "[[2026-04-09-proj1-aaaa]]"\n'
+        'project: proj1\n'
+        'tags:\n'
+        '  - claude/insight\n'
+        '  - claude/project/proj1\n'
+        '---\n'
+        '\n'
+        '# body unchanged\n'
+        '\n'
+        'paragraph with [[2026-04-09-proj1-aaaa]] in body\n',
+        encoding="utf-8",
+    )
+    os.utime(insight, (b_start + 1800, b_start + 1800))
+    original_text = insight.read_text(encoding="utf-8")
+    original_body = original_text.split("---\n", 2)[-1]
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["OBSIDIAN_BRAIN_VAULT"] = str(vault)
+    env["OBSIDIAN_BRAIN_SESSIONS_FOLDER"] = "claude-sessions"
+    env["OBSIDIAN_BRAIN_INSIGHTS_FOLDER"] = "claude-insights"
+
+    script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
+
+    # --- 1. Dry-run → exit 1, file untouched ---
+    r = subprocess.run(
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+         "--project", "proj1", "--json"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 1, f"dry-run exit: expected 1, got {r.returncode}: {r.stderr}"
+    payload = json.loads(r.stdout)
+    assert payload["total_issues"] == 1
+    assert payload["issues"][0]["check"] == "source-sessions"
+    assert payload["issues"][0]["project"] == "proj1"
+    assert insight.read_text(encoding="utf-8") == original_text, "dry-run must not modify the file"
+
+    # --- 2. Apply with --yes (non-interactive) ---
+    r = subprocess.run(
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+         "--project", "proj1", "--apply", "--yes"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 1, f"apply exit: expected 1 (successful apply), got {r.returncode}: {r.stderr}"
+
+    # --- 3. Verify: frontmatter patched, body byte-identical, backup exists ---
+    patched = insight.read_text(encoding="utf-8")
+    assert "source_session: sid-b" in patched
+    assert 'source_session_note: "[[2026-04-10-proj1-bbbb]]"' in patched
+    assert "claude/project/proj1" in patched
+    assert "type: claude-insight" in patched
+
+    patched_body = patched.split("---\n", 2)[-1]
+    assert patched_body == original_body, "body must be byte-identical after apply"
+
+    # Backup must exist under ~/.claude/obsidian-brain-doctor-backup/<timestamp>/proj1/
+    backup_root = home / ".claude" / "obsidian-brain-doctor-backup"
+    assert backup_root.exists(), f"backup root not created at {backup_root}"
+    backups = list(backup_root.rglob("2026-04-10-stale-e2e.md"))
+    assert backups, f"no backup found for the patched note under {backup_root}"
+    backup_content = backups[0].read_text(encoding="utf-8")
+    assert backup_content == original_text, "backup must match pre-patch content exactly"
+
+    # --- 4. Re-scan → exit 0 (clean) ---
+    r = subprocess.run(
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+         "--project", "proj1", "--json"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 0, f"re-scan exit: expected 0 (clean), got {r.returncode}: {r.stderr}"
+    assert json.loads(r.stdout)["total_issues"] == 0

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1,5 +1,6 @@
 """Tests for the source_sessions vault_doctor check module."""
 
+import calendar
 import json
 import os
 import sys
@@ -88,13 +89,13 @@ def test_scan_flags_insight_stamped_to_wrong_session(doctor_vault, monkeypatch):
     monkeypatch.setenv("HOME", str(home))
 
     # Session A: 2026-04-09 10:00–11:00
-    a_start = time.mktime(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
     a_end = a_start + 3600
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_end)
     _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
 
     # Session B: 2026-04-10 14:00–15:00
-    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
     b_end = b_start + 3600
     _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_end)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
@@ -132,7 +133,7 @@ def test_scan_ignores_correct_insight(doctor_vault, monkeypatch):
     jsonl_dir = doctor_vault["jsonl_dir"]
     monkeypatch.setenv("HOME", str(home))
 
-    a_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    a_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
     a_end = a_start + 3600
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-10T14:00:00Z", a_end)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-a", "aaaa")
@@ -186,12 +187,12 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
     jsonl_dir = doctor_vault["jsonl_dir"]
     monkeypatch.setenv("HOME", str(home))
 
-    a_start = time.mktime(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
+    a_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-10T10:00:00Z", a_start + 3600)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-a", "aaaa")
 
     # Insight captured at 20:00 — no session window covers it, and current source 'wrong-sid' isn't a real session
-    gap_mtime = time.mktime(time.strptime("2026-04-10 20:00", "%Y-%m-%d %H:%M"))
+    gap_mtime = calendar.timegm(time.strptime("2026-04-10 20:00", "%Y-%m-%d %H:%M"))
     _write_insight(
         v / "claude-insights",
         "2026-04-10",
@@ -220,8 +221,8 @@ def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monke
     jsonl_dir = doctor_vault["jsonl_dir"]
     monkeypatch.setenv("HOME", str(home))
 
-    a_start = time.mktime(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
-    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_start + 3600)
     _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_start + 3600)
     _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
@@ -359,19 +360,19 @@ def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
     monkeypatch.setenv("HOME", str(home))
 
     # Session A: 10:00 - 14:05 (mtime)
-    a_start = time.mktime(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
-    a_mtime = time.mktime(time.strptime("2026-04-10 14:05", "%Y-%m-%d %H:%M"))
+    a_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
+    a_mtime = calendar.timegm(time.strptime("2026-04-10 14:05", "%Y-%m-%d %H:%M"))
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-10T10:00:00Z", a_mtime)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-a", "aaaa")
 
     # Session B: 14:00 - 15:00 (mtime) — overlaps session A from 14:00-14:05
-    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
     b_mtime = b_start + 3600
     _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_mtime)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
     # Insight captured at 14:02 — inside BOTH windows
-    insight_mtime = time.mktime(time.strptime("2026-04-10 14:02", "%Y-%m-%d %H:%M"))
+    insight_mtime = calendar.timegm(time.strptime("2026-04-10 14:02", "%Y-%m-%d %H:%M"))
     _write_insight(
         v / "claude-insights",
         "2026-04-10",

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1,0 +1,208 @@
+"""Tests for the source_sessions vault_doctor check module."""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+
+@pytest.fixture
+def doctor_vault(tmp_path):
+    """Tmp vault layout with folders + JSONL home for session matching."""
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+    (vault / "claude-decisions").mkdir(parents=True)
+    (vault / "claude-error-fixes").mkdir(parents=True)
+    (vault / "claude-retros").mkdir(parents=True)
+    claude_home = tmp_path / ".claude" / "projects" / "-Users-foo-proj1"
+    claude_home.mkdir(parents=True)
+    return {
+        "vault": vault,
+        "home": tmp_path,
+        "jsonl_dir": claude_home,
+        "project": "proj1",
+    }
+
+
+def _write_jsonl(path: Path, first_ts: str, last_ts_mtime: float) -> None:
+    """Write a minimal JSONL with two entries and set mtime to last_ts_mtime."""
+    payload = [
+        {"type": "user", "timestamp": first_ts},
+        {"type": "assistant", "timestamp": first_ts},
+    ]
+    path.write_text("\n".join(json.dumps(p) for p in payload) + "\n", encoding="utf-8")
+    os.utime(path, (last_ts_mtime, last_ts_mtime))
+
+
+def _write_session_note(dir_path: Path, date: str, project: str, sid: str, hash_: str) -> Path:
+    note = dir_path / f"{date}-{project}-{hash_}.md"
+    note.write_text(
+        f"---\n"
+        f"type: claude-session\n"
+        f"date: {date}\n"
+        f"session_id: {sid}\n"
+        f"project: {project}\n"
+        f"status: summarized\n"
+        f"---\n"
+        f"# Session\n## Summary\nstub\n",
+        encoding="utf-8",
+    )
+    return note
+
+
+def _write_insight(dir_path: Path, date: str, slug: str, project: str, src_sid: str,
+                   src_note_basename: str, mtime: float) -> Path:
+    note = dir_path / f"{date}-{slug}.md"
+    note.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: {date}\n"
+        f"source_session: {src_sid}\n"
+        f'source_session_note: "[[{src_note_basename}]]"\n'
+        f"project: {project}\n"
+        f"tags:\n"
+        f"  - claude/insight\n"
+        f"  - claude/project/{project}\n"
+        f"---\n"
+        f"# Test insight\n",
+        encoding="utf-8",
+    )
+    os.utime(note, (mtime, mtime))
+    return note
+
+
+def test_scan_flags_insight_stamped_to_wrong_session(doctor_vault, monkeypatch):
+    """Insight mtime falls in session-B window but references session-A → stale."""
+    import vault_doctor_checks.source_sessions as check
+
+    v = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Session A: 2026-04-09 10:00–11:00
+    a_start = time.mktime(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    a_end = a_start + 3600
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_end)
+    _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
+
+    # Session B: 2026-04-10 14:00–15:00
+    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    b_end = b_start + 3600
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_end)
+    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
+
+    # Insight captured 2026-04-10 14:30 but wrongly stamped with sid-a
+    insight_mtime = b_start + 1800
+    _write_insight(
+        v / "claude-insights",
+        "2026-04-10",
+        "stale-insight-0001",
+        "proj1",
+        "sid-a",
+        "2026-04-09-proj1-aaaa",
+        insight_mtime,
+    )
+
+    issues = check.scan(
+        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+    )
+    assert len(issues) == 1
+    iss = issues[0]
+    assert "stale-insight-0001" in iss.note_path
+    assert iss.current_source == "[[2026-04-09-proj1-aaaa]]"
+    assert iss.proposed_source == "[[2026-04-10-proj1-bbbb]]"
+    assert iss.project == "proj1"
+    assert iss.extra.get("proposed_sid") == "sid-b"
+
+
+def test_scan_ignores_correct_insight(doctor_vault, monkeypatch):
+    """Insight mtime matches its referenced session window → not flagged."""
+    import vault_doctor_checks.source_sessions as check
+
+    v = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    monkeypatch.setenv("HOME", str(home))
+
+    a_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    a_end = a_start + 3600
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-10T14:00:00Z", a_end)
+    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-a", "aaaa")
+
+    _write_insight(
+        v / "claude-insights",
+        "2026-04-10",
+        "good-insight",
+        "proj1",
+        "sid-a",
+        "2026-04-10-proj1-aaaa",
+        a_start + 1800,
+    )
+
+    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=7, project="proj1")
+    assert issues == []
+
+
+def test_scan_honors_days_window(doctor_vault, monkeypatch):
+    """Notes older than `days` are not scanned."""
+    import vault_doctor_checks.source_sessions as check
+
+    v = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    monkeypatch.setenv("HOME", str(home))
+
+    old_ts = time.time() - 30 * 86400
+    _write_jsonl(jsonl_dir / "sid-old.jsonl", "2026-03-12T10:00:00Z", old_ts + 3600)
+    _write_session_note(v / "claude-sessions", "2026-03-12", "proj1", "sid-old", "0aaa")
+    _write_insight(
+        v / "claude-insights",
+        "2026-03-12",
+        "ancient-insight",
+        "proj1",
+        "wrong-sid",
+        "2026-03-12-proj1-0aaa",
+        old_ts + 1800,
+    )
+
+    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=7, project="proj1")
+    assert issues == []  # outside 7-day window
+
+
+def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch):
+    """Insight whose mtime does not fall inside any session window → UNRESOLVED (or not flagged)."""
+    import vault_doctor_checks.source_sessions as check
+
+    v = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    monkeypatch.setenv("HOME", str(home))
+
+    a_start = time.mktime(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-10T10:00:00Z", a_start + 3600)
+    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-a", "aaaa")
+
+    # Insight captured at 20:00 — no session window covers it, and current source 'wrong-sid' isn't a real session
+    gap_mtime = time.mktime(time.strptime("2026-04-10 20:00", "%Y-%m-%d %H:%M"))
+    _write_insight(
+        v / "claude-insights",
+        "2026-04-10",
+        "gap-insight",
+        "proj1",
+        "wrong-sid",  # doesn't match any session
+        "2026-04-10-proj1-wrong",
+        gap_mtime,
+    )
+
+    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=7, project="proj1")
+    # Either reported as unresolved, or not flagged at all — but not silently repointed
+    for iss in issues:
+        assert iss.extra.get("unresolved", False) is True

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -347,3 +347,98 @@ def test_apply_errors_on_missing_proposed_sid(doctor_vault, tmp_path):
     assert results[0].status == "error"
     assert "proposed_sid" in (results[0].error or "")
     assert note.read_text(encoding="utf-8") == original
+
+
+def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
+    """When two session windows both contain capture_time, latest first_ts wins."""
+    import vault_doctor_checks.source_sessions as check
+
+    v = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Session A: 10:00 - 14:05 (mtime)
+    a_start = time.mktime(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
+    a_mtime = time.mktime(time.strptime("2026-04-10 14:05", "%Y-%m-%d %H:%M"))
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-10T10:00:00Z", a_mtime)
+    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-a", "aaaa")
+
+    # Session B: 14:00 - 15:00 (mtime) — overlaps session A from 14:00-14:05
+    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    b_mtime = b_start + 3600
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_mtime)
+    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
+
+    # Insight captured at 14:02 — inside BOTH windows
+    insight_mtime = time.mktime(time.strptime("2026-04-10 14:02", "%Y-%m-%d %H:%M"))
+    _write_insight(
+        v / "claude-insights",
+        "2026-04-10",
+        "boundary-tie-insight",
+        "proj1",
+        "sid-a",  # currently (wrongly) stamped with the older session
+        "2026-04-10-proj1-aaaa",
+        insight_mtime,
+    )
+
+    issues = check.scan(
+        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+    )
+    assert len(issues) == 1
+    # Latest first_ts wins: sid-b (started at 14:00) beats sid-a (started at 10:00)
+    assert issues[0].extra.get("proposed_sid") == "sid-b"
+    assert issues[0].proposed_source == "[[2026-04-10-proj1-bbbb]]"
+
+
+def test_jsonl_window_returns_none_when_all_lines_unparseable(tmp_path):
+    """Fully corrupt JSONL returns None, not a fabricated window."""
+    import vault_doctor_checks.source_sessions as check
+
+    bad = tmp_path / "corrupt.jsonl"
+    bad.write_text("this is not json\nthis either\n", encoding="utf-8")
+    assert check._jsonl_window(str(bad)) is None
+
+
+def test_jsonl_window_falls_back_when_parsed_but_no_timestamps(tmp_path):
+    """JSONL with valid JSON but no timestamp field → mtime-3600 fallback."""
+    import vault_doctor_checks.source_sessions as check
+    import json
+    import os
+
+    jsonl = tmp_path / "no-ts.jsonl"
+    jsonl.write_text(
+        json.dumps({"type": "user"}) + "\n" + json.dumps({"type": "assistant"}) + "\n",
+        encoding="utf-8",
+    )
+    mtime = 1700000000.0
+    os.utime(jsonl, (mtime, mtime))
+    window = check._jsonl_window(str(jsonl))
+    assert window is not None
+    first_ts, last_ts = window
+    assert last_ts == mtime
+    assert first_ts == mtime - 3600
+
+
+def test_jsonl_dir_for_project_picks_newest_worktree(tmp_path, monkeypatch):
+    """Two .claude/projects/*proj1 dirs exist (path encoding variants) → newest-mtime wins."""
+    import vault_doctor_checks.source_sessions as check
+    import os
+    import time as _time
+
+    # Both dirs end with "proj1" so the `*proj1` glob matches both. Simulates
+    # two encoded path variants for the same project name (e.g. after a user
+    # moved the checkout between machines or worktrees).
+    older = tmp_path / ".claude" / "projects" / "-Users-foo-proj1"
+    newer = tmp_path / ".claude" / "projects" / "-Users-bar-worktrees-proj1"
+    older.mkdir(parents=True)
+    newer.mkdir(parents=True)
+    os.utime(older, (_time.time() - 3600, _time.time() - 3600))
+    os.utime(newer, (_time.time() - 60, _time.time() - 60))
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = check._jsonl_dir_for_project("proj1")
+    assert result is not None
+    assert str(result).endswith("-Users-bar-worktrees-proj1"), (
+        f"expected newer dir, got {result}"
+    )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -443,3 +443,62 @@ def test_jsonl_dir_for_project_picks_newest_worktree(tmp_path, monkeypatch):
     assert str(result).endswith("-Users-bar-worktrees-proj1"), (
         f"expected newer dir, got {result}"
     )
+
+
+def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
+    """After apply, the patched note's mtime equals its pre-apply mtime.
+
+    This is load-bearing: scan() uses note mtime as capture_time. If apply
+    updated mtime to 'now', a subsequent scan would match the note's new
+    mtime against the current session's window, not the original capture
+    session — re-flagging every fixed note on every run.
+    """
+    import vault_doctor_checks.source_sessions as check
+    import os
+
+    v = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    monkeypatch.setenv("HOME", str(home))
+
+    import calendar, time
+    a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_start + 3600)
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_start + 3600)
+    _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
+    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
+
+    original_mtime = b_start + 1800  # 2026-04-10 14:30
+    _write_insight(
+        v / "claude-insights",
+        "2026-04-10",
+        "mtime-preserve",
+        "proj1",
+        "sid-a",
+        "2026-04-09-proj1-aaaa",
+        original_mtime,
+    )
+
+    issues = check.scan(
+        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+    )
+    assert len(issues) == 1
+
+    backup_root = tmp_path / "backups"
+    results = check.apply(issues, str(backup_root))
+    assert results[0].status == "applied"
+
+    # Critical: mtime must be preserved
+    note_path = issues[0].note_path
+    new_mtime = os.path.getmtime(note_path)
+    assert abs(new_mtime - original_mtime) < 1.0, (
+        f"mtime not preserved: original={original_mtime}, new={new_mtime}"
+    )
+
+    # And a re-scan with the patched note should find nothing (proves the
+    # self-reinforcing bug is not reintroduced)
+    rescan_issues = check.scan(
+        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+    )
+    assert rescan_issues == [], f"re-scan should be clean, got: {rescan_issues}"

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -502,3 +502,25 @@ def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
         str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
     )
     assert rescan_issues == [], f"re-scan should be clean, got: {rescan_issues}"
+
+
+def test_jsonl_dir_for_project_deterministic_same_mtime_tiebreak(tmp_path, monkeypatch):
+    """Two dirs with identical mtimes: winner is deterministic across runs."""
+    import vault_doctor_checks.source_sessions as check
+    import os
+
+    dir_a = tmp_path / ".claude" / "projects" / "-aaa-proj1"
+    dir_b = tmp_path / ".claude" / "projects" / "-bbb-proj1"
+    dir_a.mkdir(parents=True)
+    dir_b.mkdir(parents=True)
+    now = 1700000000.0
+    os.utime(dir_a, (now, now))
+    os.utime(dir_b, (now, now))
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Both runs should return the same winner
+    result1 = check._jsonl_dir_for_project("proj1")
+    result2 = check._jsonl_dir_for_project("proj1")
+    assert result1 is not None
+    assert result1 == result2, f"non-deterministic: {result1} vs {result2}"

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -209,3 +209,141 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
     assert iss.confidence == 0.0
     assert iss.proposed_source == ""
     assert "gap-insight" in iss.note_path
+
+
+def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monkeypatch):
+    """After apply, only source_session/source_session_note change; body+tags preserved."""
+    import vault_doctor_checks.source_sessions as check
+
+    v = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    monkeypatch.setenv("HOME", str(home))
+
+    a_start = time.mktime(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    b_start = time.mktime(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_start + 3600)
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_start + 3600)
+    _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
+    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
+
+    # Build an insight with extra tags and body content we want preserved
+    note = v / "claude-insights" / "2026-04-10-rewrite-me.md"
+    note.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "date: 2026-04-10\n"
+        "source_session: sid-a\n"
+        'source_session_note: "[[2026-04-09-proj1-aaaa]]"\n'
+        "project: proj1\n"
+        "tags:\n"
+        "  - claude/insight\n"
+        "  - claude/project/proj1\n"
+        "  - claude/topic/foo\n"
+        "---\n"
+        "\n"
+        "# My insight\n"
+        "\n"
+        "Body line 1\n"
+        "Body line 2 with [[2026-04-09-proj1-aaaa]] reference in body\n",
+        encoding="utf-8",
+    )
+    os.utime(note, (b_start + 1800, b_start + 1800))
+
+    # Capture the original body for byte-identity comparison
+    original_text = note.read_text(encoding="utf-8")
+    original_body = original_text.split("---\n", 2)[-1]
+
+    issues = check.scan(
+        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+    )
+    assert len(issues) == 1, f"expected 1 issue, got {len(issues)}"
+
+    backup_root = tmp_path / "backups"
+    results = check.apply(issues, str(backup_root))
+
+    assert len(results) == 1
+    assert results[0].status == "applied"
+    assert results[0].backup_path is not None
+    assert Path(results[0].backup_path).exists()
+
+    patched = note.read_text(encoding="utf-8")
+    # Frontmatter targets rewritten
+    assert "source_session: sid-b" in patched
+    assert 'source_session_note: "[[2026-04-10-proj1-bbbb]]"' in patched
+    # Untouched frontmatter preserved
+    assert "claude/topic/foo" in patched
+    assert "type: claude-insight" in patched
+    assert "tags:\n  - claude/insight" in patched
+    # Body byte-identical
+    patched_body = patched.split("---\n", 2)[-1]
+    assert patched_body == original_body, "body must be byte-identical after frontmatter rewrite"
+    # Backup file matches the pre-patch content
+    assert Path(results[0].backup_path).read_text(encoding="utf-8") == original_text
+
+
+def test_apply_skips_unresolved(doctor_vault, tmp_path):
+    """Issues marked unresolved are skipped, never rewritten."""
+    import vault_doctor_checks.source_sessions as check
+    from vault_doctor_checks import Issue
+
+    v = doctor_vault["vault"]
+    note = v / "claude-insights" / "2026-04-10-unresolved.md"
+    original = (
+        "---\n"
+        "type: claude-insight\n"
+        "date: 2026-04-10\n"
+        "source_session: gone-sid\n"
+        'source_session_note: "[[does-not-exist]]"\n'
+        "project: proj1\n"
+        "---\n"
+        "# unresolved\n"
+    )
+    note.write_text(original, encoding="utf-8")
+
+    issue = Issue(
+        check="source-sessions",
+        note_path=str(note),
+        project="proj1",
+        current_source="[[does-not-exist]]",
+        proposed_source="",
+        reason="no window",
+        confidence=0.0,
+        extra={"unresolved": True},
+    )
+
+    backup_root = tmp_path / "backups"
+    results = check.apply([issue], str(backup_root))
+    assert len(results) == 1
+    assert results[0].status == "unresolved"
+    assert results[0].backup_path is None
+    # File must be byte-identical
+    assert note.read_text(encoding="utf-8") == original
+
+
+def test_apply_errors_on_missing_proposed_sid(doctor_vault, tmp_path):
+    """Issue with no proposed_sid returns status=error, file untouched."""
+    import vault_doctor_checks.source_sessions as check
+    from vault_doctor_checks import Issue
+
+    v = doctor_vault["vault"]
+    note = v / "claude-insights" / "2026-04-10-noprop.md"
+    original = "---\ntype: claude-insight\nproject: proj1\nsource_session: x\n---\n# x\n"
+    note.write_text(original, encoding="utf-8")
+
+    issue = Issue(
+        check="source-sessions",
+        note_path=str(note),
+        project="proj1",
+        current_source="[[foo]]",
+        proposed_source="[[bar]]",  # proposed basename exists but extra['proposed_sid'] is missing
+        reason="test",
+        confidence=0.95,
+        extra={},  # no proposed_sid
+    )
+
+    backup_root = tmp_path / "backups"
+    results = check.apply([issue], str(backup_root))
+    assert results[0].status == "error"
+    assert "proposed_sid" in (results[0].error or "")
+    assert note.read_text(encoding="utf-8") == original

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -203,6 +203,9 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
     )
 
     issues = check.scan(str(v), "claude-sessions", "claude-insights", days=7, project="proj1")
-    # Either reported as unresolved, or not flagged at all — but not silently repointed
-    for iss in issues:
-        assert iss.extra.get("unresolved", False) is True
+    assert len(issues) == 1, f"expected exactly 1 unresolved issue, got {len(issues)}"
+    iss = issues[0]
+    assert iss.extra.get("unresolved") is True
+    assert iss.confidence == 0.0
+    assert iss.proposed_source == ""
+    assert "gap-insight" in iss.note_path

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -524,3 +524,68 @@ def test_jsonl_dir_for_project_deterministic_same_mtime_tiebreak(tmp_path, monke
     result2 = check._jsonl_dir_for_project("proj1")
     assert result1 is not None
     assert result1 == result2, f"non-deterministic: {result1} vs {result2}"
+
+
+def test_apply_rejects_path_traversal_in_project_name(doctor_vault, tmp_path):
+    """An issue with a malicious project name cannot write outside backup_root."""
+    import vault_doctor_checks.source_sessions as check
+    from vault_doctor_checks import Issue
+
+    v = doctor_vault["vault"]
+    note = v / "claude-insights" / "2026-04-10-malicious.md"
+    note.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "date: 2026-04-10\n"
+        "source_session: sid-a\n"
+        'source_session_note: "[[old]]"\n'
+        "project: ../../../etc\n"
+        "---\n"
+        "# x\n",
+        encoding="utf-8",
+    )
+
+    issue = Issue(
+        check="source-sessions",
+        note_path=str(note),
+        project="../../../etc",  # malicious
+        current_source="[[old]]",
+        proposed_source="[[new]]",
+        reason="test",
+        confidence=0.95,
+        extra={"proposed_sid": "sid-b"},
+    )
+
+    backup_root = tmp_path / "backups"
+    results = check.apply([issue], str(backup_root))
+
+    # Backup must go under a sanitized slug inside backup_root, never outside
+    assert len(results) == 1
+    if results[0].status == "applied":
+        # If it succeeded, the backup path must still be under backup_root
+        bp = Path(results[0].backup_path).resolve()
+        br = Path(backup_root).resolve()
+        assert br in bp.parents, (
+            f"backup escaped root: {bp} not under {br}"
+        )
+    elif results[0].status == "error":
+        # Acceptable — sanitizer or defensive check rejected it.
+        pass
+    else:
+        assert False, f"unexpected status: {results[0].status}"
+
+
+def test_safe_project_slug_sanitizes_dots_and_separators():
+    """_safe_project_slug strips path-traversal payloads."""
+    import vault_doctor_checks.source_sessions as check
+
+    result = check._safe_project_slug("../../../etc")
+    assert "/" not in result
+    assert ".." not in result
+
+    result = check._safe_project_slug("foo/bar")
+    assert "/" not in result
+
+    assert check._safe_project_slug("") == "unknown"
+    assert check._safe_project_slug("...") == "unknown"
+    assert check._safe_project_slug("valid-name_1") == "valid-name_1"


### PR DESCRIPTION
## Summary

Fixes a silent data-integrity bug where `/compress`, `/decide`, `/error-log`, `/retro` stamped new insight notes with a **previous session's** ID instead of the current one, and adds a new `/vault-doctor` maintenance skill that can detect and repair the resulting stale backlinks across the vault.

## Root cause

`_get_session_id_fast()` in `hooks/obsidian_utils.py` used a project-scoped bootstrap file (`/tmp/.obsidian-brain-sid-<project>`) as a session-id cache. Its fast-path validation only checked whether the cached JSONL still existed — never whether it was still the **newest**. Result: every second-or-later session in a given project returned the stale sid from the previous session, which got stamped into every `source_session` / `source_session_note` frontmatter via `get_session_context()`.

Smoke test against my live vault found **35 stale backlinks** for obsidian-brain alone — exactly the pattern described in the bug report.

## Fix (two layers)

1. **Primary:** `hooks/obsidian_session_hint.py` (SessionStart hook) now reads `session_id` from its stdin JSON payload and atomically writes it to the bootstrap file before any skill can run. The bootstrap is always authoritative at session start.
2. **Defense-in-depth:** `_get_session_id_fast()` now detects when a new session has become authoritative by comparing the basename of the newest JSONL (deterministically selected via `(mtime, path)` tuples) against the cached sid. A same-second mtime tie-breaker trusts the hook-written bootstrap when its JSONL shares the newest mtime.

## Observability

- `~/.claude/obsidian-brain-hook.log` — rolling audit log of every SessionStart hook invocation with authoritative sid, rotated at 100 KB.
- `scripts/verify-hooks.sh` — manual diagnostic that simulates a SessionStart hook and verifies the bootstrap + log were written, independent of a running CC session.
- `/recall` brief now leads with a `[OK]`/`[WARN]` SessionStart hook status line.
- SessionEnd hook now cleans up `/tmp/.ob-cache-<sid>.json` so the cache dir doesn't grow unbounded.

## New skill: `/vault-doctor`

Diagnostic + repair skill with a pluggable check-module registry. Ships with one check (`source-sessions`) that:

- Scans the last N days (default 7) of insight/decision/error-fix/retro notes
- Matches each note's mtime against JSONL activity windows (`first_entry_timestamp` → `file mtime`) to identify the correct source session
- Reports a grouped-by-project JSON/human report
- Under ``/vault-doctor fix``: writes backups to ``~/.claude/obsidian-brain-doctor-backup/<ts>/<project>/``, then atomically rewrites **only** ``source_session`` + ``source_session_note`` in frontmatter. Body, tags, and all other frontmatter fields are preserved **byte-identically** (asserted by integration test).
- Per-project confirmation prompts; unresolved gap-cases are never guessed.
- Deterministic matching with latest-start tiebreaker on window boundaries.

Exit codes: ``0`` clean / ``1`` issues or successful apply / ``2`` apply errors / ``3`` usage error.

Invocations:
- ``/vault-doctor`` — dry-run all checks
- ``/vault-doctor fix`` — apply with per-project confirmation
- ``/vault-doctor --check source-sessions --days 14 --project foo`` — filters
- ``/vault-doctor fix --check source-sessions`` — combine

## Architecture for future checks

``scripts/vault_doctor_checks/`` is a package that auto-discovers any module exposing ``NAME``, ``scan()``, and ``apply()``. Adding a new check (e.g., ``broken-backlinks``, ``orphan-insights``, ``missing-project-tags``) is a single file drop — no changes to the skill or the dispatcher.

## Test plan

- [x] pytest suite: **153 passing** (18 new tests, 97.90% coverage)
- [x] ``commit-preflight.sh`` clean on every commit
- [x] Unit tests for: mtime-aware fast path, SessionStart bootstrap write, log rotation, check_hook_status helper, session cache cleanup, scan window matching, apply byte-identity, CLI exit codes, frontmatter byte-identity
- [x] End-to-end integration test (``test_vault_doctor_integration.py``) seeds a realistic vault with JSONL + stale insight, runs full scan→apply→verify pipeline
- [x] Live-vault dry-run smoke test detected 35 stale backlinks in obsidian-brain project (validates the feature works against real data)
- [ ] Local ``/dev-test install`` verification in a fresh Claude Code session (15-item checklist — will run before merge)
- [ ] Parallel review agents (code-reviewer + silent-failure-hunter + pr-test-analyzer)
- [ ] Copilot review

## Spec & plan

- Spec: [``2026-04-11-vault-doctor-and-stale-session-fix-design.md``](https://github.com/abhattacherjee/spec-docs/blob/main/superpowers/specs/2026-04-11-vault-doctor-and-stale-session-fix-design.md)
- Plan: [``2026-04-11-vault-doctor-and-stale-session-fix.md``](https://github.com/abhattacherjee/spec-docs/blob/main/superpowers/plans/2026-04-11-vault-doctor-and-stale-session-fix.md)

## Post-merge

Run ``/vault-doctor fix --days 7`` against the live vault to repair the 35+ stale backlinks detected during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
