### PR TITLE
fix: Python 3.9 compat, underscore project paths, and hash instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Add `from __future__ import annotations` to `vault_index.py` and `obsidian_context_snapshot.py` — fixes PEP 604 `TypeError` on macOS system Python 3.9.6
 - Fix false "No session files found" warning in `check_hook_status()` when project directory contains underscores (Claude Code normalizes `_` to `-` in project paths)
+- Fix ambiguous hash instructions in 4 skills (error-log, decide, compress, vault-import) — replace vague `md5` with explicit `cut -c` commands to prevent `tail -c 4` newline byte bug producing 3-char hashes
 
 ### Added
 - Regression test `test_hooks_future_annotations` ensuring all hook files with PEP 604/585 syntax include the `__future__` import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Add `from __future__ import annotations` to `vault_index.py` and `obsidian_context_snapshot.py` — fixes PEP 604 `TypeError` on macOS system Python 3.9.6
+- Fix false "No session files found" warning in `check_hook_status()` when project directory contains underscores (Claude Code normalizes `_` to `-` in project paths)
 
 ### Added
 - Regression test `test_hooks_future_annotations` ensuring all hook files with PEP 604/585 syntax include the `__future__` import
+- Test `test_slow_path_underscore_to_hyphen_fallback` for underscore-to-hyphen project path matching
 
 ## [2.0.1] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Regression test `test_hooks_future_annotations` ensuring all hook files with PEP 604/585 syntax include the `__future__` import
 - Test `test_slow_path_underscore_to_hyphen_fallback` for underscore-to-hyphen project path matching
+- Test `test_no_tail_c_in_skills` preventing `tail -c` usage in SKILL.md files
 
 ## [2.0.1] - 2026-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Normalize project names (underscore → hyphen) in `get_session_context()`, `extract_session_metadata()`, and vault-doctor `source_sessions.py` comparisons — prevents project name splits in frontmatter tags
 
 ### Added
+- `project-name-normalization` vault-doctor check — detects and auto-fixes underscored project names in frontmatter (both `project:` field and `claude/project/` tags)
 - `_glob_project_jsonls()` helper in `obsidian_utils.py` — centralizes `~/.claude/projects/` globbing with underscore-to-hyphen fallback
 - Regression test `test_hooks_future_annotations` ensuring all hook files with PEP 604/585 syntax include the `__future__` import
 - Tests for underscore-to-hyphen fallback in `_slow_path_newest_sid`, `_get_session_id_fast`, and `_jsonl_dir_for_project`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Add `from __future__ import annotations` to `vault_index.py` and `obsidian_context_snapshot.py` — fixes PEP 604 `TypeError` on macOS system Python 3.9.6
+
+### Added
+- Regression test `test_hooks_future_annotations` ensuring all hook files with PEP 604/585 syntax include the `__future__` import
+
 ## [2.0.1] - 2026-04-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `from __future__ import annotations` to `vault_index.py` and `obsidian_context_snapshot.py` — fixes PEP 604 `TypeError` on macOS system Python 3.9.6
 - Fix underscore-to-hyphen project path matching across all 3 functions that glob `~/.claude/projects/`: `_slow_path_newest_sid()`, `_get_session_id_fast()`, and `_jsonl_dir_for_project()` — extracted shared `_glob_project_jsonls()` helper
 - Fix ambiguous hash instructions in 4 skills (error-log, decide, compress, vault-import) — replace vague `md5` with explicit `cut -c` commands to prevent `tail -c 4` newline byte bug producing 3-char hashes
+- Normalize project names (underscore → hyphen) in `get_session_context()`, `extract_session_metadata()`, and vault-doctor `source_sessions.py` comparisons — prevents project name splits in frontmatter tags
 
 ### Added
 - `_glob_project_jsonls()` helper in `obsidian_utils.py` — centralizes `~/.claude/projects/` globbing with underscore-to-hyphen fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Add `from __future__ import annotations` to `vault_index.py` and `obsidian_context_snapshot.py` — fixes PEP 604 `TypeError` on macOS system Python 3.9.6
-- Fix false "No session files found" warning in `check_hook_status()` when project directory contains underscores (Claude Code normalizes `_` to `-` in project paths)
+- Fix underscore-to-hyphen project path matching across all 3 functions that glob `~/.claude/projects/`: `_slow_path_newest_sid()`, `_get_session_id_fast()`, and `_jsonl_dir_for_project()` — extracted shared `_glob_project_jsonls()` helper
 - Fix ambiguous hash instructions in 4 skills (error-log, decide, compress, vault-import) — replace vague `md5` with explicit `cut -c` commands to prevent `tail -c 4` newline byte bug producing 3-char hashes
 
 ### Added
+- `_glob_project_jsonls()` helper in `obsidian_utils.py` — centralizes `~/.claude/projects/` globbing with underscore-to-hyphen fallback
 - Regression test `test_hooks_future_annotations` ensuring all hook files with PEP 604/585 syntax include the `__future__` import
-- Test `test_slow_path_underscore_to_hyphen_fallback` for underscore-to-hyphen project path matching
+- Tests for underscore-to-hyphen fallback in `_slow_path_newest_sid`, `_get_session_id_fast`, and `_jsonl_dir_for_project`
 - Test `test_no_tail_c_in_skills` preventing `tail -c` usage in SKILL.md files
 
 ## [2.0.1] - 2026-04-12

--- a/hooks/obsidian_context_snapshot.py
+++ b/hooks/obsidian_context_snapshot.py
@@ -7,6 +7,8 @@ context clear, writing it to the Obsidian vault. Uses raw message extraction
 (no claude -p call) to avoid timing issues. Always exits 0.
 """
 
+from __future__ import annotations
+
 import datetime
 import json
 import os

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -720,7 +720,7 @@ def extract_session_metadata(messages: list[dict], cwd: str) -> dict:
     errors, duration_minutes, commits.
     """
     meta: dict = {
-        "project": Path(cwd).name.replace("_", "-") if cwd else "unknown",
+        "project": Path(cwd).name.lower().replace(" ", "-").replace("_", "-") if cwd else "unknown",
         "project_path": cwd or "",
         "git_branch": "",
         "files_touched": [],

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -65,6 +65,24 @@ def _safe_mtime(path: str) -> float:
         return -1.0
 
 
+def _glob_project_jsonls(safe_project: str, suffix: str = "*.jsonl") -> list[str]:
+    """Glob ~/.claude/projects/*<project>/<suffix>, with underscore-to-hyphen fallback.
+
+    Claude Code normalizes underscores to hyphens in project directory names,
+    so a project at ``personal_ws/`` gets stored as ``personal-ws/``.
+    """
+    import glob as _glob
+    pattern = os.path.expanduser(
+        f"~/.claude/projects/*{safe_project}/{suffix}"
+    )
+    matches = _glob.glob(pattern)
+    if not matches and "_" in safe_project:
+        alt = safe_project.replace("_", "-")
+        pattern = os.path.expanduser(f"~/.claude/projects/*{alt}/{suffix}")
+        matches = _glob.glob(pattern)
+    return matches
+
+
 def _slow_path_newest_sid() -> str:
     """Determine the current session id by scanning JSONL files directly.
 
@@ -72,16 +90,10 @@ def _slow_path_newest_sid() -> str:
     cache. Used by health checks that must not be fooled by stale cache
     entries. Returns 'unknown' if no JSONLs are found for the current cwd.
     """
-    project = os.path.basename(os.getcwd())
     import glob as _glob
+    project = os.path.basename(os.getcwd())
     safe_project = _glob.escape(project)
-    pattern = os.path.expanduser(f"~/.claude/projects/*{safe_project}/*.jsonl")
-    matches = _glob.glob(pattern)
-    # Fallback: Claude Code normalizes underscores to hyphens in project dirs
-    if not matches and "_" in safe_project:
-        alt = safe_project.replace("_", "-")
-        pattern = os.path.expanduser(f"~/.claude/projects/*{alt}/*.jsonl")
-        matches = _glob.glob(pattern)
+    matches = _glob_project_jsonls(safe_project)
     entries = [(_safe_mtime(p), p) for p in matches]
     viable = [(m, p) for m, p in entries if m >= 0]
     if not viable:
@@ -120,12 +132,10 @@ def _get_session_id_fast() -> str:
     happens whenever downstream hook code calls a function that triggers
     this, before CC has flushed the new session's JSONL to disk).
     """
+    import glob as _glob
     project = os.path.basename(os.getcwd())
     bootstrap = f"{_bootstrap_prefix()}{project}"
-
-    import glob as _glob
     safe_project = _glob.escape(project)
-    pattern = os.path.expanduser(f"~/.claude/projects/*{safe_project}/*.jsonl")
 
     # Fast path: bootstrap file
     try:
@@ -133,16 +143,15 @@ def _get_session_id_fast() -> str:
             cached_sid = f.read().strip()
         if cached_sid:
             safe_cached = _glob.escape(cached_sid)
-            cached_pattern = os.path.expanduser(
-                f"~/.claude/projects/*{safe_project}/{safe_cached}.jsonl"
+            cached_matches = _glob_project_jsonls(
+                safe_project, f"{safe_cached}.jsonl"
             )
-            cached_matches = _glob.glob(cached_pattern)
             if cached_matches:
                 # Determine the newest JSONL deterministically: order by
                 # (mtime, path). Ties broken by path string so results are
                 # reproducible across filesystems that report 1-second mtime
                 # resolution.
-                all_matches = _glob.glob(pattern)
+                all_matches = _glob_project_jsonls(safe_project)
                 if all_matches:
                     # Determine the newest JSONL deterministically via (mtime, path).
                     # _safe_mtime returns -1.0 for files that disappear between glob
@@ -188,7 +197,7 @@ def _get_session_id_fast() -> str:
     # hook's downstream code calls a function that triggers this).
     # Use _safe_mtime so a JSONL deleted or rotated between glob and
     # stat cannot crash the caller (e.g. load_config).
-    matches = _glob.glob(pattern)
+    matches = _glob_project_jsonls(safe_project)
     entries = [(_safe_mtime(p), p) for p in matches]
     viable = [(m, p) for m, p in entries if m >= 0]
     if not viable:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -77,6 +77,11 @@ def _slow_path_newest_sid() -> str:
     safe_project = _glob.escape(project)
     pattern = os.path.expanduser(f"~/.claude/projects/*{safe_project}/*.jsonl")
     matches = _glob.glob(pattern)
+    # Fallback: Claude Code normalizes underscores to hyphens in project dirs
+    if not matches and "_" in safe_project:
+        alt = safe_project.replace("_", "-")
+        pattern = os.path.expanduser(f"~/.claude/projects/*{alt}/*.jsonl")
+        matches = _glob.glob(pattern)
     entries = [(_safe_mtime(p), p) for p in matches]
     viable = [(m, p) for m, p in entries if m >= 0]
     if not viable:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -429,7 +429,7 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
     if cached is not None:
         return cached
 
-    project = os.path.basename(os.getcwd()).lower().replace(' ', '-')
+    project = os.path.basename(os.getcwd()).lower().replace(' ', '-').replace('_', '-')
     if sid == "unknown":
         # Don't cache "unknown" — would pollute cache shared across projects
         return {"session_id": "unknown", "hash": "", "project": project, "session_note_name": ""}
@@ -720,7 +720,7 @@ def extract_session_metadata(messages: list[dict], cwd: str) -> dict:
     errors, duration_minutes, commits.
     """
     meta: dict = {
-        "project": Path(cwd).name if cwd else "unknown",
+        "project": Path(cwd).name.replace("_", "-") if cwd else "unknown",
         "project_path": cwd or "",
         "git_branch": "",
         "files_touched": [],

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -6,6 +6,8 @@ sync, and layered ranking for context-relevant note discovery.
 DB location: ~/.claude/obsidian-brain-vault.db (outside vault, alongside config).
 """
 
+from __future__ import annotations
+
 import os
 import re
 import sqlite3

--- a/scripts/vault_doctor_checks/project_name_normalization.py
+++ b/scripts/vault_doctor_checks/project_name_normalization.py
@@ -1,0 +1,199 @@
+"""vault_doctor check: normalize underscore project names to hyphens in frontmatter.
+
+Claude Code normalizes underscores to hyphens in project directory names
+(e.g. ``personal_ws`` → ``personal-ws``). Notes created before this
+normalization was applied to ``get_session_context()`` and
+``extract_session_metadata()`` may have ``project: personal_ws`` in their
+frontmatter, causing vault-doctor to treat them as a separate project.
+This check detects and fixes the inconsistency.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import tempfile
+from pathlib import Path
+
+from . import Issue, Result
+
+NAME = "project-name-normalization"
+DESCRIPTION = "Detect and fix underscored project names in frontmatter (should use hyphens to match Claude Code convention)"
+DEFAULT_WINDOW_DAYS = 9999  # unbounded — scan all notes
+
+_FM_PROJECT_RE = re.compile(r"^project:\s*(.+)$", re.MULTILINE)
+
+
+def _parse_frontmatter_project(content: str) -> str | None:
+    """Extract the project value from YAML frontmatter."""
+    if not content.startswith("---"):
+        return None
+    end = content.find("\n---", 3)
+    if end == -1:
+        return None
+    fm_block = content[: end + 4]
+    m = _FM_PROJECT_RE.search(fm_block)
+    if not m:
+        return None
+    return m.group(1).strip().strip("\"'")
+
+
+def scan(
+    vault_path: str,
+    sessions_folder: str,
+    insights_folder: str,
+    days: int,
+    project: str | None = None,
+) -> list[Issue]:
+    """Find notes with underscored project names in frontmatter."""
+    issues: list[Issue] = []
+
+    for folder in (sessions_folder, insights_folder):
+        folder_path = Path(vault_path) / folder
+        if not folder_path.is_dir():
+            continue
+
+        for md_file in sorted(folder_path.glob("*.md")):
+            try:
+                content = md_file.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+
+            note_project = _parse_frontmatter_project(content)
+            if not note_project:
+                continue
+
+            # Optional project filter (normalize both sides)
+            if project and note_project.replace("_", "-") != project.replace("_", "-"):
+                continue
+
+            if "_" in note_project:
+                normalized = note_project.replace("_", "-")
+                issues.append(Issue(
+                    check=NAME,
+                    note_path=str(md_file),
+                    project=note_project,
+                    current_source=f"project: {note_project}",
+                    proposed_source=f"project: {normalized}",
+                    reason="underscore in project name; Claude Code uses hyphens",
+                    confidence=1.0,
+                    extra={"original": note_project, "normalized": normalized},
+                ))
+
+    return issues
+
+
+def apply(issues: list[Issue], backup_root: str) -> list[Result]:
+    """Replace underscored project names with hyphenated versions in frontmatter."""
+    results: list[Result] = []
+
+    for issue in issues:
+        note_path = issue.note_path
+        original = issue.extra.get("original", "")
+        normalized = issue.extra.get("normalized", "")
+        if not original or not normalized:
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="error",
+                error="missing original/normalized in issue extra",
+            ))
+            continue
+
+        try:
+            content = Path(note_path).read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="error",
+                error=str(exc),
+            ))
+            continue
+
+        # Only replace in frontmatter block, not in body text
+        if not content.startswith("---"):
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="skipped",
+            ))
+            continue
+
+        end = content.find("\n---", 3)
+        if end == -1:
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="skipped",
+            ))
+            continue
+
+        fm_block = content[: end + 4]
+        body = content[end + 4:]
+
+        # Replace project value and tag references in frontmatter
+        new_fm = fm_block.replace(f"project: {original}", f"project: {normalized}")
+        new_fm = new_fm.replace(f"claude/project/{original}", f"claude/project/{normalized}")
+
+        if new_fm == fm_block:
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="skipped",
+            ))
+            continue
+
+        # Backup original
+        backup_dir = Path(backup_root) / NAME
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_path = backup_dir / Path(note_path).name
+        try:
+            shutil.copy2(note_path, backup_path)
+        except OSError as exc:
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="error",
+                error=f"backup failed: {exc}",
+            ))
+            continue
+
+        # Atomic write
+        new_content = new_fm + body
+        dest = Path(note_path)
+        try:
+            fd, tmp = tempfile.mkstemp(
+                dir=str(dest.parent),
+                prefix=".vd-projnorm-",
+                suffix=".tmp",
+            )
+            try:
+                os.write(fd, new_content.encode("utf-8"))
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, str(dest))
+        except OSError as exc:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            results.append(Result(
+                check=NAME,
+                note_path=note_path,
+                status="error",
+                error=str(exc),
+            ))
+            continue
+
+        results.append(Result(
+            check=NAME,
+            note_path=note_path,
+            status="applied",
+            backup_path=str(backup_path),
+        ))
+
+    return results

--- a/scripts/vault_doctor_checks/project_name_normalization.py
+++ b/scripts/vault_doctor_checks/project_name_normalization.py
@@ -133,8 +133,13 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
         fm_block = content[: end + 4]
         body = content[end + 4:]
 
-        # Replace project value and tag references in frontmatter
-        new_fm = fm_block.replace(f"project: {original}", f"project: {normalized}")
+        # Replace project value (with or without quotes) and tag references
+        new_fm = re.sub(
+            rf"^(project:\s*)[\"']?{re.escape(original)}[\"']?\s*$",
+            rf"\g<1>{normalized}",
+            fm_block,
+            flags=re.MULTILINE,
+        )
         new_fm = new_fm.replace(f"claude/project/{original}", f"claude/project/{normalized}")
 
         if new_fm == fm_block:

--- a/scripts/vault_doctor_checks/project_name_normalization.py
+++ b/scripts/vault_doctor_checks/project_name_normalization.py
@@ -145,8 +145,9 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
             ))
             continue
 
-        # Backup original
-        backup_dir = Path(backup_root) / NAME
+        # Backup original (include source folder to avoid cross-folder collisions)
+        source_folder = Path(note_path).parent.name
+        backup_dir = Path(backup_root) / NAME / source_folder
         backup_dir.mkdir(parents=True, exist_ok=True)
         backup_path = backup_dir / Path(note_path).name
         try:
@@ -163,6 +164,7 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
         # Atomic write
         new_content = new_fm + body
         dest = Path(note_path)
+        tmp = None
         try:
             fd, tmp = tempfile.mkstemp(
                 dir=str(dest.parent),
@@ -176,11 +178,8 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
                 os.close(fd)
             os.chmod(tmp, 0o600)
             os.replace(tmp, str(dest))
+            tmp = None  # consumed by os.replace
         except OSError as exc:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
             results.append(Result(
                 check=NAME,
                 note_path=note_path,
@@ -188,6 +187,12 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
                 error=str(exc),
             ))
             continue
+        finally:
+            if tmp is not None:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
 
         results.append(Result(
             check=NAME,

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -198,7 +198,7 @@ def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
                 file=sys.stderr,
             )
             continue
-        if fm.get("project") != project:
+        if fm.get("project", "").replace("_", "-") != project.replace("_", "-"):
             continue
         sid = fm.get("session_id", "")
         if not sid:
@@ -290,15 +290,17 @@ def scan(
             note_project = fm.get("project", "")
             if not note_project:
                 continue
-            if project and note_project != project:
+            if project and note_project.replace("_", "-") != project.replace("_", "-"):
                 continue
 
-            if note_project not in session_index_cache:
-                session_index_cache[note_project] = _list_session_notes(sessions_dir, note_project)
-                jsonl_dir_cache[note_project] = _jsonl_dir_for_project(note_project)
+            # Normalize cache key so personal_ws and personal-ws share index
+            cache_key = note_project.replace("_", "-")
+            if cache_key not in session_index_cache:
+                session_index_cache[cache_key] = _list_session_notes(sessions_dir, note_project)
+                jsonl_dir_cache[cache_key] = _jsonl_dir_for_project(note_project)
 
-            idx = session_index_cache[note_project]
-            jsonl_dir = jsonl_dir_cache[note_project]
+            idx = session_index_cache[cache_key]
+            jsonl_dir = jsonl_dir_cache[cache_key]
 
             current_sid = fm.get("source_session", "")
             raw_src_note = fm.get("source_session_note", "")

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -153,6 +153,11 @@ def _jsonl_dir_for_project(project: str) -> Path | None:
     safe_project = glob.escape(project)
     pattern = os.path.join(home, ".claude", "projects", f"*{safe_project}")
     matches = glob.glob(pattern)
+    # Fallback: Claude Code normalizes underscores to hyphens in project dirs
+    if not matches and "_" in safe_project:
+        alt = safe_project.replace("_", "-")
+        pattern = os.path.join(home, ".claude", "projects", f"*{alt}")
+        matches = glob.glob(pattern)
     if not matches:
         return None
 

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -345,7 +345,7 @@ Construct the filename from these parts:
 
 1. **Date:** `YYYY-MM-DD` (today)
 2. **Slug:** The note title, lowercased, spaces replaced with hyphens, non-alphanumeric characters (except hyphens) removed, truncated to 50 characters
-3. **Hash:** 4-character hex hash derived from the current timestamp (use the last 4 hex characters of `date +%s | md5` or equivalent)
+3. **Hash:** 4-character hex hash derived from the current timestamp: `date +%s | md5 | cut -c29-32` (macOS) or `date +%s | md5sum | cut -c1-4` (Linux). Do NOT use `tail -c 4` — it counts the trailing newline as a byte and returns only 3 visible characters.
 
 Final filename: `YYYY-MM-DD-<slug>-<hash>.md`
 

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -180,7 +180,7 @@ Construct the filename from these parts:
 
 1. **Date:** `YYYY-MM-DD` (today)
 2. **Slug:** The decision title, lowercased, spaces replaced with hyphens, non-alphanumeric characters (except hyphens) removed, truncated to 50 characters
-3. **Hash:** 4-character hex hash derived from the current timestamp (use the last 4 hex characters of `date +%s | md5` or equivalent)
+3. **Hash:** 4-character hex hash derived from the current timestamp: `date +%s | md5 | cut -c29-32` (macOS) or `date +%s | md5sum | cut -c1-4` (Linux). Do NOT use `tail -c 4` — it counts the trailing newline as a byte and returns only 3 visible characters.
 4. **Suffix:** `-decision`
 
 Final filename: `YYYY-MM-DD-<slug>-<hash>-decision.md`

--- a/skills/error-log/SKILL.md
+++ b/skills/error-log/SKILL.md
@@ -170,7 +170,7 @@ Construct the filename from these parts:
 
 1. **Date:** `YYYY-MM-DD` (today)
 2. **Slug:** The error title, lowercased, spaces replaced with hyphens, non-alphanumeric characters (except hyphens) removed, truncated to 50 characters
-3. **Hash:** 4-character hex hash derived from the current timestamp (use the last 4 hex characters of `date +%s | md5` or equivalent)
+3. **Hash:** 4-character hex hash derived from the current timestamp: `date +%s | md5 | cut -c29-32` (macOS) or `date +%s | md5sum | cut -c1-4` (Linux). Do NOT use `tail -c 4` — it counts the trailing newline as a byte and returns only 3 visible characters.
 4. **Suffix:** `-error`
 
 Final filename: `YYYY-MM-DD-<slug>-<hash>-error.md`

--- a/skills/vault-import/SKILL.md
+++ b/skills/vault-import/SKILL.md
@@ -214,7 +214,7 @@ Generate the filename using the same convention as other session notes:
 
 1. **Date:** `YYYY-MM-DD` (session date)
 2. **Slug:** Title lowercased, spaces to hyphens, non-alphanumeric (except hyphens) removed, truncated to 50 chars
-3. **Hash:** 4-character hex hash from the session_id (first 4 hex chars of `echo "<session_id>" | md5`)
+3. **Hash:** 4-character hex hash from the session_id: `echo -n "<session_id>" | md5 | cut -c1-4` (macOS) or `echo -n "<session_id>" | md5sum | cut -c1-4` (Linux). Do NOT use `tail -c 4` — it counts the trailing newline as a byte and returns only 3 visible characters.
 
 Final filename: `YYYY-MM-DD-<slug>-<hash>.md`
 

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -1516,6 +1516,16 @@ def test_extract_session_metadata_normalizes_underscores():
     )
 
 
+def test_extract_session_metadata_normalizes_case_and_spaces():
+    """extract_session_metadata lowercases and normalizes spaces like get_session_context."""
+    import obsidian_utils
+
+    meta = obsidian_utils.extract_session_metadata([], "/Users/foo/My Project")
+    assert meta["project"] == "my-project", (
+        f"Expected 'my-project' but got '{meta['project']}' — case/space normalization failed"
+    )
+
+
 def test_check_hook_status_missing_bootstrap(tmp_path, monkeypatch):
     """check_hook_status returns ok=False when bootstrap file is absent."""
     import obsidian_utils

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -1463,6 +1463,31 @@ def test_slow_path_underscore_to_hyphen_fallback(tmp_path, monkeypatch):
     assert sid == "abc123", f"Expected 'abc123' but got '{sid}' — hyphen fallback failed"
 
 
+def test_fast_path_underscore_to_hyphen_fallback(tmp_path, monkeypatch):
+    """_get_session_id_fast matches when cwd has underscores but CC dir has hyphens."""
+    import obsidian_utils
+
+    proj_dir = tmp_path / "my_project"
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # CC dir uses hyphens
+    cc_projects = tmp_path / ".claude" / "projects" / "-Users-foo-my-project"
+    cc_projects.mkdir(parents=True)
+    jsonl = cc_projects / "sess-fast-123.jsonl"
+    jsonl.write_text("{}", encoding="utf-8")
+
+    # Bootstrap file points to the correct sid
+    bootstrap_prefix = str(tmp_path / ".obsidian-brain-sid-")
+    monkeypatch.setattr(obsidian_utils, "_BOOTSTRAP_PREFIX", bootstrap_prefix)
+    bootstrap = tmp_path / ".obsidian-brain-sid-my_project"
+    bootstrap.write_text("sess-fast-123", encoding="utf-8")
+
+    sid = obsidian_utils._get_session_id_fast()
+    assert sid == "sess-fast-123", f"Expected 'sess-fast-123' but got '{sid}'"
+
+
 def test_check_hook_status_missing_bootstrap(tmp_path, monkeypatch):
     """check_hook_status returns ok=False when bootstrap file is absent."""
     import obsidian_utils

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -1443,6 +1443,26 @@ def test_check_hook_status_no_session_files(tmp_path, monkeypatch):
     assert status["current_sid"] == "unknown"
 
 
+def test_slow_path_underscore_to_hyphen_fallback(tmp_path, monkeypatch):
+    """_slow_path_newest_sid matches when cwd has underscores but CC dir has hyphens."""
+    import obsidian_utils
+
+    # cwd basename has underscores
+    proj_dir = tmp_path / "personal_ws"
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Claude Code normalizes underscores to hyphens in project dir names
+    cc_projects = tmp_path / ".claude" / "projects" / "-Users-foo-personal-ws"
+    cc_projects.mkdir(parents=True)
+    jsonl = cc_projects / "abc123.jsonl"
+    jsonl.write_text("{}", encoding="utf-8")
+
+    sid = obsidian_utils._slow_path_newest_sid()
+    assert sid == "abc123", f"Expected 'abc123' but got '{sid}' — hyphen fallback failed"
+
+
 def test_check_hook_status_missing_bootstrap(tmp_path, monkeypatch):
     """check_hook_status returns ok=False when bootstrap file is absent."""
     import obsidian_utils

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -1488,6 +1488,34 @@ def test_fast_path_underscore_to_hyphen_fallback(tmp_path, monkeypatch):
     assert sid == "sess-fast-123", f"Expected 'sess-fast-123' but got '{sid}'"
 
 
+def test_get_session_context_normalizes_underscores(tmp_path, monkeypatch):
+    """get_session_context normalizes underscores to hyphens in project name."""
+    import obsidian_utils
+
+    proj_dir = tmp_path / "personal_ws"
+    proj_dir.mkdir()
+    monkeypatch.chdir(proj_dir)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Stub _get_session_id_fast to return unknown (avoids bootstrap setup)
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: "unknown")
+
+    ctx = obsidian_utils.get_session_context()
+    assert ctx["project"] == "personal-ws", (
+        f"Expected 'personal-ws' but got '{ctx['project']}' — underscores not normalized"
+    )
+
+
+def test_extract_session_metadata_normalizes_underscores():
+    """extract_session_metadata normalizes underscores to hyphens in project name."""
+    import obsidian_utils
+
+    meta = obsidian_utils.extract_session_metadata([], "/Users/foo/personal_ws")
+    assert meta["project"] == "personal-ws", (
+        f"Expected 'personal-ws' but got '{meta['project']}' — underscores not normalized"
+    )
+
+
 def test_check_hook_status_missing_bootstrap(tmp_path, monkeypatch):
     """check_hook_status returns ok=False when bootstrap file is absent."""
     import obsidian_utils

--- a/tests/test_skill_snippets.py
+++ b/tests/test_skill_snippets.py
@@ -74,6 +74,26 @@ def test_cache_glob_finds_installed_hooks():
     )
 
 
+def test_no_tail_c_in_skills():
+    """SKILL.md files must not use 'tail -c' for hash extraction.
+
+    tail -c counts raw bytes including trailing newlines, producing fewer
+    visible characters than expected (e.g. 3 hex chars instead of 4).
+    Use 'cut -c' instead. Lines containing "Do NOT use" are warnings, not usage.
+    """
+    _TAIL_C_RE = re.compile(r'tail -c')
+    _WARNING_RE = re.compile(r'Do NOT use.*tail -c')
+    for skill_path in sorted(glob.glob(os.path.join(_REPO_ROOT, "skills/*/SKILL.md"))):
+        skill_name = skill_path.replace("\\", "/").split("/")[-2]
+        with open(skill_path, encoding="utf-8") as f:
+            for lineno, line in enumerate(f, 1):
+                if _TAIL_C_RE.search(line) and not _WARNING_RE.search(line):
+                    raise AssertionError(
+                        f"Skill {skill_name} line {lineno} uses 'tail -c' which "
+                        "miscounts bytes due to trailing newlines. Use 'cut -c' instead."
+                    )
+
+
 def test_hooks_future_annotations():
     """Hook .py files using PEP 604/585 type hints must have 'from __future__ import annotations'.
 

--- a/tests/test_skill_snippets.py
+++ b/tests/test_skill_snippets.py
@@ -74,6 +74,27 @@ def test_cache_glob_finds_installed_hooks():
     )
 
 
+def test_hooks_future_annotations():
+    """Hook .py files using PEP 604/585 type hints must have 'from __future__ import annotations'.
+
+    Without this import, `dict | None` and `list[str]` syntax fails on
+    Python < 3.10 (macOS system Python is 3.9.6).
+    """
+    hooks_dir = os.path.join(_REPO_ROOT, "hooks")
+    pep604_re = re.compile(r':\s*\w+\s*\|\s*\w+|-> \w+\s*\|\s*\w+')
+    pep585_re = re.compile(r':\s*(?:list|dict|set|tuple)\[')
+    for py_file in sorted(glob.glob(os.path.join(hooks_dir, "*.py"))):
+        with open(py_file, encoding="utf-8") as f:
+            content = f.read()
+        uses_modern = pep604_re.search(content) or pep585_re.search(content)
+        if uses_modern:
+            assert "from __future__ import annotations" in content, (
+                f"{os.path.basename(py_file)} uses PEP 604/585 type hints "
+                "but is missing 'from __future__ import annotations'. "
+                "This breaks on Python < 3.10 (macOS system Python 3.9.6)."
+            )
+
+
 def test_snippets_import_os_before_usage():
     """Snippets using os.* must import os on a PRIOR line.
 

--- a/tests/test_skill_snippets.py
+++ b/tests/test_skill_snippets.py
@@ -95,21 +95,25 @@ def test_no_tail_c_in_skills():
 
 
 def test_hooks_future_annotations():
-    """Hook .py files using PEP 604/585 type hints must have 'from __future__ import annotations'.
+    """All .py files using PEP 604/585 type hints must have 'from __future__ import annotations'.
 
     Without this import, `dict | None` and `list[str]` syntax fails on
-    Python < 3.10 (macOS system Python is 3.9.6).
+    Python < 3.10 (macOS system Python is 3.9.6). Scans hooks/ and scripts/.
     """
-    hooks_dir = os.path.join(_REPO_ROOT, "hooks")
     pep604_re = re.compile(r':\s*\w+\s*\|\s*\w+|-> \w+\s*\|\s*\w+')
     pep585_re = re.compile(r':\s*(?:list|dict|set|tuple)\[')
-    for py_file in sorted(glob.glob(os.path.join(hooks_dir, "*.py"))):
+    py_files = sorted(
+        glob.glob(os.path.join(_REPO_ROOT, "hooks", "*.py"))
+        + glob.glob(os.path.join(_REPO_ROOT, "scripts", "**", "*.py"), recursive=True)
+    )
+    for py_file in py_files:
         with open(py_file, encoding="utf-8") as f:
             content = f.read()
         uses_modern = pep604_re.search(content) or pep585_re.search(content)
         if uses_modern:
+            rel_path = os.path.relpath(py_file, _REPO_ROOT)
             assert "from __future__ import annotations" in content, (
-                f"{os.path.basename(py_file)} uses PEP 604/585 type hints "
+                f"{rel_path} uses PEP 604/585 type hints "
                 "but is missing 'from __future__ import annotations'. "
                 "This breaks on Python < 3.10 (macOS system Python 3.9.6)."
             )

--- a/tests/test_vault_doctor_project_normalization.py
+++ b/tests/test_vault_doctor_project_normalization.py
@@ -151,6 +151,34 @@ def test_apply_does_not_touch_body(norm_vault):
     assert "The project my_project uses underscores." in content
 
 
+def test_apply_handles_quoted_project_value(norm_vault):
+    """apply normalizes project even when value is quoted in frontmatter."""
+    import vault_doctor_checks.project_name_normalization as check
+
+    note = norm_vault["sessions"] / "quoted.md"
+    note.write_text(
+        '---\n'
+        'type: claude-session\n'
+        'project: "personal_ws"\n'
+        'tags:\n'
+        '  - claude/project/personal_ws\n'
+        '---\n\n# Quoted\n',
+        encoding="utf-8",
+    )
+
+    issues = check.scan(
+        str(norm_vault["vault"]), "claude-sessions", "claude-insights", 9999
+    )
+    assert len(issues) == 1
+
+    results = check.apply(issues, str(norm_vault["vault"] / ".backups"))
+    assert results[0].status == "applied"
+
+    content = note.read_text(encoding="utf-8")
+    assert "project: personal-ws" in content
+    assert '"personal_ws"' not in content
+
+
 def test_apply_error_missing_extra_fields(norm_vault):
     """apply returns error when Issue.extra lacks original/normalized."""
     from vault_doctor_checks import Issue

--- a/tests/test_vault_doctor_project_normalization.py
+++ b/tests/test_vault_doctor_project_normalization.py
@@ -1,0 +1,151 @@
+"""Tests for vault_doctor_checks/project_name_normalization.py."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Ensure scripts/ is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+
+@pytest.fixture
+def norm_vault(tmp_path):
+    """Create a minimal vault with underscore project names."""
+    sessions = tmp_path / "claude-sessions"
+    insights = tmp_path / "claude-insights"
+    sessions.mkdir()
+    insights.mkdir()
+    return {"vault": tmp_path, "sessions": sessions, "insights": insights}
+
+
+def _write_note(path, project, note_type="claude-session"):
+    path.write_text(
+        f"---\n"
+        f"type: {note_type}\n"
+        f"date: 2026-04-13\n"
+        f"project: {project}\n"
+        f"session_id: abc123\n"
+        f"tags:\n"
+        f"  - claude/{note_type.split('-')[1]}\n"
+        f"  - claude/project/{project}\n"
+        f"---\n\n# Test note\n",
+        encoding="utf-8",
+    )
+
+
+def test_scan_finds_underscored_projects(norm_vault):
+    import vault_doctor_checks.project_name_normalization as check
+
+    _write_note(norm_vault["sessions"] / "session1.md", "personal_ws")
+    _write_note(norm_vault["insights"] / "insight1.md", "personal_ws", "claude-insight")
+
+    issues = check.scan(
+        str(norm_vault["vault"]), "claude-sessions", "claude-insights", 9999
+    )
+    assert len(issues) == 2
+    for issue in issues:
+        assert issue.extra["original"] == "personal_ws"
+        assert issue.extra["normalized"] == "personal-ws"
+
+
+def test_scan_ignores_hyphenated_projects(norm_vault):
+    import vault_doctor_checks.project_name_normalization as check
+
+    _write_note(norm_vault["sessions"] / "session1.md", "personal-ws")
+
+    issues = check.scan(
+        str(norm_vault["vault"]), "claude-sessions", "claude-insights", 9999
+    )
+    assert len(issues) == 0
+
+
+def test_scan_respects_project_filter(norm_vault):
+    import vault_doctor_checks.project_name_normalization as check
+
+    _write_note(norm_vault["sessions"] / "s1.md", "personal_ws")
+    _write_note(norm_vault["sessions"] / "s2.md", "other_project")
+
+    # Filter for personal_ws — should match despite _ vs -
+    issues = check.scan(
+        str(norm_vault["vault"]), "claude-sessions", "claude-insights", 9999,
+        project="personal-ws",
+    )
+    assert len(issues) == 1
+    assert issues[0].extra["original"] == "personal_ws"
+
+
+def test_apply_normalizes_project_and_tag(norm_vault):
+    import vault_doctor_checks.project_name_normalization as check
+
+    note = norm_vault["sessions"] / "session1.md"
+    _write_note(note, "personal_ws")
+
+    issues = check.scan(
+        str(norm_vault["vault"]), "claude-sessions", "claude-insights", 9999
+    )
+    assert len(issues) == 1
+
+    backup_root = str(norm_vault["vault"] / ".backups")
+    results = check.apply(issues, backup_root)
+    assert len(results) == 1
+    assert results[0].status == "applied"
+    assert results[0].backup_path is not None
+
+    # Verify the note was updated
+    content = note.read_text(encoding="utf-8")
+    assert "project: personal-ws" in content
+    assert "claude/project/personal-ws" in content
+    assert "personal_ws" not in content
+
+    # Verify backup exists
+    assert os.path.isfile(results[0].backup_path)
+
+
+def test_apply_creates_backup(norm_vault):
+    import vault_doctor_checks.project_name_normalization as check
+
+    note = norm_vault["insights"] / "insight1.md"
+    _write_note(note, "my_app", "claude-insight")
+
+    issues = check.scan(
+        str(norm_vault["vault"]), "claude-sessions", "claude-insights", 9999
+    )
+    results = check.apply(issues, str(norm_vault["vault"] / ".backups"))
+
+    assert results[0].status == "applied"
+    # Backup should have original content
+    backup_content = open(results[0].backup_path, encoding="utf-8").read()
+    assert "project: my_app" in backup_content
+
+
+def test_apply_does_not_touch_body(norm_vault):
+    import vault_doctor_checks.project_name_normalization as check
+
+    note = norm_vault["sessions"] / "session1.md"
+    note.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "project: my_project\n"
+        "tags:\n"
+        "  - claude/project/my_project\n"
+        "---\n\n"
+        "# Body with my_project reference\n"
+        "The project my_project uses underscores.\n",
+        encoding="utf-8",
+    )
+
+    issues = check.scan(
+        str(norm_vault["vault"]), "claude-sessions", "claude-insights", 9999
+    )
+    results = check.apply(issues, str(norm_vault["vault"] / ".backups"))
+    assert results[0].status == "applied"
+
+    content = note.read_text(encoding="utf-8")
+    # Frontmatter normalized
+    assert "project: my-project" in content
+    assert "claude/project/my-project" in content
+    # Body untouched
+    assert "The project my_project uses underscores." in content

--- a/tests/test_vault_doctor_project_normalization.py
+++ b/tests/test_vault_doctor_project_normalization.py
@@ -149,3 +149,66 @@ def test_apply_does_not_touch_body(norm_vault):
     assert "claude/project/my-project" in content
     # Body untouched
     assert "The project my_project uses underscores." in content
+
+
+def test_apply_error_missing_extra_fields(norm_vault):
+    """apply returns error when Issue.extra lacks original/normalized."""
+    from vault_doctor_checks import Issue
+    import vault_doctor_checks.project_name_normalization as check
+
+    issue = Issue(
+        check=check.NAME,
+        note_path=str(norm_vault["sessions"] / "fake.md"),
+        project="test",
+        current_source="project: test",
+        proposed_source="project: test",
+        reason="test",
+        extra={},  # missing original/normalized
+    )
+    results = check.apply([issue], str(norm_vault["vault"] / ".backups"))
+    assert len(results) == 1
+    assert results[0].status == "error"
+    assert "missing" in results[0].error
+
+
+def test_apply_error_note_deleted_between_scan_and_apply(norm_vault):
+    """apply returns error when note is deleted after scan."""
+    import vault_doctor_checks.project_name_normalization as check
+
+    note = norm_vault["sessions"] / "session1.md"
+    _write_note(note, "my_app")
+
+    issues = check.scan(
+        str(norm_vault["vault"]), "claude-sessions", "claude-insights", 9999
+    )
+    # Delete the note before apply
+    note.unlink()
+
+    results = check.apply(issues, str(norm_vault["vault"] / ".backups"))
+    assert len(results) == 1
+    assert results[0].status == "error"
+
+
+def test_apply_backup_includes_source_folder(norm_vault):
+    """Backups include the source folder name to avoid cross-folder collisions."""
+    import vault_doctor_checks.project_name_normalization as check
+
+    # Create same-named notes in both folders
+    _write_note(norm_vault["sessions"] / "note.md", "my_app")
+    _write_note(norm_vault["insights"] / "note.md", "my_app", "claude-insight")
+
+    issues = check.scan(
+        str(norm_vault["vault"]), "claude-sessions", "claude-insights", 9999
+    )
+    assert len(issues) == 2
+
+    backup_root = str(norm_vault["vault"] / ".backups")
+    results = check.apply(issues, backup_root)
+
+    applied = [r for r in results if r.status == "applied"]
+    assert len(applied) == 2
+    # Both backups should exist (no collision)
+    paths = [r.backup_path for r in applied]
+    assert len(set(paths)) == 2, f"Backup collision: both backups at same path {paths}"
+    for p in paths:
+        assert os.path.isfile(p)

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -539,6 +539,31 @@ def test_jsonl_dir_for_project_underscore_to_hyphen_fallback(tmp_path, monkeypat
     assert str(result).endswith("-Users-foo-my-project")
 
 
+def test_list_session_notes_matches_across_underscore_hyphen(tmp_path):
+    """_list_session_notes matches session notes regardless of _ vs - in project name."""
+    import vault_doctor_checks.source_sessions as check
+
+    sessions_dir = tmp_path / "claude-sessions"
+    sessions_dir.mkdir()
+    # Session note has project: personal-ws (hyphen)
+    note = sessions_dir / "2026-04-13-test-session.md"
+    note.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-13\n"
+        "project: personal-ws\n"
+        "session_id: abc123\n"
+        "---\n\n# Test\n",
+        encoding="utf-8",
+    )
+
+    # Query with underscore variant — should still match
+    result = check._list_session_notes(sessions_dir, "personal_ws")
+    assert "abc123" in result, (
+        f"Expected session note to match despite _ vs - difference, got keys: {list(result.keys())}"
+    )
+
+
 def test_apply_rejects_path_traversal_in_project_name(doctor_vault, tmp_path):
     """An issue with a malicious project name cannot write outside backup_root."""
     import vault_doctor_checks.source_sessions as check

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -526,6 +526,19 @@ def test_jsonl_dir_for_project_deterministic_same_mtime_tiebreak(tmp_path, monke
     assert result1 == result2, f"non-deterministic: {result1} vs {result2}"
 
 
+def test_jsonl_dir_for_project_underscore_to_hyphen_fallback(tmp_path, monkeypatch):
+    """Project with underscores matches CC dir with hyphens."""
+    import vault_doctor_checks.source_sessions as check
+
+    cc_dir = tmp_path / ".claude" / "projects" / "-Users-foo-my-project"
+    cc_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = check._jsonl_dir_for_project("my_project")
+    assert result is not None, "Expected hyphen fallback to match"
+    assert str(result).endswith("-Users-foo-my-project")
+
+
 def test_apply_rejects_path_traversal_in_project_name(doctor_vault, tmp_path):
     """An issue with a malicious project name cannot write outside backup_root."""
     import vault_doctor_checks.source_sessions as check


### PR DESCRIPTION
## Summary
- Add `from __future__ import annotations` to `vault_index.py` and `obsidian_context_snapshot.py` — fixes `TypeError` on macOS system Python 3.9.6
- Fix underscore-to-hyphen project path matching across all 3 functions that glob `~/.claude/projects/` — extracted shared `_glob_project_jsonls()` helper
- Normalize project names (underscore → hyphen, lowercase, space → hyphen) consistently in `get_session_context()`, `extract_session_metadata()`, and vault-doctor comparisons
- Add `project-name-normalization` vault-doctor check — detects and auto-fixes underscored project names in frontmatter (`project:` field + `claude/project/` tags)
- Fix ambiguous hash instructions in 4 skills — replace vague `md5` with explicit `cut -c` commands
- Address 3-agent code review: normalization mismatch, backup collision, unbound `tmp` guard

## Test plan
- [x] 283 tests pass (18 new tests across all fixes)
- [x] Verified hook imports on `/usr/bin/python3` (3.9.6)
- [x] Commit preflight passed (92%+ coverage)
- [x] 3-agent parallel review: code-reviewer + silent-failure-hunter + test-analyzer

🤖 Generated with [Claude Code](https://claude.com/claude-code)