### PR TITLE
feat: SQLite + FTS5 vault index for smart insight ranking and instant search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `build_context_brief()` insight loading now surfaces contextually relevant insights via layered ranking (backlinks → tags → FTS keywords) instead of most-recent-by-mtime. Falls back to the original file scan if the vault index is unavailable.
+- `/vault-search` and `/vault-ask` FTS snippets now call `ensure_index()` before `search_vault()` so newly written notes are always picked up.
+- FTS5 schema uses contentless tables (`content=''`) — orphaned FTS entries are filtered out by JOIN, no DELETE needed.
+- `build_context_brief()` fallback narrowed from `except Exception` to `except (sqlite3.Error, OSError)` so programming bugs propagate instead of silently degrading to file scan.
+- All `vault_index.py` public functions use `try/finally` for connection cleanup.
+- Corrupt DB recovery now removes WAL/SHM sidecar files and logs to stderr.
+- Layer query failures log to stderr instead of silently passing.
 
 ### Fixed
+- FTS5 hyphen-as-NOT bug: `_sanitize_fts_query()` now replaces hyphens with spaces before tokenization. Previously, `"maintain-catalog"` was interpreted as `"maintain" NOT "catalog"` by FTS5's unicode61 tokenizer.
+- Contentless FTS5 delete compatibility: `_upsert_note()` and `_delete_note()` no longer use `DELETE FROM notes_fts` (invalid for contentless tables). Orphaned FTS entries are filtered by the JOIN in all queries.
+- `source_session` column mapping: `_upsert_note()` now correctly reads `parsed.get("source_session")` instead of `parsed.get("session_id")`.
+- Missing `import os` in `/recall` Step 4 cascade checkoff inline Python snippet.
 - `upgrade_note_with_summary()` now guarantees that a returned `Upgraded` status means the summary actually landed on disk. The rewritten tempfile is `fsync`'d before `os.replace()`, the parent directory is `fsync`'d after the rename (crash-durable rename), and the target file is re-read and verified before the function returns. Verification checks that `status: summarized` appears in the **YAML frontmatter block** (anchored to the start of the file via `re.match`, not a whole-file substring match — so a body that happens to mention the literal string or contains a Markdown `---` horizontal rule cannot false-positive) AND that the first real content line of the supplied summary is present in the **`## Summary` section** as its own stripped line (line-granularity, not substring match). Empty or heading-only Summary bodies are rejected upfront with `Failed: malformed summary`. Post-write mismatches return distinct `Failed: post-write verification — …` statuses (status not flipped, summary body missing, `## Summary` section not found, YAML frontmatter not found at start, post-write read failure) so callers (and `/recall`) can no longer be told "Upgraded" about a note that did not actually receive its summary.
 
 ## [1.9.0] - 2026-04-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `hooks/vault_index.py` — SQLite + FTS5 vault index with lazy mtime-based sync, layered ranking queries (backlinks → tags → FTS keywords), and sub-millisecond ad-hoc search
+- `/vault-reindex` skill — full index rebuild for recovery, setup, and after bulk Obsidian edits
+- `/obsidian-setup` Step 8.5 — bootstraps vault index on first setup and upgrades
+- `/vault-search` FTS fast path — tries instant FTS5 search before falling back to Grep
+- `/vault-ask` FTS pre-filter — reduces sub-agent file reads by pre-filtering with FTS5
+
+### Changed
+- `build_context_brief()` insight loading now surfaces contextually relevant insights via layered ranking (backlinks → tags → FTS keywords) instead of most-recent-by-mtime. Falls back to the original file scan if the vault index is unavailable.
+
 ### Fixed
 - `upgrade_note_with_summary()` now guarantees that a returned `Upgraded` status means the summary actually landed on disk. The rewritten tempfile is `fsync`'d before `os.replace()`, the parent directory is `fsync`'d after the rename (crash-durable rename), and the target file is re-read and verified before the function returns. Verification checks that `status: summarized` appears in the **YAML frontmatter block** (anchored to the start of the file via `re.match`, not a whole-file substring match — so a body that happens to mention the literal string or contains a Markdown `---` horizontal rule cannot false-positive) AND that the first real content line of the supplied summary is present in the **`## Summary` section** as its own stripped line (line-granularity, not substring match). Empty or heading-only Summary bodies are rejected upfront with `Failed: malformed summary`. Post-write mismatches return distinct `Failed: post-write verification — …` statuses (status not flipped, summary body missing, `## Summary` section not found, YAML frontmatter not found at start, post-write read failure) so callers (and `/recall`) can no longer be told "Upgraded" about a note that did not actually receive its summary.
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1332,35 +1332,49 @@ def build_context_brief(
             pass
         history_rows.append(f"| {i+1} | {date} | {duration} | {title} | {branch} |")
 
-    # --- 3. Scan and read insights ---
+    # --- 3. Load insights via vault index (layered ranking) ---
     insight_entries: list[tuple[str, str]] = []  # (title, key_point)
     insight_count = 0
-    if insights_dir.is_dir():
-        insight_files = sorted(
-            [f for f in insights_dir.iterdir() if f.suffix == '.md'],
-            reverse=True
-        )
-        project_insights: list[Path] = []
-        for f in insight_files:
-            meta = read_note_metadata(str(f))
-            if not meta:
-                continue
-            fm_project = meta.get('project', '')
-            if fm_project.lower() != project.lower() and slugify(fm_project) != slugify(project):
-                continue
-            project_insights.append(f)
 
-        insight_count = len(project_insights)
-        for f in project_insights[:20]:
-            title = f.stem
+    # Collect session context for layered ranking
+    _session_ids: list[str] = []
+    _session_tags: list[str] = []
+    _session_summary = ""
+    for _, _, _meta in session_files[:5]:
+        sid = _meta.get("session_id", "")
+        if sid:
+            _session_ids.append(sid)
+        for tag in _meta.get("tags", []):
+            if "claude/topic/" in tag and tag not in _session_tags:
+                _session_tags.append(tag)
+
+    # Build summary from loaded sessions
+    if most_recent_summary:
+        _session_summary = most_recent_summary
+
+    try:
+        from vault_index import ensure_index, query_related_notes
+        db_path = ensure_index(vault_path, [sessions_folder, insights_folder])
+        ranked_notes = query_related_notes(
+            db_path=db_path,
+            project=project,
+            session_ids=_session_ids,
+            session_tags=_session_tags,
+            session_summary=_session_summary,
+            limit=20,
+        )
+        insight_count = len(ranked_notes)
+        for note in ranked_notes:
+            title = note["title"]
             key_point = ""
+            note_path = note["path"]
             try:
-                with open(f, 'r', encoding='utf-8', errors='replace') as fh:
+                with open(note_path, "r", encoding="utf-8", errors="replace") as fh:
                     past_frontmatter = False
                     frontmatter_closed = False
                     for line_text in fh:
                         stripped = line_text.strip()
-                        if stripped == '---':
+                        if stripped == "---":
                             if not past_frontmatter:
                                 past_frontmatter = True
                                 continue
@@ -1369,15 +1383,59 @@ def build_context_brief(
                                 continue
                         if not frontmatter_closed:
                             continue
-                        if stripped.startswith('# '):
-                            title = stripped[2:].strip()
+                        if stripped.startswith("# "):
                             continue
-                        if stripped and not stripped.startswith('#') and not stripped.startswith('---'):
+                        if stripped and not stripped.startswith("#") and not stripped.startswith("---"):
                             key_point = stripped[:100]
                             break
             except OSError:
                 pass
             insight_entries.append((title, key_point))
+    except Exception:
+        # Fallback to original file scan if vault index unavailable
+        if insights_dir.is_dir():
+            insight_files = sorted(
+                [f for f in insights_dir.iterdir() if f.suffix == '.md'],
+                reverse=True
+            )
+            project_insights: list[Path] = []
+            for f in insight_files:
+                meta = read_note_metadata(str(f))
+                if not meta:
+                    continue
+                fm_project = meta.get('project', '')
+                if fm_project.lower() != project.lower() and slugify(fm_project) != slugify(project):
+                    continue
+                project_insights.append(f)
+
+            insight_count = len(project_insights)
+            for f in project_insights[:20]:
+                title = f.stem
+                key_point = ""
+                try:
+                    with open(f, 'r', encoding='utf-8', errors='replace') as fh:
+                        past_frontmatter = False
+                        frontmatter_closed = False
+                        for line_text in fh:
+                            stripped = line_text.strip()
+                            if stripped == '---':
+                                if not past_frontmatter:
+                                    past_frontmatter = True
+                                    continue
+                                else:
+                                    frontmatter_closed = True
+                                    continue
+                            if not frontmatter_closed:
+                                continue
+                            if stripped.startswith('# '):
+                                title = stripped[2:].strip()
+                                continue
+                            if stripped and not stripped.startswith('#') and not stripped.startswith('---'):
+                                key_point = stripped[:100]
+                                break
+                except OSError:
+                    pass
+                insight_entries.append((title, key_point))
 
     # Trim insights to ~500 tokens (~375 words, ~1875 chars)
     insight_text_parts: list[str] = []

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import os
 import re
+import sqlite3
 import subprocess
 import sys
 import tempfile
@@ -1398,7 +1399,7 @@ def build_context_brief(
                 except OSError:
                     pass
                 insight_entries.append((title, key_point))
-        except Exception as _vi_exc:
+        except (sqlite3.Error, OSError) as _vi_exc:
             print(f"[obsidian-brain] vault index failed ({type(_vi_exc).__name__}: {_vi_exc}); "
                   "falling back to file scan", file=sys.stderr)
             _use_vault_index = False

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1352,46 +1352,58 @@ def build_context_brief(
     if most_recent_summary:
         _session_summary = most_recent_summary
 
+    _use_vault_index = True
     try:
         from vault_index import ensure_index, query_related_notes
-        db_path = ensure_index(vault_path, [sessions_folder, insights_folder])
-        ranked_notes = query_related_notes(
-            db_path=db_path,
-            project=project,
-            session_ids=_session_ids,
-            session_tags=_session_tags,
-            session_summary=_session_summary,
-            limit=20,
-        )
-        insight_count = len(ranked_notes)
-        for note in ranked_notes:
-            title = note["title"]
-            key_point = ""
-            note_path = note["path"]
-            try:
-                with open(note_path, "r", encoding="utf-8", errors="replace") as fh:
-                    past_frontmatter = False
-                    frontmatter_closed = False
-                    for line_text in fh:
-                        stripped = line_text.strip()
-                        if stripped == "---":
-                            if not past_frontmatter:
-                                past_frontmatter = True
+    except ImportError:
+        _use_vault_index = False
+
+    if _use_vault_index:
+        try:
+            db_path = ensure_index(vault_path, [sessions_folder, insights_folder])
+            ranked_notes = query_related_notes(
+                db_path=db_path,
+                project=project,
+                session_ids=_session_ids,
+                session_tags=_session_tags,
+                session_summary=_session_summary,
+                note_types=["claude-insight", "claude-decision", "claude-error-fix", "claude-retro"],
+                limit=20,
+            )
+            insight_count = len(ranked_notes)
+            for note in ranked_notes:
+                title = note["title"]
+                key_point = ""
+                note_path = note["path"]
+                try:
+                    with open(note_path, "r", encoding="utf-8", errors="replace") as fh:
+                        past_frontmatter = False
+                        frontmatter_closed = False
+                        for line_text in fh:
+                            stripped = line_text.strip()
+                            if stripped == "---":
+                                if not past_frontmatter:
+                                    past_frontmatter = True
+                                    continue
+                                else:
+                                    frontmatter_closed = True
+                                    continue
+                            if not frontmatter_closed:
                                 continue
-                            else:
-                                frontmatter_closed = True
+                            if stripped.startswith("# "):
                                 continue
-                        if not frontmatter_closed:
-                            continue
-                        if stripped.startswith("# "):
-                            continue
-                        if stripped and not stripped.startswith("#") and not stripped.startswith("---"):
-                            key_point = stripped[:100]
-                            break
-            except OSError:
-                pass
-            insight_entries.append((title, key_point))
-    except Exception:
+                            if stripped and not stripped.startswith("#") and not stripped.startswith("---"):
+                                key_point = stripped[:100]
+                                break
+                except OSError:
+                    pass
+                insight_entries.append((title, key_point))
+        except Exception as _vi_exc:
+            print(f"[obsidian-brain] vault index failed ({type(_vi_exc).__name__}: {_vi_exc}); "
+                  "falling back to file scan", file=sys.stderr)
+            _use_vault_index = False
+
+    if not _use_vault_index:
         # Fallback to original file scan if vault index unavailable
         if insights_dir.is_dir():
             insight_files = sorted(

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1,0 +1,588 @@
+"""SQLite + FTS5 vault index for fast note lookup and context-driven ranking.
+
+Provides full-text search over Obsidian vault notes, mtime-based incremental
+sync, and layered ranking for context-relevant note discovery.
+
+DB location: ~/.claude/obsidian-brain-vault.db (outside vault, alongside config).
+"""
+
+import os
+import re
+import sqlite3
+import tempfile
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+_SCHEMA_SQL = """\
+CREATE TABLE IF NOT EXISTS notes (
+    path            TEXT PRIMARY KEY,
+    type            TEXT NOT NULL,
+    date            TEXT,
+    project         TEXT,
+    title           TEXT,
+    source_session  TEXT,
+    source_note     TEXT,
+    tags            TEXT,
+    status          TEXT,
+    mtime           REAL NOT NULL,
+    size            INTEGER
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
+    title,
+    body,
+    tags,
+    content=notes,
+    content_rowid='rowid'
+);
+"""
+
+# ---------------------------------------------------------------------------
+# Stopwords for keyword extraction
+# ---------------------------------------------------------------------------
+
+_STOPWORDS = frozenset(
+    "a an the and or but in on at to for of is it this that was were be been "
+    "being have has had do does did will would shall should may might can could "
+    "not no nor so if then than too very are am was were with from by about "
+    "into through during before after above below between out off over under "
+    "again further once here there when where why how all each every both few "
+    "more most other some such only own same also just because as until while "
+    "up down its they them their what which who whom he she we you i my your "
+    "his her our me him us".split()
+)
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _default_db_path() -> str:
+    """Return default DB path: ~/.claude/obsidian-brain-vault.db."""
+    return os.path.join(os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db")
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    """Open a WAL-mode connection with 5s timeout."""
+    conn = sqlite3.connect(db_path, timeout=5.0)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _init_schema(conn: sqlite3.Connection) -> None:
+    """Create tables if they don't exist."""
+    # Split and execute each statement (can't use executescript with IF NOT EXISTS
+    # for virtual tables reliably in all sqlite versions)
+    cur = conn.cursor()
+    for stmt in _SCHEMA_SQL.strip().split(";"):
+        stmt = stmt.strip()
+        if stmt:
+            cur.execute(stmt)
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_note(file_path: str) -> dict | None:
+    """Parse frontmatter and body from a vault note.
+
+    Returns dict with keys: type, date, project, title, source_session,
+    source_note, tags (comma-separated), status, body.
+    Returns None for files that can't be parsed.
+    """
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            lines = []
+            for i, line in enumerate(f):
+                if i >= 40:
+                    break
+                lines.append(line)
+    except OSError:
+        return None
+
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    meta: dict = {}
+    tags: list[str] = []
+    in_tags = False
+    end_idx = None
+
+    for idx, line in enumerate(lines[1:], start=1):
+        stripped = line.strip()
+        if stripped == "---":
+            end_idx = idx
+            break
+        if stripped.startswith("- ") and in_tags:
+            tags.append(stripped[2:].strip())
+            continue
+        in_tags = False
+        if ":" in stripped:
+            key, _, val = stripped.partition(":")
+            key = key.strip()
+            val = val.strip().strip('"').strip("'")
+            if key == "tags":
+                in_tags = True
+                continue
+            meta[key] = val
+
+    if end_idx is None:
+        # No closing --- found
+        return None
+
+    if tags:
+        meta["tags"] = ",".join(tags)
+
+    # Extract title from first heading after frontmatter
+    title = meta.get("title", "")
+    if not title:
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                for line in f:
+                    stripped = line.strip()
+                    if stripped.startswith("# "):
+                        title = stripped[2:].strip()
+                        break
+        except OSError:
+            pass
+    meta["title"] = title
+
+    # Handle source_session_note -> source_note (strip [[wikilink]])
+    source_note_raw = meta.pop("source_session_note", None)
+    if source_note_raw:
+        meta["source_note"] = source_note_raw.strip("[]").replace("[[", "").replace("]]", "")
+
+    # Read body (everything after frontmatter)
+    body = ""
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            full_text = f.read()
+        # Find second --- and take everything after
+        parts = full_text.split("---", 2)
+        if len(parts) >= 3:
+            body = parts[2].strip()
+    except OSError:
+        pass
+
+    meta["body"] = body
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Sync engine
+# ---------------------------------------------------------------------------
+
+
+def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: float, size: int) -> None:
+    """Insert or replace a note in the index + FTS table."""
+    # Delete old FTS entry if exists (external content table requires manual sync)
+    row = conn.execute("SELECT rowid FROM notes WHERE path = ?", (rel_path,)).fetchone()
+    if row:
+        conn.execute(
+            "DELETE FROM notes_fts WHERE rowid = ?", (row["rowid"],)
+        )
+        conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
+
+    conn.execute(
+        "INSERT INTO notes (path, type, date, project, title, source_session, "
+        "source_note, tags, status, mtime, size) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            rel_path,
+            parsed.get("type", "unknown"),
+            parsed.get("date"),
+            parsed.get("project"),
+            parsed.get("title", ""),
+            parsed.get("session_id"),
+            parsed.get("source_note"),
+            parsed.get("tags", ""),
+            parsed.get("status"),
+            mtime,
+            size,
+        ),
+    )
+
+    # Get the rowid for FTS
+    rowid = conn.execute("SELECT rowid FROM notes WHERE path = ?", (rel_path,)).fetchone()["rowid"]
+    conn.execute(
+        "INSERT INTO notes_fts (rowid, title, body, tags) VALUES (?, ?, ?, ?)",
+        (rowid, parsed.get("title", ""), parsed.get("body", ""), parsed.get("tags", "")),
+    )
+
+
+def _delete_note(conn: sqlite3.Connection, rel_path: str) -> None:
+    """Remove a note from the index + FTS table."""
+    row = conn.execute("SELECT rowid FROM notes WHERE path = ?", (rel_path,)).fetchone()
+    if row:
+        conn.execute("DELETE FROM notes_fts WHERE rowid = ?", (row["rowid"],))
+        conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
+
+
+def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict:
+    """Incremental sync: add new/changed files, remove deleted ones.
+
+    Returns {"inserted": N, "skipped": M, "deleted": D, "by_type": {...}}.
+    """
+    vault = Path(vault_path)
+    stats = {"inserted": 0, "skipped": 0, "deleted": 0, "by_type": {}}
+
+    # Collect all .md files in target folders
+    disk_files: dict[str, Path] = {}  # rel_path -> absolute Path
+    for folder in folders:
+        folder_path = vault / folder
+        if not folder_path.is_dir():
+            continue
+        for md_file in folder_path.rglob("*.md"):
+            rel = str(md_file.relative_to(vault))
+            disk_files[rel] = md_file
+
+    # Get indexed files
+    indexed = {
+        row["path"]: row["mtime"]
+        for row in conn.execute("SELECT path, mtime FROM notes").fetchall()
+    }
+
+    # Delete removed files
+    for rel_path in list(indexed.keys()):
+        if rel_path not in disk_files:
+            _delete_note(conn, rel_path)
+            stats["deleted"] += 1
+
+    # Insert/update files
+    for rel_path, abs_path in disk_files.items():
+        st = abs_path.stat()
+        file_mtime = st.st_mtime
+        file_size = st.st_size
+
+        # Skip if mtime unchanged (0.001 tolerance)
+        if rel_path in indexed and abs(file_mtime - indexed[rel_path]) < 0.001:
+            stats["skipped"] += 1
+            continue
+
+        parsed = _parse_note(str(abs_path))
+        if parsed is None:
+            stats["skipped"] += 1
+            continue
+
+        _upsert_note(conn, rel_path, parsed, file_mtime, file_size)
+        note_type = parsed.get("type", "unknown")
+        stats["by_type"][note_type] = stats["by_type"].get(note_type, 0) + 1
+        stats["inserted"] += 1
+
+    conn.commit()
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def ensure_index(vault_path: str, folders: list[str], db_path: str | None = None) -> str:
+    """Create or update the vault index. Returns the DB path.
+
+    Handles corrupt DB by deleting and recreating.
+    """
+    if db_path is None:
+        db_path = _default_db_path()
+
+    # Ensure parent directory exists
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+
+    try:
+        conn = _connect(db_path)
+        _init_schema(conn)
+        _sync(conn, vault_path, folders)
+        conn.close()
+    except sqlite3.DatabaseError:
+        # Corrupt DB — delete and recreate
+        try:
+            os.remove(db_path)
+        except OSError:
+            pass
+        conn = _connect(db_path)
+        _init_schema(conn)
+        _sync(conn, vault_path, folders)
+        conn.close()
+
+    # Set permissions
+    try:
+        os.chmod(db_path, 0o644)
+    except OSError:
+        pass
+
+    return db_path
+
+
+def rebuild_index(vault_path: str, folders: list[str], db_path: str | None = None) -> dict:
+    """Drop and rebuild the entire index from scratch.
+
+    Returns {"inserted": N, "skipped": M, "by_type": {...}}.
+    """
+    if db_path is None:
+        db_path = _default_db_path()
+
+    # Delete existing DB
+    try:
+        os.remove(db_path)
+    except OSError:
+        pass
+
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+
+    conn = _connect(db_path)
+    _init_schema(conn)
+    stats = _sync(conn, vault_path, folders)
+    conn.close()
+
+    try:
+        os.chmod(db_path, 0o644)
+    except OSError:
+        pass
+
+    return stats
+
+
+def index_note(db_path: str, note_path: str) -> bool:
+    """Index a single note file. Returns True on success, False otherwise."""
+    if not os.path.isfile(db_path):
+        return False
+
+    if not os.path.isfile(note_path):
+        return False
+
+    parsed = _parse_note(note_path)
+    if parsed is None:
+        return False
+
+    st = os.stat(note_path)
+
+    try:
+        conn = _connect(db_path)
+        _upsert_note(conn, note_path, parsed, st.st_mtime, st.st_size)
+        conn.commit()
+        conn.close()
+        return True
+    except sqlite3.Error:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# FTS search
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_fts_query(query: str) -> str:
+    """Sanitize user input for FTS5 MATCH.
+
+    Wraps each word in double quotes and joins with OR.
+    """
+    # Extract alphanumeric words
+    words = re.findall(r"[a-zA-Z0-9_/-]+", query)
+    if not words:
+        return ""
+    return " OR ".join(f'"{w}"' for w in words)
+
+
+def search_vault(
+    db_path: str,
+    query: str,
+    project: str | None = None,
+    note_type: str | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Full-text search over the vault index.
+
+    Returns list of dicts with note metadata + rank.
+    """
+    if not os.path.isfile(db_path):
+        return []
+
+    sanitized = _sanitize_fts_query(query)
+    if not sanitized:
+        return []
+
+    try:
+        conn = _connect(db_path)
+    except sqlite3.Error:
+        return []
+
+    sql = (
+        "SELECT n.path, n.type, n.date, n.project, n.title, n.tags, n.status, "
+        "n.source_session, n.source_note, n.size, "
+        "rank "
+        "FROM notes_fts f "
+        "JOIN notes n ON n.rowid = f.rowid "
+        "WHERE notes_fts MATCH ? "
+    )
+    params: list = [sanitized]
+
+    if project:
+        sql += "AND n.project = ? "
+        params.append(project)
+    if note_type:
+        sql += "AND n.type = ? "
+        params.append(note_type)
+
+    sql += "ORDER BY rank LIMIT ?"
+    params.append(limit)
+
+    try:
+        rows = conn.execute(sql, params).fetchall()
+        results = [dict(row) for row in rows]
+        conn.close()
+        return results
+    except sqlite3.Error:
+        conn.close()
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Keyword extraction
+# ---------------------------------------------------------------------------
+
+
+def extract_keywords(text: str, limit: int = 8) -> list[str]:
+    """Extract keywords from text, removing stopwords and short words.
+
+    Returns up to `limit` keywords ordered by frequency.
+    """
+    words = re.findall(r"[a-zA-Z][a-zA-Z0-9_-]*", text.lower())
+    # Filter stopwords and words <= 2 chars
+    filtered = [w for w in words if w not in _STOPWORDS and len(w) > 2]
+
+    # Count frequency
+    freq: dict[str, int] = {}
+    for w in filtered:
+        freq[w] = freq.get(w, 0) + 1
+
+    # Sort by frequency descending, then alphabetically
+    ranked = sorted(freq.keys(), key=lambda w: (-freq[w], w))
+    return ranked[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Layered ranking query
+# ---------------------------------------------------------------------------
+
+
+def query_related_notes(
+    db_path: str,
+    project: str,
+    session_ids: list[str],
+    session_tags: list[str],
+    session_summary: str,
+    note_types: list[str] | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Find notes related to current context using layered ranking.
+
+    Layer 1: Backlinks (notes whose source_session is in session_ids)
+    Layer 2: Tag overlap (claude/topic/* tags)
+    Layer 3: FTS keyword search on session summary
+
+    Returns up to `limit` results, filling slots layer by layer.
+    """
+    if not os.path.isfile(db_path):
+        return []
+
+    try:
+        conn = _connect(db_path)
+    except sqlite3.Error:
+        return []
+
+    results: list[dict] = []
+    seen_paths: set[str] = set()
+
+    type_filter = ""
+    type_params: list = []
+    if note_types:
+        placeholders = ",".join("?" for _ in note_types)
+        type_filter = f"AND type IN ({placeholders})"
+        type_params = list(note_types)
+
+    # Layer 1: Backlinks — notes whose source_session matches loaded sessions
+    if session_ids:
+        placeholders = ",".join("?" for _ in session_ids)
+        sql = (
+            f"SELECT path, type, date, project, title, tags, status, "
+            f"source_session, source_note, size "
+            f"FROM notes WHERE source_session IN ({placeholders}) "
+            f"{type_filter} "
+            f"ORDER BY date DESC"
+        )
+        try:
+            rows = conn.execute(sql, session_ids + type_params).fetchall()
+            for row in rows:
+                d = dict(row)
+                d["layer"] = "backlink"
+                if d["path"] not in seen_paths:
+                    results.append(d)
+                    seen_paths.add(d["path"])
+        except sqlite3.Error:
+            pass
+
+    # Layer 2: Tag overlap (claude/topic/* tags)
+    topic_tags = [t for t in session_tags if t.startswith("claude/topic/")]
+    if topic_tags and len(results) < limit:
+        for tag in topic_tags:
+            if len(results) >= limit:
+                break
+            sql = (
+                f"SELECT path, type, date, project, title, tags, status, "
+                f"source_session, source_note, size "
+                f"FROM notes WHERE tags LIKE ? AND project = ? "
+                f"{type_filter} "
+                f"ORDER BY date DESC"
+            )
+            try:
+                rows = conn.execute(
+                    sql, [f"%{tag}%", project] + type_params
+                ).fetchall()
+                for row in rows:
+                    d = dict(row)
+                    d["layer"] = "tag"
+                    if d["path"] not in seen_paths:
+                        results.append(d)
+                        seen_paths.add(d["path"])
+            except sqlite3.Error:
+                pass
+
+    # Layer 3: FTS keyword search
+    if len(results) < limit and session_summary:
+        keywords = extract_keywords(session_summary)
+        if keywords:
+            fts_query = _sanitize_fts_query(" ".join(keywords))
+            if fts_query:
+                remaining = limit - len(results)
+                sql = (
+                    f"SELECT n.path, n.type, n.date, n.project, n.title, n.tags, "
+                    f"n.status, n.source_session, n.source_note, n.size "
+                    f"FROM notes_fts f "
+                    f"JOIN notes n ON n.rowid = f.rowid "
+                    f"WHERE notes_fts MATCH ? AND n.project = ? "
+                    f"{type_filter} "
+                    f"ORDER BY rank LIMIT ?"
+                )
+                try:
+                    rows = conn.execute(
+                        sql, [fts_query, project] + type_params + [remaining]
+                    ).fetchall()
+                    for row in rows:
+                        d = dict(row)
+                        d["layer"] = "fts"
+                        if d["path"] not in seen_paths:
+                            results.append(d)
+                            seen_paths.add(d["path"])
+                except sqlite3.Error:
+                    pass
+
+    conn.close()
+    return results[:limit]

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -9,6 +9,7 @@ DB location: ~/.claude/obsidian-brain-vault.db (outside vault, alongside config)
 import os
 import re
 import sqlite3
+import sys
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
@@ -34,8 +35,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
     title,
     body,
     tags,
-    content=notes,
-    content_rowid='rowid'
+    content=''
 );
 """
 
@@ -184,7 +184,7 @@ def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: f
             parsed.get("date"),
             parsed.get("project"),
             parsed.get("title", ""),
-            parsed.get("session_id"),
+            parsed.get("source_session"),
             parsed.get("source_note"),
             parsed.get("tags", ""),
             parsed.get("status"),
@@ -281,19 +281,25 @@ def ensure_index(vault_path: str, folders: list[str], db_path: str | None = None
 
     try:
         conn = _connect(db_path)
-        _init_schema(conn)
-        _sync(conn, vault_path, folders)
-        conn.close()
-    except sqlite3.DatabaseError:
+        try:
+            _init_schema(conn)
+            _sync(conn, vault_path, folders)
+        finally:
+            conn.close()
+    except sqlite3.DatabaseError as exc:
         # Corrupt DB — delete and recreate
+        print(f"[vault-index] Corrupt or incompatible DB ({exc}); rebuilding {db_path}",
+              file=sys.stderr)
         try:
             os.remove(db_path)
         except OSError:
             pass
         conn = _connect(db_path)
-        _init_schema(conn)
-        _sync(conn, vault_path, folders)
-        conn.close()
+        try:
+            _init_schema(conn)
+            _sync(conn, vault_path, folders)
+        finally:
+            conn.close()
 
     # Set permissions
     try:
@@ -321,9 +327,11 @@ def rebuild_index(vault_path: str, folders: list[str], db_path: str | None = Non
     os.makedirs(os.path.dirname(db_path), exist_ok=True)
 
     conn = _connect(db_path)
-    _init_schema(conn)
-    stats = _sync(conn, vault_path, folders)
-    conn.close()
+    try:
+        _init_schema(conn)
+        stats = _sync(conn, vault_path, folders)
+    finally:
+        conn.close()
 
     try:
         os.chmod(db_path, 0o644)
@@ -349,10 +357,16 @@ def index_note(db_path: str, note_path: str) -> bool:
 
     try:
         conn = _connect(db_path)
-        _upsert_note(conn, note_path, parsed, st.st_mtime, st.st_size)
-        conn.commit()
-        conn.close()
-        return True
+        try:
+            _upsert_note(conn, note_path, parsed, st.st_mtime, st.st_size)
+            conn.commit()
+            return True
+        except sqlite3.Error as exc:
+            print(f"[vault-index] index_note failed for {note_path}: {exc}",
+                  file=sys.stderr)
+            return False
+        finally:
+            conn.close()
     except sqlite3.Error:
         return False
 
@@ -419,12 +433,11 @@ def search_vault(
 
     try:
         rows = conn.execute(sql, params).fetchall()
-        results = [dict(row) for row in rows]
-        conn.close()
-        return results
+        return [dict(row) for row in rows]
     except sqlite3.Error:
-        conn.close()
         return []
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -498,19 +511,21 @@ def query_related_notes(
             f"SELECT path, type, date, project, title, tags, status, "
             f"source_session, source_note, size "
             f"FROM notes WHERE source_session IN ({placeholders}) "
+            f"AND project = ? "
             f"{type_filter} "
             f"ORDER BY date DESC"
         )
         try:
-            rows = conn.execute(sql, session_ids + type_params).fetchall()
+            rows = conn.execute(sql, session_ids + [project] + type_params).fetchall()
             for row in rows:
                 d = dict(row)
                 d["layer"] = "backlink"
                 if d["path"] not in seen_paths:
                     results.append(d)
                     seen_paths.add(d["path"])
-        except sqlite3.Error:
-            pass
+        except sqlite3.Error as exc:
+            print(f"[vault-index] Layer 1 (backlinks) query failed: {exc}",
+                  file=sys.stderr)
 
     # Layer 2: Tag overlap (claude/topic/* tags)
     topic_tags = [t for t in session_tags if t.startswith("claude/topic/")]
@@ -535,8 +550,9 @@ def query_related_notes(
                     if d["path"] not in seen_paths:
                         results.append(d)
                         seen_paths.add(d["path"])
-            except sqlite3.Error:
-                pass
+            except sqlite3.Error as exc:
+                print(f"[vault-index] Layer 2 (tags) query failed: {exc}",
+                      file=sys.stderr)
 
     # Layer 3: FTS keyword search
     if len(results) < limit and session_summary:
@@ -564,8 +580,9 @@ def query_related_notes(
                         if d["path"] not in seen_paths:
                             results.append(d)
                             seen_paths.add(d["path"])
-                except sqlite3.Error:
-                    pass
+                except sqlite3.Error as exc:
+                    print(f"[vault-index] Layer 3 (FTS) query failed: {exc}",
+                          file=sys.stderr)
 
     conn.close()
     return results[:limit]

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -97,24 +97,22 @@ def _parse_note(file_path: str) -> dict | None:
     Returns None for files that can't be parsed.
     """
     try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            lines = []
-            for i, line in enumerate(f):
-                if i >= 40:
-                    break
-                lines.append(line)
+        with open(file_path, "r", encoding="utf-8", errors="replace") as f:
+            full_text = f.read()
     except OSError:
         return None
 
+    lines = full_text.split("\n")
     if not lines or lines[0].strip() != "---":
         return None
 
+    # Parse frontmatter (first 40 lines)
     meta: dict = {}
     tags: list[str] = []
     in_tags = False
     end_idx = None
 
-    for idx, line in enumerate(lines[1:], start=1):
+    for idx, line in enumerate(lines[1:40], start=1):
         stripped = line.strip()
         if stripped == "---":
             end_idx = idx
@@ -133,24 +131,24 @@ def _parse_note(file_path: str) -> dict | None:
             meta[key] = val
 
     if end_idx is None:
-        # No closing --- found
         return None
 
     if tags:
         meta["tags"] = ",".join(tags)
 
-    # Extract title from first heading after frontmatter
+    # Body: everything after closing ---
+    body_lines = lines[end_idx + 1:]
+    body = "\n".join(body_lines).strip()
+    meta["body"] = body
+
+    # Extract title from first H1 heading in body
     title = meta.get("title", "")
     if not title:
-        try:
-            with open(file_path, "r", encoding="utf-8") as f:
-                for line in f:
-                    stripped = line.strip()
-                    if stripped.startswith("# "):
-                        title = stripped[2:].strip()
-                        break
-        except OSError:
-            pass
+        for bl in body_lines:
+            stripped = bl.strip()
+            if stripped.startswith("# "):
+                title = stripped[2:].strip()
+                break
     meta["title"] = title
 
     # Handle source_session_note -> source_note (strip [[wikilink]])
@@ -158,19 +156,6 @@ def _parse_note(file_path: str) -> dict | None:
     if source_note_raw:
         meta["source_note"] = source_note_raw.strip("[]").replace("[[", "").replace("]]", "")
 
-    # Read body (everything after frontmatter)
-    body = ""
-    try:
-        with open(file_path, "r", encoding="utf-8") as f:
-            full_text = f.read()
-        # Find second --- and take everything after
-        parts = full_text.split("---", 2)
-        if len(parts) >= 3:
-            body = parts[2].strip()
-    except OSError:
-        pass
-
-    meta["body"] = body
     return meta
 
 
@@ -232,15 +217,14 @@ def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict
     vault = Path(vault_path)
     stats = {"inserted": 0, "skipped": 0, "deleted": 0, "by_type": {}}
 
-    # Collect all .md files in target folders
-    disk_files: dict[str, Path] = {}  # rel_path -> absolute Path
+    # Collect all .md files in target folders (keyed by absolute path)
+    disk_files: dict[str, Path] = {}  # abs_path_str -> Path object
     for folder in folders:
         folder_path = vault / folder
         if not folder_path.is_dir():
             continue
         for md_file in folder_path.rglob("*.md"):
-            rel = str(md_file.relative_to(vault))
-            disk_files[rel] = md_file
+            disk_files[str(md_file)] = md_file
 
     # Get indexed files
     indexed = {
@@ -249,19 +233,19 @@ def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict
     }
 
     # Delete removed files
-    for rel_path in list(indexed.keys()):
-        if rel_path not in disk_files:
-            _delete_note(conn, rel_path)
+    for abs_path_str in list(indexed.keys()):
+        if abs_path_str not in disk_files:
+            _delete_note(conn, abs_path_str)
             stats["deleted"] += 1
 
     # Insert/update files
-    for rel_path, abs_path in disk_files.items():
+    for abs_path_str, abs_path in disk_files.items():
         st = abs_path.stat()
         file_mtime = st.st_mtime
         file_size = st.st_size
 
         # Skip if mtime unchanged (0.001 tolerance)
-        if rel_path in indexed and abs(file_mtime - indexed[rel_path]) < 0.001:
+        if abs_path_str in indexed and abs(file_mtime - indexed[abs_path_str]) < 0.001:
             stats["skipped"] += 1
             continue
 
@@ -270,7 +254,7 @@ def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict
             stats["skipped"] += 1
             continue
 
-        _upsert_note(conn, rel_path, parsed, file_mtime, file_size)
+        _upsert_note(conn, abs_path_str, parsed, file_mtime, file_size)
         note_type = parsed.get("type", "unknown")
         stats["by_type"][note_type] = stats["by_type"].get(note_type, 0) + 1
         stats["inserted"] += 1

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -408,33 +408,37 @@ def search_vault(
 
     try:
         conn = _connect(db_path)
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        print(f"[vault-index] search_vault could not connect: {exc}",
+              file=sys.stderr)
         return []
 
-    sql = (
-        "SELECT n.path, n.type, n.date, n.project, n.title, n.tags, n.status, "
-        "n.source_session, n.source_note, n.size, "
-        "rank "
-        "FROM notes_fts f "
-        "JOIN notes n ON n.rowid = f.rowid "
-        "WHERE notes_fts MATCH ? "
-    )
-    params: list = [sanitized]
-
-    if project:
-        sql += "AND n.project = ? "
-        params.append(project)
-    if note_type:
-        sql += "AND n.type = ? "
-        params.append(note_type)
-
-    sql += "ORDER BY rank LIMIT ?"
-    params.append(limit)
-
     try:
+        sql = (
+            "SELECT n.path, n.type, n.date, n.project, n.title, n.tags, n.status, "
+            "n.source_session, n.source_note, n.size, "
+            "rank "
+            "FROM notes_fts f "
+            "JOIN notes n ON n.rowid = f.rowid "
+            "WHERE notes_fts MATCH ? "
+        )
+        params: list = [sanitized]
+
+        if project:
+            sql += "AND n.project = ? "
+            params.append(project)
+        if note_type:
+            sql += "AND n.type = ? "
+            params.append(note_type)
+
+        sql += "ORDER BY rank LIMIT ?"
+        params.append(limit)
+
         rows = conn.execute(sql, params).fetchall()
         return [dict(row) for row in rows]
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        print(f"[vault-index] search_vault query failed: {exc}",
+              file=sys.stderr)
         return []
     finally:
         conn.close()
@@ -491,98 +495,102 @@ def query_related_notes(
 
     try:
         conn = _connect(db_path)
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        print(f"[vault-index] query_related_notes could not connect: {exc}",
+              file=sys.stderr)
         return []
 
-    results: list[dict] = []
-    seen_paths: set[str] = set()
+    try:
+        results: list[dict] = []
+        seen_paths: set[str] = set()
 
-    type_filter = ""
-    type_params: list = []
-    if note_types:
-        placeholders = ",".join("?" for _ in note_types)
-        type_filter = f"AND type IN ({placeholders})"
-        type_params = list(note_types)
+        type_filter = ""
+        type_params: list = []
+        if note_types:
+            placeholders = ",".join("?" for _ in note_types)
+            type_filter = f"AND type IN ({placeholders})"
+            type_params = list(note_types)
 
-    # Layer 1: Backlinks — notes whose source_session matches loaded sessions
-    if session_ids:
-        placeholders = ",".join("?" for _ in session_ids)
-        sql = (
-            f"SELECT path, type, date, project, title, tags, status, "
-            f"source_session, source_note, size "
-            f"FROM notes WHERE source_session IN ({placeholders}) "
-            f"AND project = ? "
-            f"{type_filter} "
-            f"ORDER BY date DESC"
-        )
-        try:
-            rows = conn.execute(sql, session_ids + [project] + type_params).fetchall()
-            for row in rows:
-                d = dict(row)
-                d["layer"] = "backlink"
-                if d["path"] not in seen_paths:
-                    results.append(d)
-                    seen_paths.add(d["path"])
-        except sqlite3.Error as exc:
-            print(f"[vault-index] Layer 1 (backlinks) query failed: {exc}",
-                  file=sys.stderr)
-
-    # Layer 2: Tag overlap (claude/topic/* tags)
-    topic_tags = [t for t in session_tags if t.startswith("claude/topic/")]
-    if topic_tags and len(results) < limit:
-        for tag in topic_tags:
-            if len(results) >= limit:
-                break
+        # Layer 1: Backlinks — notes whose source_session matches loaded sessions
+        if session_ids:
+            placeholders = ",".join("?" for _ in session_ids)
             sql = (
                 f"SELECT path, type, date, project, title, tags, status, "
                 f"source_session, source_note, size "
-                f"FROM notes WHERE tags LIKE ? AND project = ? "
+                f"FROM notes WHERE source_session IN ({placeholders}) "
+                f"AND project = ? "
                 f"{type_filter} "
                 f"ORDER BY date DESC"
             )
             try:
-                rows = conn.execute(
-                    sql, [f"%{tag}%", project] + type_params
-                ).fetchall()
+                rows = conn.execute(sql, session_ids + [project] + type_params).fetchall()
                 for row in rows:
                     d = dict(row)
-                    d["layer"] = "tag"
+                    d["layer"] = "backlink"
                     if d["path"] not in seen_paths:
                         results.append(d)
                         seen_paths.add(d["path"])
             except sqlite3.Error as exc:
-                print(f"[vault-index] Layer 2 (tags) query failed: {exc}",
+                print(f"[vault-index] Layer 1 (backlinks) query failed: {exc}",
                       file=sys.stderr)
 
-    # Layer 3: FTS keyword search
-    if len(results) < limit and session_summary:
-        keywords = extract_keywords(session_summary)
-        if keywords:
-            fts_query = _sanitize_fts_query(" ".join(keywords))
-            if fts_query:
-                remaining = limit - len(results)
+        # Layer 2: Tag overlap (claude/topic/* tags)
+        topic_tags = [t for t in session_tags if t.startswith("claude/topic/")]
+        if topic_tags and len(results) < limit:
+            for tag in topic_tags:
+                if len(results) >= limit:
+                    break
                 sql = (
-                    f"SELECT n.path, n.type, n.date, n.project, n.title, n.tags, "
-                    f"n.status, n.source_session, n.source_note, n.size "
-                    f"FROM notes_fts f "
-                    f"JOIN notes n ON n.rowid = f.rowid "
-                    f"WHERE notes_fts MATCH ? AND n.project = ? "
+                    f"SELECT path, type, date, project, title, tags, status, "
+                    f"source_session, source_note, size "
+                    f"FROM notes WHERE tags LIKE ? AND project = ? "
                     f"{type_filter} "
-                    f"ORDER BY rank LIMIT ?"
+                    f"ORDER BY date DESC"
                 )
                 try:
                     rows = conn.execute(
-                        sql, [fts_query, project] + type_params + [remaining]
+                        sql, [f"%{tag}%", project] + type_params
                     ).fetchall()
                     for row in rows:
                         d = dict(row)
-                        d["layer"] = "fts"
+                        d["layer"] = "tag"
                         if d["path"] not in seen_paths:
                             results.append(d)
                             seen_paths.add(d["path"])
                 except sqlite3.Error as exc:
-                    print(f"[vault-index] Layer 3 (FTS) query failed: {exc}",
+                    print(f"[vault-index] Layer 2 (tags) query failed: {exc}",
                           file=sys.stderr)
 
-    conn.close()
-    return results[:limit]
+        # Layer 3: FTS keyword search
+        if len(results) < limit and session_summary:
+            keywords = extract_keywords(session_summary)
+            if keywords:
+                fts_query = _sanitize_fts_query(" ".join(keywords))
+                if fts_query:
+                    remaining = limit - len(results)
+                    sql = (
+                        f"SELECT n.path, n.type, n.date, n.project, n.title, n.tags, "
+                        f"n.status, n.source_session, n.source_note, n.size "
+                        f"FROM notes_fts f "
+                        f"JOIN notes n ON n.rowid = f.rowid "
+                        f"WHERE notes_fts MATCH ? AND n.project = ? "
+                        f"{type_filter} "
+                        f"ORDER BY rank LIMIT ?"
+                    )
+                    try:
+                        rows = conn.execute(
+                            sql, [fts_query, project] + type_params + [remaining]
+                        ).fetchall()
+                        for row in rows:
+                            d = dict(row)
+                            d["layer"] = "fts"
+                            if d["path"] not in seen_paths:
+                                results.append(d)
+                                seen_paths.add(d["path"])
+                    except sqlite3.Error as exc:
+                        print(f"[vault-index] Layer 3 (FTS) query failed: {exc}",
+                              file=sys.stderr)
+
+        return results[:limit]
+    finally:
+        conn.close()

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -384,10 +384,14 @@ def index_note(db_path: str, note_path: str) -> bool:
 def _sanitize_fts_query(query: str) -> str:
     """Sanitize user input for FTS5 MATCH.
 
-    Wraps each word in double quotes and joins with OR.
+    Replaces hyphens with spaces (FTS5 unicode61 tokenizer treats hyphens
+    as token separators, so "maintain-catalog" inside quotes becomes
+    "maintain" NOT "catalog"). Then wraps each word in quotes and joins
+    with OR.
     """
-    # Extract alphanumeric words
-    words = re.findall(r"[a-zA-Z0-9_/-]+", query)
+    # Replace hyphens with spaces before tokenization to avoid FTS5 NOT operator
+    query = query.replace("-", " ")
+    words = re.findall(r"[a-zA-Z0-9_/]+", query)
     if not words:
         return ""
     return " OR ".join(f'"{w}"' for w in words)

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -9,7 +9,6 @@ DB location: ~/.claude/obsidian-brain-vault.db (outside vault, alongside config)
 import os
 import re
 import sqlite3
-import tempfile
 from pathlib import Path
 
 # ---------------------------------------------------------------------------

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -290,10 +290,11 @@ def ensure_index(vault_path: str, folders: list[str], db_path: str | None = None
         # Corrupt DB — delete and recreate
         print(f"[vault-index] Corrupt or incompatible DB ({exc}); rebuilding {db_path}",
               file=sys.stderr)
-        try:
-            os.remove(db_path)
-        except OSError:
-            pass
+        for suffix in ("", "-wal", "-shm"):
+            try:
+                os.remove(db_path + suffix)
+            except OSError:
+                pass
         conn = _connect(db_path)
         try:
             _init_schema(conn)
@@ -431,7 +432,7 @@ def search_vault(
             sql += "AND n.type = ? "
             params.append(note_type)
 
-        sql += "ORDER BY rank LIMIT ?"
+        sql += "ORDER BY f.rank LIMIT ?"
         params.append(limit)
 
         rows = conn.execute(sql, params).fetchall()
@@ -575,7 +576,7 @@ def query_related_notes(
                         f"JOIN notes n ON n.rowid = f.rowid "
                         f"WHERE notes_fts MATCH ? AND n.project = ? "
                         f"{type_filter} "
-                        f"ORDER BY rank LIMIT ?"
+                        f"ORDER BY f.rank LIMIT ?"
                     )
                     try:
                         rows = conn.execute(

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -240,7 +240,10 @@ def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict
 
     # Insert/update files
     for abs_path_str, abs_path in disk_files.items():
-        st = abs_path.stat()
+        try:
+            st = abs_path.stat()
+        except OSError:
+            continue  # File deleted/moved between rglob and stat
         file_mtime = st.st_mtime
         file_size = st.st_size
 
@@ -319,11 +322,12 @@ def rebuild_index(vault_path: str, folders: list[str], db_path: str | None = Non
     if db_path is None:
         db_path = _default_db_path()
 
-    # Delete existing DB
-    try:
-        os.remove(db_path)
-    except OSError:
-        pass
+    # Delete existing DB and WAL/SHM sidecars
+    for suffix in ("", "-wal", "-shm"):
+        try:
+            os.remove(db_path + suffix)
+        except OSError:
+            pass
 
     os.makedirs(os.path.dirname(db_path), exist_ok=True)
 

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -165,13 +165,25 @@ def _parse_note(file_path: str) -> dict | None:
 
 
 def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: float, size: int) -> None:
-    """Insert or replace a note in the index + FTS table."""
-    # Delete old FTS entry if exists (external content table requires manual sync)
-    row = conn.execute("SELECT rowid FROM notes WHERE path = ?", (rel_path,)).fetchone()
+    """Insert or replace a note in the index + FTS table.
+
+    For contentless FTS5 (content=''), deletes require passing the old
+    column values via the special 'delete' command, not DELETE FROM.
+    """
+    row = conn.execute("SELECT rowid, title, tags FROM notes WHERE path = ?", (rel_path,)).fetchone()
     if row:
-        conn.execute(
-            "DELETE FROM notes_fts WHERE rowid = ?", (row["rowid"],)
-        )
+        # Contentless FTS5 delete: must pass old values
+        old_rowid = row["rowid"]
+        # Read old body from the FTS shadow tables isn't possible with contentless,
+        # so we need to read it from the note file or accept that we can't do
+        # precise deletes. Instead, drop and recreate the entire FTS table entry
+        # by using DELETE on the notes table first, then rebuild.
+        # Simpler approach: just delete the notes row and skip FTS delete.
+        # The stale FTS entry will be overwritten by the new INSERT with the same rowid.
+        # Actually, contentless FTS doesn't support any form of delete without old values.
+        # The cleanest approach: delete the notes row (rowid freed), insert new one
+        # (gets new rowid), insert new FTS entry. The orphaned FTS entry for the old
+        # rowid is harmless — it won't join with any notes row.
         conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
 
     conn.execute(
@@ -193,7 +205,7 @@ def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: f
         ),
     )
 
-    # Get the rowid for FTS
+    # Get the rowid for FTS insert
     rowid = conn.execute("SELECT rowid FROM notes WHERE path = ?", (rel_path,)).fetchone()["rowid"]
     conn.execute(
         "INSERT INTO notes_fts (rowid, title, body, tags) VALUES (?, ?, ?, ?)",
@@ -202,11 +214,12 @@ def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: f
 
 
 def _delete_note(conn: sqlite3.Connection, rel_path: str) -> None:
-    """Remove a note from the index + FTS table."""
-    row = conn.execute("SELECT rowid FROM notes WHERE path = ?", (rel_path,)).fetchone()
-    if row:
-        conn.execute("DELETE FROM notes_fts WHERE rowid = ?", (row["rowid"],))
-        conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
+    """Remove a note from the index + FTS table.
+
+    For contentless FTS5, we can only delete the notes row. The orphaned
+    FTS entry won't match any JOIN since the notes rowid is gone.
+    """
+    conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
 
 
 def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict:

--- a/skills/check-items/SKILL.md
+++ b/skills/check-items/SKILL.md
@@ -197,7 +197,7 @@ For each project that had confirmed checkoffs, run:
 ```bash
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
-import sys, json
+import sys, os, json
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
 from open_item_dedup import batch_cascade_checkoff
 items = json.loads(sys.argv[4])

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -161,7 +161,7 @@ Where:
   ```bash
   cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   python3 -c '
-  import sys
+  import sys, os
   import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
   from obsidian_utils import load_config, get_session_context
   c = load_config()

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -145,7 +145,7 @@ Where:
   ```bash
   cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   python3 -c '
-  import sys
+  import sys, os
   import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
   from obsidian_utils import load_config, get_session_context
   c = load_config()

--- a/skills/error-log/SKILL.md
+++ b/skills/error-log/SKILL.md
@@ -134,7 +134,7 @@ Where:
   ```bash
   cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
   python3 -c '
-  import sys
+  import sys, os
   import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
   from obsidian_utils import load_config, get_session_context
   c = load_config()

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -494,6 +494,26 @@ echo "test" > "$TESTFILE" && test -f "$TESTFILE" && rm "$TESTFILE" && echo "OK" 
 
 If FAIL, warn that vault writes are not working and ask the user to check permissions.
 
+### Step 8.5 — Build vault index
+
+Build (or rebuild) the SQLite FTS5 index for fast vault search and context-driven insight loading:
+
+```bash
+python3 -c '
+import sys, os, json, glob
+sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from vault_index import rebuild_index
+counts = rebuild_index(sys.argv[1], [sys.argv[2], sys.argv[3]])
+print(json.dumps(counts))
+' "$VAULT_PATH" "$SESSIONS_FOLDER" "$INSIGHTS_FOLDER"
+```
+
+Parse the JSON output. If successful, store `N = counts["inserted"]` for the success message.
+
+If the command fails (non-zero exit), warn but do not block setup:
+
+> ⚠️ Could not build vault index. Run `/vault-reindex` manually after setup.
+
 ### Step 9 — Configure claudeception nudge (idempotent)
 
 Check if the claudeception-to-compress nudge is already configured **globally** (in `~/.claude/`, not the project `.claude/`):
@@ -534,6 +554,7 @@ This is a soft nudge — a non-blocking suggestion, not automatic execution.
 > - Config: preserved (unchanged)
 > - New dashboards: installed (existing dashboards preserved)
 > - Claudeception nudge: configured
+> - Vault index: N notes indexed (run `/vault-reindex` to rebuild)
 >
 > Re-run `/obsidian-setup` anytime to pick up new features.
 
@@ -546,6 +567,7 @@ This is a soft nudge — a non-blocking suggestion, not automatic execution.
 > - Folders created: `claude-sessions/`, `claude-insights/`, `claude-dashboards/`
 > - Dashboards installed: `sessions-overview.md`, `project-index.md`, `weekly-review.md`, `learning-velocity.md`, `decision-timeline.md`, `open-items.md`
 > - Claudeception nudge: configured (run `/compress` reminder after knowledge extraction)
+> - Vault index: N notes indexed (run `/vault-reindex` to rebuild)
 >
 > **Next step — install the Dataview plugin in Obsidian:**
 > 1. Open Obsidian Settings > Community Plugins > Browse

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -554,7 +554,7 @@ This is a soft nudge — a non-blocking suggestion, not automatic execution.
 > - Config: preserved (unchanged)
 > - New dashboards: installed (existing dashboards preserved)
 > - Claudeception nudge: configured
-> - Vault index: N notes indexed (run `/vault-reindex` to rebuild)
+> - Vault index: N notes indexed (run `/vault-reindex` to rebuild) — _or omit this line if Step 8.5 failed_
 >
 > Re-run `/obsidian-setup` anytime to pick up new features.
 
@@ -567,7 +567,7 @@ This is a soft nudge — a non-blocking suggestion, not automatic execution.
 > - Folders created: `claude-sessions/`, `claude-insights/`, `claude-dashboards/`
 > - Dashboards installed: `sessions-overview.md`, `project-index.md`, `weekly-review.md`, `learning-velocity.md`, `decision-timeline.md`, `open-items.md`
 > - Claudeception nudge: configured (run `/compress` reminder after knowledge extraction)
-> - Vault index: N notes indexed (run `/vault-reindex` to rebuild)
+> - Vault index: N notes indexed (run `/vault-reindex` to rebuild) — _or omit this line if Step 8.5 failed_
 >
 > **Next step — install the Dataview plugin in Obsidian:**
 > 1. Open Obsidian Settings > Community Plugins > Browse

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -127,7 +127,7 @@ If the status starts with "Failed:", use the sub-agent fallback:
    ```bash
    cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
    python3 -c '
-   import sys
+   import sys, os
    import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
    from obsidian_utils import upgrade_note_with_summary
    with open(sys.argv[5], "r") as f:

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -341,7 +341,7 @@ Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
     ```bash
     cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
     python3 -c '
-    import sys, json
+    import sys, os, json
     import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
     from open_item_dedup import batch_cascade_checkoff
     items = json.loads(sys.argv[4])

--- a/skills/vault-ask/SKILL.md
+++ b/skills/vault-ask/SKILL.md
@@ -77,9 +77,12 @@ Before spawning search agents, try the vault index for instant results. Join `SE
 python3 -c '
 import sys, os, json, glob
 sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from vault_index import search_vault
+from obsidian_utils import load_config
+from vault_index import ensure_index, search_vault
+c = load_config()
+db = ensure_index(c["vault_path"], [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")])
 results = search_vault(
-    os.path.expanduser("~/.claude/obsidian-brain-vault.db"),
+    db,
     sys.argv[1],
     project=sys.argv[2] if len(sys.argv) > 2 and sys.argv[2] != "None" else None,
     limit=15,

--- a/skills/vault-ask/SKILL.md
+++ b/skills/vault-ask/SKILL.md
@@ -29,11 +29,12 @@ c = load_config()
 if not c.get("vault_path"):
     print("ERROR: vault_path not configured", file=sys.stderr)
     sys.exit(1)
-print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
+project = os.path.basename(os.getcwd()).lower().replace(" ", "-")
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights") + " PROJECT=" + project)
 '
 ```
 
-Parse the output line to extract `VAULT_PATH`, `SESSIONS_FOLDER`, and `INSIGHTS_FOLDER`.
+Parse the output line to extract `VAULT_PATH`, `SESSIONS_FOLDER`, `INSIGHTS_FOLDER`, and `PROJECT`.
 
 If the command exits non-zero or prints ERROR, tell the user:
 

--- a/skills/vault-ask/SKILL.md
+++ b/skills/vault-ask/SKILL.md
@@ -66,9 +66,32 @@ The user provides a question after `/vault-ask`. Extract 3–6 key search terms 
 - **Concept keywords** — e.g. `error handling`, `rate limiting`, `caching`
 - **Action words indicating note types** — e.g. `decided` → look for decision notes, `fixed` → look for error-fix notes
 
-Store the extracted terms as `SEARCH_TERMS`. Keep the original question for use in Step 6.
+Store the extracted terms as `SEARCH_TERMS`. Keep the original question for use in Step 7.
 
-### Step 3 — Search vault (3 parallel agents)
+### Step 3 — FTS pre-filter (fast path)
+
+Before spawning search agents, try the vault index for instant results. Join `SEARCH_TERMS` into a single space-separated string (`SEARCH_TERMS_JOINED`). Then run:
+
+```bash
+python3 -c '
+import sys, os, json, glob
+sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from vault_index import search_vault
+results = search_vault(
+    os.path.expanduser("~/.claude/obsidian-brain-vault.db"),
+    sys.argv[1],
+    project=sys.argv[2] if len(sys.argv) > 2 and sys.argv[2] != "None" else None,
+    limit=15,
+)
+print(json.dumps(results))
+' "$SEARCH_TERMS_JOINED" "$PROJECT"
+```
+
+If the output is a non-empty JSON array with 5+ results: extract the `path` field from each result and use those file paths as `CANDIDATE_FILES`. Skip Step 4 entirely and proceed directly to Step 5.
+
+If fewer than 5 results or the command fails (non-zero exit, invalid JSON, import error): fall through to Step 4 to cast a wider net with parallel Grep agents.
+
+### Step 4 — Search vault (3 parallel agents)
 
 Launch three Grep searches in parallel — one per agent below. Use the Grep tool (never Bash grep).
 
@@ -102,7 +125,7 @@ If `CANDIDATE_FILES` is empty, tell the user:
 
 Stop here.
 
-### Step 4 — Rank results
+### Step 5 — Rank results
 
 Score each file in `CANDIDATE_FILES` using these rules:
 
@@ -122,7 +145,7 @@ to get frontmatter fields (`type:`, `date:`). Use 40 lines because some notes (e
 
 Sort `CANDIDATE_FILES` by score descending. Take the top 10. Store as `RANKED_FILES`.
 
-### Step 5 — Read top notes (context shield)
+### Step 6 — Read top notes (context shield)
 
 Read the top 5–10 files from `RANKED_FILES`. Apply the following size-based strategy:
 
@@ -137,7 +160,7 @@ For each file, extract:
 
 Store all extracted content as `NOTE_SUMMARIES`.
 
-### Step 6 — Synthesize answer
+### Step 7 — Synthesize answer
 
 Using `NOTE_SUMMARIES`, synthesize a comprehensive answer to the user's question. Follow these rules strictly:
 
@@ -161,9 +184,9 @@ Using `NOTE_SUMMARIES`, synthesize a comprehensive answer to the user's question
 If the notes contain contradictory information (e.g. a decision was changed later), surface that explicitly:
 > "You initially chose X ([[older-note]]), but later switched to Y ([[newer-note]])."
 
-### Step 7 — Present answer
+### Step 8 — Present answer
 
-Display the synthesized answer from Step 6 in the conversation.
+Display the synthesized answer from Step 7 in the conversation.
 
 Do NOT write anything to the vault — this skill is read-only.
 

--- a/skills/vault-reindex/SKILL.md
+++ b/skills/vault-reindex/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: vault-reindex
+description: Rebuild the SQLite FTS5 vault index from scratch. Use when the index is stale, corrupt, or after bulk edits in Obsidian.
+metadata:
+  version: 1.0.0
+---
+
+# Vault Reindex — Rebuild FTS5 Index
+
+Rebuilds the vault index from scratch by scanning all vault markdown files. Drops the existing database and re-indexes every note in the configured sessions and insights folders.
+
+**Tools needed:** Bash
+
+## Procedure
+
+Follow these steps exactly. Do not skip steps or reorder them.
+
+### Step 1 — Load config
+
+Run:
+
+```bash
+python3 -c '
+import sys, os, glob
+sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from obsidian_utils import load_config
+c = load_config()
+if not c.get("vault_path"):
+    print("ERROR: vault_path not configured", file=sys.stderr)
+    sys.exit(1)
+print("VAULT=" + c["vault_path"] + " SESS=" + c.get("sessions_folder", "claude-sessions") + " INS=" + c.get("insights_folder", "claude-insights"))
+'
+```
+
+Parse the output line to extract `VAULT`, `SESS`, and `INS` values.
+
+If config is missing or the command fails, tell the user:
+
+> Config not found. Run `/obsidian-setup` first to configure your vault path.
+
+Stop here if config is missing.
+
+### Step 2 — Rebuild
+
+Run, substituting the values extracted in Step 1:
+
+```bash
+python3 -c '
+import sys, os, glob, time, json
+sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from vault_index import rebuild_index
+vault_path = "<VAULT>"
+folders = ["<SESS>", "<INS>"]
+t0 = time.time()
+stats = rebuild_index(vault_path, folders)
+elapsed = time.time() - t0
+stats["elapsed"] = round(elapsed, 1)
+print(json.dumps(stats))
+'
+```
+
+If the command fails (non-zero exit or exception in output), tell the user:
+
+> Index rebuild failed. Check that the vault path is accessible and that the plugin is installed. Error: `<stderr>`
+
+Stop here on failure.
+
+### Step 3 — Report
+
+Parse the JSON output from Step 2. Extract:
+
+- `inserted` — total notes indexed
+- `skipped` — files without valid frontmatter
+- `elapsed` — time in seconds
+- `by_type` — dict mapping note type to count (e.g. `{"claude-session": 42, "claude-insight": 7}`)
+
+Present this report:
+
+> **Rebuilt vault index:** `<inserted>` notes indexed in `<elapsed>`s
+>
+> | Type | Count |
+> |------|-------|
+> | claude-session | `<count>` |
+> | claude-insight | `<count>` |
+> | ... | ... |
+>
+> Skipped: `<skipped>` file(s) without frontmatter.
+
+Only include rows in the table for types that appear in `by_type` (omit zero-count types). Sort rows by count descending.
+
+If `inserted` is 0 and `skipped` is 0, also tell the user:
+
+> No notes found. Verify that `<VAULT>/<SESS>` and `<VAULT>/<INS>` exist and contain markdown files.

--- a/skills/vault-search/SKILL.md
+++ b/skills/vault-search/SKILL.md
@@ -73,9 +73,12 @@ Before falling back to Grep, try the vault index:
 python3 -c '
 import sys, os, json, glob
 sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from vault_index import search_vault
+from obsidian_utils import load_config
+from vault_index import ensure_index, search_vault
+c = load_config()
+db = ensure_index(c["vault_path"], [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")])
 results = search_vault(
-    os.path.expanduser("~/.claude/obsidian-brain-vault.db"),
+    db,
     sys.argv[1],
     project=sys.argv[2] if len(sys.argv) > 2 and sys.argv[2] != "None" else None,
     limit=20,

--- a/skills/vault-search/SKILL.md
+++ b/skills/vault-search/SKILL.md
@@ -81,7 +81,7 @@ results = search_vault(
     limit=20,
 )
 print(json.dumps(results))
-' "$QUERY" "$PROJECT_FILTER"
+' "$QUERY" "$PROJECT"
 ```
 
 If the output is a non-empty JSON array: parse and present results (path, title, type, date, excerpt) using the format in Step 6. Skip Steps 4 and 5 below.

--- a/skills/vault-search/SKILL.md
+++ b/skills/vault-search/SKILL.md
@@ -65,7 +65,30 @@ The user provides a query after `/vault-search`. Determine the search mode:
 - Treat the entire query as a content search
 - Grep for the full phrase first; if zero results, grep for each word individually and intersect
 
-### Step 3 — Search both folders in parallel
+### Step 3 — Try FTS search (fast path)
+
+Before falling back to Grep, try the vault index:
+
+```bash
+python3 -c '
+import sys, os, json, glob
+sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from vault_index import search_vault
+results = search_vault(
+    os.path.expanduser("~/.claude/obsidian-brain-vault.db"),
+    sys.argv[1],
+    project=sys.argv[2] if len(sys.argv) > 2 and sys.argv[2] != "None" else None,
+    limit=20,
+)
+print(json.dumps(results))
+' "$QUERY" "$PROJECT_FILTER"
+```
+
+If the output is a non-empty JSON array: parse and present results (path, title, type, date, excerpt) using the format in Step 6. Skip Steps 4 and 5 below.
+
+If the output is `[]` or the command fails: print a note that the vault index returned no results, then fall through to Step 4. If the command failed because the DB does not exist, also suggest running `/vault-reindex` to build the index.
+
+### Step 4 — Search both folders in parallel
 
 Use the Grep tool (never Bash grep) for all searching. Launch searches across both `SESSIONS_DIR` and `INSIGHTS_DIR` in parallel.
 
@@ -87,7 +110,7 @@ Run two parallel Grep calls:
 
 If zero results and query has multiple words, retry by grepping each word separately and intersecting the file lists.
 
-### Step 4 — Extract metadata from matches
+### Step 5 — Extract metadata from matches
 
 For each matched file (up to 20 files), use Read to read the first 40 lines. Extract from frontmatter:
 
@@ -102,7 +125,7 @@ If there are more than 20 matched files, sort by filename (which contains the da
 
 **Performance note:** If there are 10 or fewer matches, read all files in parallel. If there are 11-20, read in two parallel batches.
 
-### Step 5 — Sort and present results
+### Step 6 — Sort and present results
 
 Sort results by date descending (most recent first). Present in this format:
 
@@ -129,8 +152,9 @@ After the list, tell the user:
 
 > Pick a number to load the full note, or refine your search.
 
-### Step 6 — Handle user selection
+### Step 7 — Handle user selection
 
 If the user picks a number, read the full content of that file using the Read tool and present it in the conversation.
 
 If the user provides a new query, go back to Step 2.
+

--- a/tests/test_skill_snippets.py
+++ b/tests/test_skill_snippets.py
@@ -75,16 +75,25 @@ def test_cache_glob_finds_installed_hooks():
 
 
 def test_snippets_import_os_before_expanduser():
-    """Snippets using os.path.expanduser must import os first."""
+    """Snippets using os.path.expanduser must import os on a PRIOR line.
+
+    The check must not false-pass by matching 'os' in usage lines like
+    ``import glob; ... os.path.expanduser(...)``. Only actual import
+    statements count: ``import os``, ``import sys, os``, etc.
+    """
+    # Matches 'import os' as a standalone import or in a comma-separated list
+    _IMPORT_OS_RE = re.compile(
+        r'^\s*import\s+(?:[\w]+\s*,\s*)*os(?:\s*,|\s*$)'
+    )
     for name, code in _SNIPPETS:
         if "os.path.expanduser" not in code:
             continue
         lines = code.strip().split("\n")
         os_imported = False
         for line in lines:
-            if re.search(r'\bimport\b.*\bos\b', line):
+            if _IMPORT_OS_RE.search(line):
                 os_imported = True
-            if "os.path.expanduser" in line:
+            if "os.path.expanduser" in line and not _IMPORT_OS_RE.search(line):
                 assert os_imported, (
                     f"Snippet {name} uses os.path.expanduser "
                     "before importing os"

--- a/tests/test_skill_snippets.py
+++ b/tests/test_skill_snippets.py
@@ -74,8 +74,8 @@ def test_cache_glob_finds_installed_hooks():
     )
 
 
-def test_snippets_import_os_before_expanduser():
-    """Snippets using os.path.expanduser must import os on a PRIOR line.
+def test_snippets_import_os_before_usage():
+    """Snippets using os.* must import os on a PRIOR line.
 
     The check must not false-pass by matching 'os' in usage lines like
     ``import glob; ... os.path.expanduser(...)``. Only actual import
@@ -85,17 +85,17 @@ def test_snippets_import_os_before_expanduser():
     _IMPORT_OS_RE = re.compile(
         r'^\s*import\s+(?:[\w]+\s*,\s*)*os(?:\s*,|\s*$)'
     )
+    _OS_USAGE_RE = re.compile(r'\bos\.')
     for name, code in _SNIPPETS:
-        if "os.path.expanduser" not in code:
+        if not _OS_USAGE_RE.search(code):
             continue
         lines = code.strip().split("\n")
         os_imported = False
         for line in lines:
             if _IMPORT_OS_RE.search(line):
                 os_imported = True
-            if "os.path.expanduser" in line and not _IMPORT_OS_RE.search(line):
+            if _OS_USAGE_RE.search(line) and not _IMPORT_OS_RE.search(line):
                 assert os_imported, (
-                    f"Snippet {name} uses os.path.expanduser "
-                    "before importing os"
+                    f"Snippet {name} uses os.* before importing os"
                 )
                 break

--- a/tests/test_vault_index.py
+++ b/tests/test_vault_index.py
@@ -1,0 +1,459 @@
+"""Tests for hooks/vault_index.py — SQLite + FTS5 vault index."""
+
+import os
+import sqlite3
+import time
+from unittest.mock import patch
+
+import pytest
+
+import vault_index
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_note(path, frontmatter: dict, body: str = ""):
+    lines = ["---"]
+    for k, v in frontmatter.items():
+        if isinstance(v, list):
+            lines.append(f"{k}:")
+            for item in v:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{k}: {v}")
+    lines.append("---")
+    lines.append("")
+    if body:
+        lines.append(body)
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Commit 1: Schema + ensure_index + sync engine
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureIndex:
+    def test_ensure_index_creates_tables(self, tmp_vault):
+        """Empty vault creates notes + notes_fts tables."""
+        db_path = str(tmp_vault / "test.db")
+        result = vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db_path
+        )
+        assert result == db_path
+
+        conn = sqlite3.connect(db_path)
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type IN ('table', 'virtual table')"
+            ).fetchall()
+        }
+        conn.close()
+
+        assert "notes" in tables
+        # FTS5 tables show up with suffixes but the base name should be present
+        assert any("notes_fts" in t for t in tables)
+
+    def test_ensure_index_returns_db_path(self, tmp_vault):
+        """Returns path ending in obsidian-brain-vault.db when no override."""
+        db_path = str(tmp_vault / "obsidian-brain-vault.db")
+        result = vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions"], db_path=db_path
+        )
+        assert result.endswith("obsidian-brain-vault.db")
+
+
+class TestInsertAndSync:
+    def test_insert_single_note(self, tmp_vault):
+        """Index a note, verify all columns."""
+        note = tmp_vault / "claude-sessions" / "2026-04-10-myproj-abcd.md"
+        _write_note(
+            note,
+            {
+                "type": "claude-session",
+                "date": "2026-04-10",
+                "project": "myproj",
+                "session_id": "sess-1234",
+                "source_session_note": "[[2026-04-09-myproj-prev.md]]",
+                "tags": ["claude/session", "claude/project/myproj"],
+                "status": "summarized",
+            },
+            body="# Session: myproj\n\nDid some work on the widget.",
+        )
+
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM notes").fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row["type"] == "claude-session"
+        assert row["project"] == "myproj"
+        assert row["tags"] == "claude/session,claude/project/myproj"
+        assert row["title"] == "Session: myproj"
+        assert row["source_session"] == "sess-1234"
+        assert row["source_note"] == "2026-04-09-myproj-prev.md"
+        assert row["size"] > 0
+
+    def test_mtime_skip(self, tmp_vault):
+        """Unchanged file not re-read on second ensure_index."""
+        note = tmp_vault / "claude-sessions" / "2026-04-10-proj-skip.md"
+        _write_note(
+            note,
+            {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+            body="# Session: proj\n\nOriginal body.",
+        )
+
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        # Second call — file not changed, open should not be called for parsing
+        with patch("builtins.open", wraps=open) as mock_open:
+            vault_index.ensure_index(
+                str(tmp_vault), ["claude-sessions"], db_path=db_path
+            )
+            # open() should NOT have been called with the note path for parsing
+            # (it may be called for the DB itself by sqlite3)
+            note_calls = [
+                c
+                for c in mock_open.call_args_list
+                if len(c.args) > 0 and str(note) in str(c.args[0])
+            ]
+            assert len(note_calls) == 0, f"Note file was re-read: {note_calls}"
+
+    def test_update_changed_file(self, tmp_vault):
+        """Modified file (bumped mtime) re-indexed with new title."""
+        note = tmp_vault / "claude-sessions" / "2026-04-10-proj-upd.md"
+        _write_note(
+            note,
+            {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+            body="# Session: Original Title\n\nBody.",
+        )
+
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        # Modify file (need mtime to change)
+        time.sleep(0.05)
+        _write_note(
+            note,
+            {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+            body="# Session: Updated Title\n\nNew body.",
+        )
+
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT title FROM notes").fetchone()
+        conn.close()
+
+        assert row["title"] == "Session: Updated Title"
+
+    def test_delete_removed_file(self, tmp_vault):
+        """Deleted vault file removed from index."""
+        note = tmp_vault / "claude-sessions" / "2026-04-10-proj-del.md"
+        _write_note(
+            note,
+            {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+            body="# Session: To Delete\n\nBody.",
+        )
+
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        # Delete file
+        note.unlink()
+
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        count = conn.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
+        conn.close()
+
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Commit 2: rebuild_index + index_note
+# ---------------------------------------------------------------------------
+
+
+class TestRebuildIndex:
+    def test_rebuild_index_clean_slate(self, tmp_vault):
+        """Stale entries removed, fresh files indexed."""
+        note1 = tmp_vault / "claude-sessions" / "note1.md"
+        _write_note(
+            note1,
+            {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+            body="# Note 1\n\nBody one.",
+        )
+
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        # Now delete note1, add note2, rebuild
+        note1.unlink()
+        note2 = tmp_vault / "claude-sessions" / "note2.md"
+        _write_note(
+            note2,
+            {"type": "claude-insight", "date": "2026-04-11", "project": "proj"},
+            body="# Note 2\n\nBody two.",
+        )
+
+        stats = vault_index.rebuild_index(
+            str(tmp_vault), ["claude-sessions"], db_path=db_path
+        )
+
+        assert stats["inserted"] == 1
+        assert "claude-insight" in stats["by_type"]
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT path FROM notes").fetchall()
+        conn.close()
+
+        paths = [r["path"] for r in rows]
+        assert len(paths) == 1
+        assert "note2.md" in paths[0]
+
+
+class TestIndexNote:
+    def test_index_note_single_file(self, tmp_vault):
+        """Single-file upsert into existing DB."""
+        db_path = str(tmp_vault / "test.db")
+        # Create empty DB first
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        note = tmp_vault / "claude-insights" / "insight1.md"
+        _write_note(
+            note,
+            {
+                "type": "claude-insight",
+                "date": "2026-04-10",
+                "project": "proj",
+                "tags": ["claude/insight", "claude/topic/testing"],
+            },
+            body="# Insight: Testing Patterns\n\nAlways use fixtures.",
+        )
+
+        result = vault_index.index_note(db_path, str(note))
+        assert result is True
+
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM notes WHERE type = 'claude-insight'").fetchone()
+        conn.close()
+
+        assert row is not None
+        assert row["title"] == "Insight: Testing Patterns"
+
+
+# ---------------------------------------------------------------------------
+# Commit 3: search_vault + FTS
+# ---------------------------------------------------------------------------
+
+
+class TestSearchVault:
+    def _populate_vault(self, tmp_vault):
+        """Create several notes for search testing."""
+        notes = [
+            (
+                "claude-sessions/sess1.md",
+                {
+                    "type": "claude-session",
+                    "date": "2026-04-10",
+                    "project": "alpha",
+                    "tags": ["claude/session"],
+                },
+                "# Session: Alpha Sprint\n\nImplemented authentication module with JWT tokens.",
+            ),
+            (
+                "claude-sessions/sess2.md",
+                {
+                    "type": "claude-session",
+                    "date": "2026-04-11",
+                    "project": "beta",
+                    "tags": ["claude/session"],
+                },
+                "# Session: Beta Refactor\n\nRefactored database layer for performance.",
+            ),
+            (
+                "claude-insights/insight1.md",
+                {
+                    "type": "claude-insight",
+                    "date": "2026-04-10",
+                    "project": "alpha",
+                    "tags": ["claude/insight", "claude/topic/auth"],
+                },
+                "# Insight: JWT Best Practices\n\nAlways rotate JWT signing keys.",
+            ),
+        ]
+        for rel_path, fm, body in notes:
+            path = tmp_vault / rel_path
+            _write_note(path, fm, body)
+
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db_path
+        )
+        return db_path
+
+    def test_fts_search_returns_relevant_results(self, tmp_vault):
+        """FTS search returns matching notes ranked."""
+        db_path = self._populate_vault(tmp_vault)
+
+        results = vault_index.search_vault(db_path, "JWT authentication")
+        assert len(results) >= 1
+        # JWT notes should be in results
+        titles = [r["title"] for r in results]
+        assert any("JWT" in t for t in titles)
+
+    def test_search_vault_with_project_filter(self, tmp_vault):
+        """Project filter narrows results."""
+        db_path = self._populate_vault(tmp_vault)
+
+        results = vault_index.search_vault(db_path, "session", project="alpha")
+        for r in results:
+            assert r["project"] == "alpha"
+
+    def test_search_vault_nonexistent_db(self, tmp_path):
+        """Non-existent DB returns empty list."""
+        results = vault_index.search_vault(
+            str(tmp_path / "nonexistent.db"), "test"
+        )
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Commit 4: extract_keywords + query_related_notes + corrupt DB
+# ---------------------------------------------------------------------------
+
+
+class TestExtractKeywords:
+    def test_extract_keywords(self):
+        """Removes stopwords and short words, returns <= 8."""
+        text = (
+            "Implemented the authentication module with JWT tokens "
+            "and added comprehensive test coverage for the login flow. "
+            "The authentication system uses rotating keys."
+        )
+        keywords = vault_index.extract_keywords(text)
+        assert len(keywords) <= 8
+        assert len(keywords) > 0
+        # "the", "and", "with" etc. should be excluded
+        assert "the" not in keywords
+        assert "and" not in keywords
+        assert "with" not in keywords
+        # Short words like "an", "it" excluded
+        assert "an" not in keywords
+        # "authentication" should appear (it's repeated)
+        assert "authentication" in keywords
+
+
+class TestQueryRelatedNotes:
+    def test_query_related_notes_layered_ranking(self, tmp_vault):
+        """Fills slots: backlinks first, then tags, then FTS."""
+        # Create notes with different relationship types
+        # Note linked via session_id (backlink)
+        backlink_note = tmp_vault / "claude-insights" / "backlink.md"
+        _write_note(
+            backlink_note,
+            {
+                "type": "claude-insight",
+                "date": "2026-04-10",
+                "project": "proj",
+                "session_id": "sess-A",
+                "tags": ["claude/insight"],
+            },
+            body="# Insight: Backlinked\n\nThis is linked via session.",
+        )
+
+        # Note linked via topic tag
+        tag_note = tmp_vault / "claude-insights" / "tagged.md"
+        _write_note(
+            tag_note,
+            {
+                "type": "claude-insight",
+                "date": "2026-04-10",
+                "project": "proj",
+                "tags": ["claude/insight", "claude/topic/testing"],
+            },
+            body="# Insight: Tagged\n\nThis shares a topic tag.",
+        )
+
+        # Note findable via FTS only
+        fts_note = tmp_vault / "claude-insights" / "fts_only.md"
+        _write_note(
+            fts_note,
+            {
+                "type": "claude-insight",
+                "date": "2026-04-10",
+                "project": "proj",
+                "tags": ["claude/insight"],
+            },
+            body="# Insight: FTS Match\n\nThis note discusses frobulator optimization.",
+        )
+
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db_path
+        )
+
+        results = vault_index.query_related_notes(
+            db_path,
+            project="proj",
+            session_ids=["sess-A"],
+            session_tags=["claude/topic/testing"],
+            session_summary="We worked on frobulator optimization and testing patterns.",
+            limit=20,
+        )
+
+        assert len(results) >= 1
+
+        # Check layer ordering: backlinks should come before tags, tags before FTS
+        layers = [r["layer"] for r in results]
+        layer_order = {"backlink": 0, "tag": 1, "fts": 2}
+
+        # Verify layers are in correct order (backlink < tag < fts)
+        for i in range(len(layers) - 1):
+            assert layer_order.get(layers[i], 99) <= layer_order.get(
+                layers[i + 1], 99
+            ), f"Layer order violated: {layers}"
+
+
+class TestCorruptDB:
+    def test_corrupt_db_auto_recovery(self, tmp_vault):
+        """Truncated DB triggers auto-rebuild on ensure_index."""
+        note = tmp_vault / "claude-sessions" / "note.md"
+        _write_note(
+            note,
+            {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+            body="# Session: Recovery Test\n\nBody.",
+        )
+
+        db_path = str(tmp_vault / "test.db")
+
+        # Create a corrupt DB file
+        with open(db_path, "wb") as f:
+            f.write(b"this is not a valid sqlite database")
+
+        # ensure_index should recover by deleting and recreating
+        result = vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions"], db_path=db_path
+        )
+        assert result == db_path
+
+        # Verify the DB is now valid and has the note
+        conn = sqlite3.connect(db_path)
+        count = conn.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
+        conn.close()
+        assert count == 1

--- a/tests/test_vault_index.py
+++ b/tests/test_vault_index.py
@@ -78,7 +78,7 @@ class TestInsertAndSync:
                 "type": "claude-session",
                 "date": "2026-04-10",
                 "project": "myproj",
-                "session_id": "sess-1234",
+                "source_session": "sess-1234",
                 "source_session_note": "[[2026-04-09-myproj-prev.md]]",
                 "tags": ["claude/session", "claude/project/myproj"],
                 "status": "summarized",
@@ -457,3 +457,171 @@ class TestCorruptDB:
         count = conn.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
         conn.close()
         assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Additional edge case tests (from review)
+# ---------------------------------------------------------------------------
+
+
+class TestIndexNoteFailurePaths:
+    """index_note() returns False for various failure modes."""
+
+    def test_index_note_nonexistent_db(self, tmp_vault):
+        result = vault_index.index_note("/tmp/nonexistent.db", "/tmp/some.md")
+        assert result is False
+
+    def test_index_note_nonexistent_note(self, tmp_vault):
+        db = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db)
+        result = vault_index.index_note(db, "/tmp/nonexistent-note.md")
+        assert result is False
+
+    def test_index_note_no_frontmatter(self, tmp_vault):
+        db = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db)
+        note = tmp_vault / "claude-sessions" / "plain.md"
+        note.write_text("Just plain text, no frontmatter.", encoding="utf-8")
+        result = vault_index.index_note(db, str(note))
+        assert result is False
+
+
+class TestLayeredRankingStrong:
+    """Stronger assertions on layered ranking order."""
+
+    def test_all_three_layers_present(self, tmp_vault):
+        """All three layers contribute results and maintain order."""
+        # Layer 1: backlink
+        _write_note(
+            tmp_vault / "claude-insights" / "2026-04-10-bl.md",
+            {
+                "type": "claude-insight",
+                "date": "2026-04-10",
+                "project": "proj",
+                "source_session": "sess-X",
+                "tags": ["claude/insight"],
+            },
+            "# Backlinked\n\nDirect provenance.",
+        )
+        # Layer 2: tag match (no backlink)
+        _write_note(
+            tmp_vault / "claude-insights" / "2026-04-10-tg.md",
+            {
+                "type": "claude-insight",
+                "date": "2026-04-10",
+                "project": "proj",
+                "tags": ["claude/insight", "claude/topic/perf"],
+            },
+            "# Tagged\n\nRelated by topic.",
+        )
+        # Layer 3: FTS only (no backlink, no shared tag)
+        _write_note(
+            tmp_vault / "claude-insights" / "2026-04-10-kw.md",
+            {
+                "type": "claude-insight",
+                "date": "2026-04-10",
+                "project": "proj",
+                "tags": ["claude/insight"],
+            },
+            "# Keyword\n\nOptimization and performance caching patterns.",
+        )
+
+        db = str(tmp_vault / "test.db")
+        vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db
+        )
+
+        results = vault_index.query_related_notes(
+            db_path=db,
+            project="proj",
+            session_ids=["sess-X"],
+            session_tags=["claude/topic/perf"],
+            session_summary="Working on caching and optimization performance",
+            limit=20,
+        )
+
+        assert len(results) == 3
+        layers = [r["layer"] for r in results]
+        assert layers[0] == "backlink"
+        assert layers[1] == "tag"
+        assert layers[2] == "fts"
+        # No duplicates
+        paths = [r["path"] for r in results]
+        assert len(set(paths)) == 3
+
+    def test_deduplication_across_layers(self, tmp_vault):
+        """A note matching Layer 1 is not duplicated in Layer 2."""
+        _write_note(
+            tmp_vault / "claude-insights" / "2026-04-10-both.md",
+            {
+                "type": "claude-insight",
+                "date": "2026-04-10",
+                "project": "proj",
+                "source_session": "sess-Y",
+                "tags": ["claude/insight", "claude/topic/auth"],
+            },
+            "# Both Layers\n\nMatches backlink and tag.",
+        )
+
+        db = str(tmp_vault / "test.db")
+        vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db
+        )
+
+        results = vault_index.query_related_notes(
+            db_path=db,
+            project="proj",
+            session_ids=["sess-Y"],
+            session_tags=["claude/topic/auth"],
+            session_summary="authentication patterns",
+            limit=20,
+        )
+
+        assert len(results) == 1
+        assert results[0]["layer"] == "backlink"  # found in Layer 1, not duplicated
+
+
+class TestBuildContextBriefFallback:
+    """build_context_brief() falls back to file scan when vault index is unavailable."""
+
+    def test_fallback_when_vault_index_import_fails(self, tmp_vault, mock_config, monkeypatch):
+        """Insights still appear when vault_index module is missing."""
+        import obsidian_utils
+
+        # Create an insight note
+        insight = tmp_vault / "claude-insights" / "2026-04-10-test-insight.md"
+        insight.write_text(
+            "---\n"
+            "type: claude-insight\n"
+            "date: 2026-04-10\n"
+            "project: test-project\n"
+            "tags:\n"
+            "  - claude/insight\n"
+            "---\n\n"
+            "# Fallback Insight\n\n"
+            "This should appear via file scan fallback.\n",
+            encoding="utf-8",
+        )
+
+        # Stub session ID and cache
+        monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: "test-sid")
+        monkeypatch.setattr(obsidian_utils, "cache_get", lambda *a: None)
+        monkeypatch.setattr(obsidian_utils, "cache_set", lambda *a: None)
+
+        # Block vault_index import by removing it from sys.modules and path
+        import sys as _sys
+        monkeypatch.delitem(_sys.modules, "vault_index", raising=False)
+        original_import = __builtins__.__import__ if hasattr(__builtins__, '__import__') else __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "vault_index":
+                raise ImportError("vault_index not available")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", mock_import)
+
+        brief = obsidian_utils.build_context_brief(
+            str(tmp_vault), "claude-sessions", "claude-insights", "test-project",
+        )
+
+        assert "Fallback Insight" in brief

--- a/tests/test_vault_index.py
+++ b/tests/test_vault_index.py
@@ -332,6 +332,33 @@ class TestSearchVault:
         )
         assert results == []
 
+    def test_search_vault_hyphenated_query(self, tmp_vault):
+        """Hyphenated queries find notes containing both words (not NOT)."""
+        # Create a note with "maintain" and "catalog" in body
+        _write_note(
+            tmp_vault / "claude-insights" / "maintain-catalogs.md",
+            {"type": "claude-insight", "date": "2026-04-12", "project": "test"},
+            "# Maintain Catalogs\n\nAlways use /maintain-catalogs for catalog additions.",
+        )
+        db = str(tmp_vault / "test.db")
+        vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db
+        )
+
+        # "maintain-catalog" should find the note (not exclude it via NOT)
+        results = vault_index.search_vault(db, "maintain-catalog")
+        assert len(results) >= 1
+        assert any("Maintain" in r["title"] for r in results)
+
+    def test_sanitize_fts_query_strips_hyphens(self):
+        """_sanitize_fts_query replaces hyphens with spaces to avoid FTS5 NOT."""
+        from vault_index import _sanitize_fts_query
+
+        result = _sanitize_fts_query("maintain-catalog")
+        assert "-" not in result
+        assert '"maintain"' in result
+        assert '"catalog"' in result
+
 
 # ---------------------------------------------------------------------------
 # Commit 4: extract_keywords + query_related_notes + corrupt DB

--- a/tests/test_vault_index.py
+++ b/tests/test_vault_index.py
@@ -371,10 +371,10 @@ class TestQueryRelatedNotes:
                 "type": "claude-insight",
                 "date": "2026-04-10",
                 "project": "proj",
-                "session_id": "sess-A",
+                "source_session": "sess-A",
                 "tags": ["claude/insight"],
             },
-            body="# Insight: Backlinked\n\nThis is linked via session.",
+            body="# Insight: Backlinked\n\nThis is linked via source_session.",
         )
 
         # Note linked via topic tag

--- a/tests/test_vault_index.py
+++ b/tests/test_vault_index.py
@@ -332,6 +332,33 @@ class TestSearchVault:
         )
         assert results == []
 
+    def test_ensure_index_syncs_new_files_before_search(self, tmp_vault):
+        """ensure_index() picks up files added after initial index build."""
+        db = str(tmp_vault / "test.db")
+        # Build initial index with one note
+        _write_note(
+            tmp_vault / "claude-insights" / "2026-04-12-old.md",
+            {"type": "claude-insight", "date": "2026-04-12", "project": "test"},
+            "# Old Insight\n\nExisting content about caching.",
+        )
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db)
+
+        # Add a new note AFTER initial index
+        _write_note(
+            tmp_vault / "claude-insights" / "2026-04-12-new.md",
+            {"type": "claude-insight", "date": "2026-04-12", "project": "test"},
+            "# Fresh Discovery\n\nBrand new insight about performance tuning.",
+        )
+
+        # Without re-syncing, search won't find it
+        results_stale = vault_index.search_vault(db, "performance tuning")
+        assert not any("Fresh" in r["title"] for r in results_stale)
+
+        # After ensure_index (lazy sync), the new note is found
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db)
+        results_fresh = vault_index.search_vault(db, "performance tuning")
+        assert any("Fresh" in r["title"] for r in results_fresh)
+
     def test_search_vault_hyphenated_query(self, tmp_vault):
         """Hyphenated queries find notes containing both words (not NOT)."""
         # Create a note with "maintain" and "catalog" in body


### PR DESCRIPTION
## Summary
- Adds `hooks/vault_index.py` — SQLite + FTS5 vault index with lazy mtime-based sync, layered ranking queries (backlinks → tags → FTS keywords), and sub-millisecond ad-hoc full-text search
- Migrates `build_context_brief()` to surface contextually relevant insights (insights, decisions, error-fixes, retros) instead of most-recent-by-mtime, with file-scan fallback if index unavailable
- Adds `/vault-reindex` skill, `/obsidian-setup` Step 8.5 bootstrapping, and FTS fast paths in `/vault-search` and `/vault-ask`
- 20 new tests in `test_vault_index.py`, 204 total passing at 91.47% coverage

## Review fixes applied
- Switched FTS5 to contentless (`content=''`) — no body column needed in notes table
- Fixed `source_session` mapping (was incorrectly using `session_id` key)
- Added `try/finally` for connection cleanup in all public functions (fixes connection leaks)
- Replaced bare `except Exception` with split ImportError + logged fallback in `build_context_brief()`
- Added stderr logging for corrupt DB recovery, layer query failures
- Added project filter to Layer 1 (backlinks) query
- Filtered `note_types` to insights/decisions/error-fixes/retros (not sessions)

## Test plan
- [x] All 204 tests pass (`python3 -m pytest tests/ -v`)
- [x] Coverage at 91.47% (threshold: 90%)
- [x] Preflight passes (secrets, version-sync, tests)
- [x] Code review: connection leaks, schema mismatch, error handling all addressed
- [x] Silent failure hunt: all critical/high findings addressed
- [x] Test coverage review: fallback path, index_note failures, strong layered ranking assertions added
- [ ] `/dev-test install` → fresh session → `/obsidian-setup` bootstraps DB
- [ ] `/vault-reindex` reports correct note counts
- [ ] `/recall` loads insights via layered ranking
- [ ] `/vault-search` returns FTS results sub-second

🤖 Generated with [Claude Code](https://claude.com/claude-code)