### PR TITLE
feat: /compress update mode — append to existing notes via FTS5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `/compress <topic>` update mode — searches vault index for existing notes via FTS5 and offers to append a dated `## Update (YYYY-MM-DD)` section instead of creating duplicates
+- New `last_updated` frontmatter field set on each append to existing insight/decision notes
+- New topic tags from update content are appended without duplicating existing tags
 - `enforce-pr-base-branch.py` PreToolUse hook — blocks pull request creation without `--base develop` on feature branches and verifies base branch before merge, preventing accidental merges to main
 - `hooks/vault_index.py` — SQLite + FTS5 vault index with lazy mtime-based sync, layered ranking queries (backlinks → tags → FTS keywords), and sub-millisecond ad-hoc search
 - `/vault-reindex` skill — full index rebuild for recovery, setup, and after bulk Obsidian edits

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -371,4 +371,4 @@ If processing multiple insights from Step 4B, repeat Steps 5-9 for each remainin
 
 After all insights are saved, ask:
 
-> Anything else to capture from this session? You can run `/compress` again or `/compress <topic>` for a specific topic.
+> Anything else to capture from this session? You can run `/compress` again, `/compress <topic>` for a specific topic, or `/compress <topic>` to update an existing note.

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -95,7 +95,9 @@ else:
 ' "$TOPIC"
 ~~~
 
-Parse the JSON output. If `match` is `true`, store the `path` field as `MATCH_PATH` and the `title` field as `MATCH_TITLE`.
+Parse the JSON output. If the script exits non-zero or the output cannot be parsed as JSON, treat it as `{"match": false}` and proceed silently (log a note: "Could not search vault index; creating new note.").
+
+If `match` is `true`, store the `path` field as `MATCH_PATH` and the `title` field as `MATCH_TITLE`. Format `tags` by splitting on commas and joining with `, `. If `tags` is empty or null, display "no tags".
 
 **If `match` is `false`:** No existing note found. Proceed silently to Step 4A (create new note).
 
@@ -169,6 +171,8 @@ Use the Edit tool to append the update section to the note body.
 **Insertion point:** Scan the note from the bottom for these trailing metadata patterns: `_(Summary source: ...)_`, `## Tool Usage`, `## Conversation (raw)`, `## Session Metadata`, `## Files Touched`. If any are found, insert the update section on a new line immediately BEFORE the first trailing section. If none are found, append at the very end of the file.
 
 Use the Edit tool with the first line of the trailing section (or the last line of the file) as `old_string`, and prepend the update section + a blank line before it.
+
+**Verify:** After the Edit, use the Read tool to confirm the `## Update (YYYY-MM-DD)` heading is present in the note. If it is not, tell the user: "Failed to append update section — file may have unexpected structure. Please edit manually at `$MATCH_PATH`." Do NOT proceed to 4A-update.5 if the append failed.
 
 #### 4A-update.5 — Update frontmatter
 

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -82,7 +82,7 @@ results += search_vault(db, sys.argv[1], note_type="claude-decision", limit=3)
 # Sort combined results by rank (most negative = best match)
 results.sort(key=lambda r: r["rank"])
 # Apply high-confidence threshold: top result must have rank <= -5.0
-# AND must be significantly ahead of #2 (at least 3x better rank)
+# AND must be significantly ahead of #2 (at least 1.5x better rank)
 if results:
     top = results[0]
     rank_gap_ok = len(results) < 2 or abs(top["rank"]) > abs(results[1]["rank"]) * 1.5
@@ -95,7 +95,7 @@ else:
 ' "$TOPIC"
 ~~~
 
-Parse the JSON output.
+Parse the JSON output. If `match` is `true`, store the `path` field as `MATCH_PATH` and the `title` field as `MATCH_TITLE`.
 
 **If `match` is `false`:** No existing note found. Proceed silently to Step 4A (create new note).
 
@@ -164,9 +164,11 @@ If **cancel**, stop here.
 
 #### 4A-update.4 — Append the update section
 
-Use the Edit tool to append the update section at the end of the note body. Find the last non-empty line of the note and insert after it.
+Use the Edit tool to append the update section to the note body.
 
-**Insertion point:** If the note ends with metadata sections like `_(Summary source: ...)_` or `## Tool Usage`, insert BEFORE those trailing sections. Otherwise append at the very end.
+**Insertion point:** Scan the note from the bottom for these trailing metadata patterns: `_(Summary source: ...)_`, `## Tool Usage`, `## Conversation (raw)`, `## Session Metadata`, `## Files Touched`. If any are found, insert the update section on a new line immediately BEFORE the first trailing section. If none are found, append at the very end of the file.
+
+Use the Edit tool with the first line of the trailing section (or the last line of the file) as `old_string`, and prepend the update section + a blank line before it.
 
 #### 4A-update.5 — Update frontmatter
 
@@ -192,8 +194,11 @@ from obsidian_utils import load_config
 c = load_config()
 vp = c["vault_path"]
 folders = [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")]
-ensure_index(vp, folders)
-print("OK")
+try:
+    ensure_index(vp, folders)
+    print("OK")
+except Exception as e:
+    print(f"WARN: re-sync failed (non-fatal): {e}")
 '
 ~~~
 
@@ -371,4 +376,4 @@ If processing multiple insights from Step 4B, repeat Steps 5-9 for each remainin
 
 After all insights are saved, ask:
 
-> Anything else to capture from this session? You can run `/compress` again, `/compress <topic>` for a specific topic, or `/compress <topic>` to update an existing note.
+> Anything else to capture from this session? You can run `/compress` again or `/compress <topic>` to extract a specific topic (will offer to update if an existing note matches).

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -2,7 +2,7 @@
 name: compress
 description: "Interactively saves curated insights from the current Claude Code session to the Obsidian vault. Use when: (1) /compress command to save session insights, (2) /compress <topic> to extract a specific topic, (3) user wants to capture decisions, patterns, solutions, or error fixes from the current session."
 metadata:
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # Compress — Save Session Insights to Obsidian

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -120,6 +120,94 @@ Analyze the current conversation for content related to the user's specified top
 
 Skip to Step 5.
 
+### Step 4A-update — Append to existing note
+
+This step is reached when the user chose "update" in Step 3.5. The matched note path is `$MATCH_PATH`.
+
+#### 4A-update.1 — Read the existing note
+
+Use the Read tool to read the full contents of `$MATCH_PATH`. Note the existing frontmatter tags and whether a `last_updated` field is already present.
+
+#### 4A-update.2 — Draft the update section
+
+Analyze the current conversation for content related to the topic. Draft a dated update section:
+
+~~~markdown
+## Update (YYYY-MM-DD)
+
+<New content about this topic from today's session. Include:
+- New findings, corrections, or extensions to the original insight
+- Code snippets or commands if relevant
+- Context on why this update was triggered>
+~~~
+
+Where `YYYY-MM-DD` is today's date.
+
+**Important:** Do NOT rewrite or duplicate existing content. The update section captures only what is NEW from this session.
+
+#### 4A-update.3 — Show preview and ask for edits
+
+Present ONLY the new update section (not the full existing note):
+
+> **Update section to append to "< existing note title>":**
+>
+> (show the drafted `## Update (YYYY-MM-DD)` section)
+>
+> Preview above. Would you like to:
+> - **save** — append this update
+> - **edit content** — tell me what to change
+> - **cancel** — discard this update
+
+Wait for the user's response. Apply edits and re-show if requested. Repeat until the user says **save** or **cancel**.
+
+If **cancel**, stop here.
+
+#### 4A-update.4 — Append the update section
+
+Use the Edit tool to append the update section at the end of the note body. Find the last non-empty line of the note and insert after it.
+
+**Insertion point:** If the note ends with metadata sections like `_(Summary source: ...)_` or `## Tool Usage`, insert BEFORE those trailing sections. Otherwise append at the very end.
+
+#### 4A-update.5 — Update frontmatter
+
+Use the Edit tool to update the frontmatter of the existing note:
+
+1. **`last_updated` field:** If `last_updated:` already exists in the frontmatter, replace its value with today's date. If it does not exist, add `last_updated: YYYY-MM-DD` after the `date:` line.
+
+2. **New topic tags:** Generate 1-3 topic tags from the update content (same logic as Step 5). For each new tag, check if it already exists in the `tags:` list. Only append tags that are NOT already present. Add new tags at the end of the tags list, before the closing `---`.
+
+**Do NOT change:** `date`, `source_session`, `source_session_note`, or `type` fields. These record the original creation context.
+
+#### 4A-update.6 — Re-sync vault index
+
+Run:
+
+~~~bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 -c '
+import sys, os
+import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from vault_index import ensure_index
+from obsidian_utils import load_config
+c = load_config()
+vp = c["vault_path"]
+folders = [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")]
+ensure_index(vp, folders)
+print("OK")
+'
+~~~
+
+#### 4A-update.7 — Confirm
+
+Print:
+
+> **Note updated!**
+> - File: `$MATCH_PATH`
+> - Added section: "Update (YYYY-MM-DD)"
+> - New tags: `<list of newly added tags>` (or "none")
+
+Skip to Step 10 (offer follow-up). Do NOT proceed through Steps 5-9 (those are the create-new flow).
+
 ### Step 4B — Multi-insight suggestion
 
 **First, check for claudeception output** using layered detection:

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -59,8 +59,56 @@ Stop here if FAIL.
 
 Check if the user provided a topic argument after `/compress`.
 
-- **With argument** (e.g. `/compress rate limiting strategy`): Go to Step 4A.
+- **With argument** (e.g. `/compress rate limiting strategy`): Go to Step 3.5.
 - **Without argument** (bare `/compress`): Go to Step 4B.
+
+### Step 3.5 — Search for existing notes on this topic
+
+Run a single Python call to search the vault index for existing notes matching the topic:
+
+~~~bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 -c '
+import sys, os, json
+import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from vault_index import ensure_index, search_vault
+from obsidian_utils import load_config
+c = load_config()
+vp = c["vault_path"]
+folders = [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")]
+db = ensure_index(vp, folders)
+results = search_vault(db, sys.argv[1], note_type="claude-insight", limit=3)
+results += search_vault(db, sys.argv[1], note_type="claude-decision", limit=3)
+# Sort combined results by rank (most negative = best match)
+results.sort(key=lambda r: r["rank"])
+# Apply high-confidence threshold: top result must have rank <= -5.0
+# AND must be significantly ahead of #2 (at least 3x better rank)
+if results:
+    top = results[0]
+    rank_gap_ok = len(results) < 2 or abs(top["rank"]) > abs(results[1]["rank"]) * 1.5
+    if top["rank"] <= -5.0 and rank_gap_ok:
+        print(json.dumps({"match": True, "path": top["path"], "title": top["title"], "date": top["date"], "tags": top["tags"], "rank": top["rank"]}))
+    else:
+        print(json.dumps({"match": False}))
+else:
+    print(json.dumps({"match": False}))
+' "$TOPIC"
+~~~
+
+Parse the JSON output.
+
+**If `match` is `false`:** No existing note found. Proceed silently to Step 4A (create new note).
+
+**If `match` is `true`:** Present the match to the user:
+
+> Found an existing note on this topic:
+> **"<title>"** (<date>, <tags as comma-separated list>)
+>
+> Would you like to **update** this note or **create new**?
+
+Wait for the user's response:
+- **"update"** → Go to Step 4A-update.
+- **"create new"** → Go to Step 4A (create new note as before).
 
 ### Step 4A — Single-topic extraction
 

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 Analyze the current conversation, extract valuable insights, and save them as structured notes in the Obsidian vault. Supports both interactive multi-insight selection and targeted single-topic extraction.
 
-**Tools needed:** Bash, Write, Read
+**Tools needed:** Bash, Write, Read, Edit
 
 ## Procedure
 
@@ -73,24 +73,28 @@ import sys, os, json
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
 from vault_index import ensure_index, search_vault
 from obsidian_utils import load_config
-c = load_config()
-vp = c["vault_path"]
-folders = [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")]
-db = ensure_index(vp, folders)
-results = search_vault(db, sys.argv[1], note_type="claude-insight", limit=3)
-results += search_vault(db, sys.argv[1], note_type="claude-decision", limit=3)
-# Sort combined results by rank (most negative = best match)
-results.sort(key=lambda r: r["rank"])
-# Apply high-confidence threshold: top result must have rank <= -5.0
-# AND must be significantly ahead of #2 (at least 1.5x better rank)
-if results:
-    top = results[0]
-    rank_gap_ok = len(results) < 2 or abs(top["rank"]) > abs(results[1]["rank"]) * 1.5
-    if top["rank"] <= -5.0 and rank_gap_ok:
-        print(json.dumps({"match": True, "path": top["path"], "title": top["title"], "date": top["date"], "tags": top["tags"], "rank": top["rank"]}))
+try:
+    c = load_config()
+    vp = c["vault_path"]
+    folders = [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")]
+    db = ensure_index(vp, folders)
+    results = search_vault(db, sys.argv[1], note_type="claude-insight", limit=3)
+    results += search_vault(db, sys.argv[1], note_type="claude-decision", limit=3)
+    # Sort combined results by rank (most negative = best match)
+    results.sort(key=lambda r: r["rank"])
+    # Apply high-confidence threshold: top result must have rank <= -5.0
+    # AND must be significantly ahead of #2 (at least 1.5x better rank)
+    if results:
+        top = results[0]
+        rank_gap_ok = len(results) < 2 or abs(top["rank"]) > abs(results[1]["rank"]) * 1.5
+        if top["rank"] <= -5.0 and rank_gap_ok:
+            print(json.dumps({"match": True, "path": top["path"], "title": top["title"], "date": top["date"], "tags": top["tags"], "rank": top["rank"]}))
+        else:
+            print(json.dumps({"match": False}))
     else:
         print(json.dumps({"match": False}))
-else:
+except Exception as e:
+    print(f"Warning: could not search vault index: {e}", file=sys.stderr)
     print(json.dumps({"match": False}))
 ' "$TOPIC"
 ~~~


### PR DESCRIPTION
## Summary
- `/compress <topic>` now searches the vault index (FTS5) for existing insight/decision notes before creating a new one
- If a high-confidence match is found (rank ≤ -5.0 with 1.5× gap over #2), prompts user to **update** or **create new**
- Update mode appends a dated `## Update (YYYY-MM-DD)` section, adds `last_updated` frontmatter, and merges new topic tags without duplicates

## Changes
- `skills/compress/SKILL.md` — Step 3.5 (FTS search), Step 4A-update (7-step append flow), Step 10 text updated
- `CHANGELOG.md` — Added entry under [Unreleased]
- Compress skill version bumped to 1.1.0

## Test plan
- [ ] `/dev-test install` → fresh CC session → `/compress vault index verification` → verify match prompt appears
- [ ] Choose "update" → verify dated section drafted, preview shown, append works
- [ ] Verify `last_updated` frontmatter set and new tags appended without duplicates
- [ ] `/compress some novel unique topic xyz123` → verify no match, falls through to create
- [ ] Bare `/compress` → verify multi-insight discovery unchanged
- [ ] `/dev-test restore` after testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)