### PR TITLE
fix: escape bash [[ in session notes to prevent spurious Obsidian wikilinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Escape bash `[[` conditionals in raw conversation excerpts to prevent Obsidian from parsing them as wikilinks
+
+### Added
+- `escape_wikilinks()` helper in `obsidian_utils.py`
+- `spurious-wikilinks` vault-doctor check — detects and repairs unescaped `[[` in existing session notes
+
 ## [2.0.0] - 2026-04-12
 
 ### Security

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1041,6 +1041,15 @@ def scrub_secrets(text: str) -> str:
     return text
 
 
+def escape_wikilinks(text: str) -> str:
+    """Escape ``[[`` so Obsidian does not parse bash conditionals as wikilinks.
+
+    Bash ``[[ $VAR == pattern ]]`` in conversation excerpts triggers
+    Obsidian's wikilink parser, creating spurious outgoing links.
+    """
+    return text.replace("[[", r"\[\[")
+
+
 # ---------------------------------------------------------------------------
 # Vault operations
 # ---------------------------------------------------------------------------
@@ -2103,7 +2112,7 @@ def build_raw_fallback(
         sections.append("## Tool Usage")
         for tu in tool_uses[:80]:
             name = tu.get("name", "")
-            detail = scrub_secrets(tu.get("detail", ""))
+            detail = escape_wikilinks(scrub_secrets(tu.get("detail", "")))
             if name and detail:
                 sections.append(f"- **{name}**: {detail}")
             elif name:
@@ -2130,14 +2139,14 @@ def build_raw_fallback(
         turn = 0
         while turn < max_turns and (u_idx < len(user_msgs) or (assistant_msgs and a_idx < len(assistant_msgs))):
             if u_idx < len(user_msgs):
-                snippet = scrub_secrets(user_msgs[u_idx][:1200].replace("\n", " "))
+                snippet = escape_wikilinks(scrub_secrets(user_msgs[u_idx][:1200].replace("\n", " ")))
                 # Skip system noise (task notifications, command loading, etc.)
                 if not snippet.startswith("<task-notification>") and not snippet.startswith("Base directory for this skill:") and not snippet.startswith("<local-command"):
                     sections.append(f"**User:** {snippet}")
                     turn += 1
                 u_idx += 1
             if assistant_msgs and a_idx < len(assistant_msgs):
-                snippet = scrub_secrets(assistant_msgs[a_idx][:1200].replace("\n", " "))
+                snippet = escape_wikilinks(scrub_secrets(assistant_msgs[a_idx][:1200].replace("\n", " ")))
                 sections.append(f"**Assistant:** {snippet}")
                 a_idx += 1
                 turn += 1

--- a/scripts/vault_doctor_checks/spurious_wikilinks.py
+++ b/scripts/vault_doctor_checks/spurious_wikilinks.py
@@ -1,0 +1,180 @@
+"""vault_doctor check: detect and repair spurious wikilinks in conversation excerpts.
+
+Bash ``[[ $VAR == pattern ]]`` conditionals in raw conversation and tool-usage
+lines are parsed by Obsidian as wikilinks, creating phantom outgoing links.
+This check finds unescaped ``[[`` in lines that are clearly conversation
+excerpts (prefixed with ``**User:**``, ``**Assistant:**``, or ``- **``) and
+escapes them to ``\\[\\[``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import Issue, Result
+
+NAME = "spurious-wikilinks"
+DESCRIPTION = "Detect and fix unescaped [[ in conversation excerpts (bash conditionals parsed as Obsidian wikilinks)"
+DEFAULT_WINDOW_DAYS = 9999  # unbounded — scan all notes
+
+# Lines where [[ is conversation content, never an intentional wikilink.
+_CONVERSATION_LINE_RE = re.compile(
+    r"^(\*\*User:\*\*|\*\*Assistant:\*\*|- \*\*)"
+)
+
+# Unescaped [[ (not preceded by backslash).
+_UNESCAPED_WIKILINK_RE = re.compile(r"(?<!\\)\[\[")
+
+
+def scan(
+    vault_path: str,
+    sessions_folder: str,
+    insights_folder: str,
+    days: int,
+    project: str | None = None,
+) -> list[Issue]:
+    """Find session notes with unescaped [[ in conversation/tool-usage lines."""
+    sess_dir = Path(vault_path) / sessions_folder
+    if not sess_dir.is_dir():
+        return []
+
+    issues: list[Issue] = []
+
+    for md_file in sorted(sess_dir.glob("*.md")):
+        # Optional project filter via filename pattern
+        if project and f"-{project}-" not in md_file.name:
+            continue
+
+        try:
+            content = md_file.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        lines = content.split("\n")
+
+        # Extract project from frontmatter
+        note_project = "unknown"
+        in_fm = False
+        for line in lines[:30]:
+            if line.strip() == "---":
+                if not in_fm:
+                    in_fm = True
+                    continue
+                else:
+                    break
+            if in_fm and line.startswith("project:"):
+                note_project = line.split(":", 1)[1].strip().strip("\"'")
+                break
+
+        # Find unescaped [[ in conversation lines
+        hit_lines: list[int] = []
+        for i, line in enumerate(lines):
+            if _CONVERSATION_LINE_RE.match(line) and _UNESCAPED_WIKILINK_RE.search(line):
+                hit_lines.append(i + 1)  # 1-indexed
+
+        if hit_lines:
+            issues.append(Issue(
+                check=NAME,
+                note_path=str(md_file),
+                project=note_project,
+                current_source=f"{len(hit_lines)} line(s) with unescaped [[",
+                proposed_source="escape [[ to \\[\\[",
+                reason=f"Lines {', '.join(str(n) for n in hit_lines[:10])}{'...' if len(hit_lines) > 10 else ''}",
+                confidence=1.0,
+                extra={"hit_lines": hit_lines},
+            ))
+
+    return issues
+
+
+def apply(issues: list[Issue], backup_root: str) -> list[Result]:
+    """Escape [[ → \\[\\[ in conversation lines of affected notes."""
+    results: list[Result] = []
+
+    for issue in issues:
+        note_path = issue.note_path
+        try:
+            content = Path(note_path).read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="error",
+                error=str(exc),
+            ))
+            continue
+
+        lines = content.split("\n")
+        changed = False
+
+        for i, line in enumerate(lines):
+            if _CONVERSATION_LINE_RE.match(line) and _UNESCAPED_WIKILINK_RE.search(line):
+                lines[i] = _UNESCAPED_WIKILINK_RE.sub(r"\\[\\[", line)
+                changed = True
+
+        if not changed:
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="skipped",
+            ))
+            continue
+
+        # Backup original
+        backup_dir = Path(backup_root) / NAME
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_path = backup_dir / Path(note_path).name
+        try:
+            shutil.copy2(note_path, backup_path)
+        except OSError as exc:
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="error",
+                error=f"backup failed: {exc}",
+            ))
+            continue
+
+        # Atomic write (temp + rename, owner-only permissions)
+        new_content = "\n".join(lines)
+        dest = Path(note_path)
+        try:
+            fd, tmp = tempfile.mkstemp(
+                dir=str(dest.parent),
+                prefix=".vd-wikilink-",
+                suffix=".tmp",
+            )
+            try:
+                os.write(fd, new_content.encode("utf-8"))
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, str(dest))
+        except OSError as exc:
+            # Clean up temp file on failure
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="error",
+                error=str(exc),
+            ))
+            continue
+
+        results.append(Result(
+            check=NAME,
+            note_path=note_path,
+            status="applied",
+            backup_path=str(backup_path),
+        ))
+
+    return results

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -179,6 +179,63 @@ class TestRawMessageToggle:
         assert "## Conversation (raw)" in result
 
 
+class TestWikilinkEscaping:
+    """Bash [[ ]] conditionals must not become Obsidian wikilinks."""
+
+    def test_escape_wikilinks_basic(self):
+        from obsidian_utils import escape_wikilinks
+        assert escape_wikilinks("if [[ $X == y ]]; then") == r"if \[\[ $X == y ]]; then"
+
+    def test_escape_wikilinks_no_false_positive(self):
+        from obsidian_utils import escape_wikilinks
+        # Single brackets should not be touched
+        assert escape_wikilinks("if [ $X == y ]; then") == "if [ $X == y ]; then"
+
+    def test_escape_wikilinks_empty(self):
+        from obsidian_utils import escape_wikilinks
+        assert escape_wikilinks("") == ""
+
+    def test_escape_wikilinks_multiple(self):
+        from obsidian_utils import escape_wikilinks
+        text = "[[ a ]] && [[ b ]]"
+        assert text.count("[[") == 2
+        result = escape_wikilinks(text)
+        assert "[[" not in result
+        assert r"\[\[" in result
+
+    def test_build_raw_fallback_escapes_wikilinks_in_user_msgs(self):
+        from obsidian_utils import build_raw_fallback
+        result = build_raw_fallback(
+            ['if [[ $CURRENT_BRANCH == feature/* ]]; then echo yes; fi'],
+            {"project": "test", "duration_minutes": 5},
+            config={"log_raw_messages": True},
+        )
+        assert "[[" not in result.split("## Conversation (raw)")[1]
+        assert r"\[\[" in result
+
+    def test_build_raw_fallback_escapes_wikilinks_in_assistant_msgs(self):
+        from obsidian_utils import build_raw_fallback
+        result = build_raw_fallback(
+            ["user msg"],
+            {"project": "test", "duration_minutes": 5},
+            assistant_msgs=['Run: if [[ $VAR ]]; then ...'],
+            config={"log_raw_messages": True},
+        )
+        assert r"\[\[" in result
+
+    def test_build_raw_fallback_escapes_wikilinks_in_tool_usage(self):
+        from obsidian_utils import build_raw_fallback
+        result = build_raw_fallback(
+            ["user msg"],
+            {"project": "test", "duration_minutes": 5},
+            tool_uses=[{"name": "Bash", "detail": 'if [[ -f foo ]]; then rm foo; fi'}],
+            config={"log_raw_messages": True},
+        )
+        tool_section = result.split("## Tool Usage")[1].split("##")[0]
+        assert "[[" not in tool_section
+        assert r"\[\[" in tool_section
+
+
 class TestShellInjectionFix:
     """H4: commit-preflight.sh uses sys.argv, not path interpolation."""
 

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -163,6 +163,94 @@ def test_cli_unknown_check_errors(tmp_path):
     assert result.returncode == 3, f"expected exit 3, got {result.returncode}"
 
 
+def test_registry_lists_spurious_wikilinks_check():
+    """The registry auto-discovers the spurious_wikilinks check module."""
+    import vault_doctor_checks
+    importlib.reload(vault_doctor_checks)
+    names = vault_doctor_checks.list_checks()
+    assert "spurious-wikilinks" in names
+
+
+def test_spurious_wikilinks_scan_detects_bash_conditionals(tmp_path):
+    """scan() finds unescaped [[ in conversation lines."""
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-sessions" / "2026-04-12-proj-abcd.md").write_text(
+        "---\ntype: claude-session\nproject: proj\n---\n"
+        "# Session\n"
+        '**User:** if [[ $BRANCH == feature/* ]]; then echo yes; fi\n'
+        "**Assistant:** ok\n",
+        encoding="utf-8",
+    )
+    from vault_doctor_checks import spurious_wikilinks
+    issues = spurious_wikilinks.scan(str(vault), "claude-sessions", "claude-insights", 9999)
+    assert len(issues) == 1
+    assert issues[0].project == "proj"
+    assert "1 line(s)" in issues[0].current_source
+
+
+def test_spurious_wikilinks_scan_ignores_escaped(tmp_path):
+    """scan() does not flag already-escaped \\[\\[."""
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-sessions" / "2026-04-12-proj-abcd.md").write_text(
+        "---\ntype: claude-session\nproject: proj\n---\n"
+        "# Session\n"
+        r'**User:** if \[\[ $BRANCH == feature/* ]]; then echo yes; fi' + "\n",
+        encoding="utf-8",
+    )
+    from vault_doctor_checks import spurious_wikilinks
+    issues = spurious_wikilinks.scan(str(vault), "claude-sessions", "claude-insights", 9999)
+    assert len(issues) == 0
+
+
+def test_spurious_wikilinks_scan_ignores_non_conversation_lines(tmp_path):
+    """scan() does not flag [[ in non-conversation lines (e.g., frontmatter wikilinks)."""
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-sessions" / "2026-04-12-proj-abcd.md").write_text(
+        '---\ntype: claude-session\nproject: proj\nsource_session_note: "[[2026-04-12-proj-1234]]"\n---\n'
+        "# Session\n"
+        "Normal text with no bash.\n",
+        encoding="utf-8",
+    )
+    from vault_doctor_checks import spurious_wikilinks
+    issues = spurious_wikilinks.scan(str(vault), "claude-sessions", "claude-insights", 9999)
+    assert len(issues) == 0
+
+
+def test_spurious_wikilinks_apply_escapes_and_backs_up(tmp_path):
+    """apply() escapes [[ and creates a backup."""
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    note = vault / "claude-sessions" / "2026-04-12-proj-abcd.md"
+    note.write_text(
+        "---\ntype: claude-session\nproject: proj\n---\n"
+        "# Session\n"
+        '**User:** if [[ $X == y ]]; then echo yes; fi\n'
+        "**Assistant:** sure\n",
+        encoding="utf-8",
+    )
+
+    from vault_doctor_checks import spurious_wikilinks
+    issues = spurious_wikilinks.scan(str(vault), "claude-sessions", "claude-insights", 9999)
+    assert len(issues) == 1
+
+    backup_root = str(tmp_path / "backups")
+    results = spurious_wikilinks.apply(issues, backup_root)
+    assert len(results) == 1
+    assert results[0].status == "applied"
+    assert results[0].backup_path is not None
+
+    patched = note.read_text(encoding="utf-8")
+    assert "[[" not in patched.split("# Session")[1]
+    assert r"\[\[" in patched
+
+    # Backup contains original
+    backup_content = Path(results[0].backup_path).read_text(encoding="utf-8")
+    assert "[[" in backup_content
+
+
 def test_cli_missing_vault_errors(tmp_path, monkeypatch):
     """Missing vault config → exit 3."""
     import subprocess, sys, os


### PR DESCRIPTION
## Summary
- Bash `[[ ]]` conditionals in raw conversation excerpts were parsed by Obsidian as wikilinks, creating phantom outgoing links (e.g. `$CURRENT_BRANCH on feature/*`)
- Added `escape_wikilinks()` helper applied at all 3 injection points in `build_raw_fallback()`
- Added `spurious-wikilinks` vault-doctor check to detect and repair existing notes

## Test plan
- [x] 12 new tests (265 total), 92.22% coverage
- [x] `test_escape_wikilinks_*` — basic escaping, no false positives, multiple occurrences
- [x] `test_build_raw_fallback_escapes_wikilinks_*` — user msgs, assistant msgs, tool usage
- [x] `test_spurious_wikilinks_*` — scan detection, ignores escaped, ignores non-conversation lines, apply with backup
- [x] Ran vault-doctor `--apply --yes` on live vault: 42 notes fixed, 0 issues remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)