### PR TITLE
feat: add /vault-stats skill for vault health diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `/vault-stats` skill — vault health diagnostics and usage analytics showing signal coverage, access patterns, importance distribution, and top accessed notes; saves report to vault as `claude-stats` note for trend tracking
 - **vault-index**: ACT-R access tracking — `access_log` table records every note read with context type (recall, search, ask, related) for activation-based ranking
 - **vault-index**: `batch_activations()` computes ACT-R base-level activation (`ln(Σ t_i^(-0.5))`) for combined recency+frequency scoring
 - **vault-index**: `importance` column on `notes` table — 1-10 write-time score extracted from Haiku/sub-agent summarization output

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Run `/obsidian-setup` after installation. It will:
 | `/check-items` | Cross-project sweep for completed open items — auto-checks off matches after user confirmation |
 | `/vault-doctor` | Audit and repair the vault — detects stale `source_session` backlinks and other health issues (dry-run by default) |
 | `/vault-reindex` | Rebuild the SQLite + FTS5 search index from scratch — use after bulk edits in Obsidian or to recover from a corrupt index |
+| `/vault-stats` | Vault health diagnostics and usage analytics — signal coverage, access patterns, importance distribution, top accessed notes. Saves report to vault for trend tracking. |
 
 ### Usage Examples
 

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -90,7 +90,6 @@ def compute_stats(db_path: str, project: str) -> str:
     conn = None
     try:
         conn = sqlite3.connect(db_path, timeout=5.0)
-        conn.execute("PRAGMA journal_mode=WAL")
         conn.row_factory = sqlite3.Row
     except (sqlite3.Error, OSError) as exc:
         if conn is not None:
@@ -264,5 +263,6 @@ if __name__ == "__main__":
         sys.exit(1)
     result = compute_stats(sys.argv[1], sys.argv[2])
     print(result)
-    if '"error"' in result:
+    parsed = json.loads(result)
+    if "error" in parsed:
         sys.exit(1)

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -1,18 +1,17 @@
 """Vault statistics module — compute aggregate stats from the vault index DB.
 
 Single entry point: compute_stats(db_path, project) -> JSON string.
-Standalone module — no vault_index imports. Uses only Python stdlib.
 """
 
 from __future__ import annotations
 
 import json
-import math
 import os
 import sqlite3
 import sys
 import time
-from collections import defaultdict
+
+import vault_index
 
 
 # ---------------------------------------------------------------------------
@@ -20,45 +19,10 @@ from collections import defaultdict
 # ---------------------------------------------------------------------------
 
 
-def _compute_activations(
-    conn: sqlite3.Connection, note_paths: list[str], decay: float = 0.5
-) -> dict[str, float]:
-    """Compute ACT-R base-level activation for each note path.
-
-    Formula: ln(Σ t_i^(-decay)) where t_i = seconds since access.
-    Returns {path: activation} with 0.0 for notes with no access history.
-    Uses the existing connection (does NOT open a new one).
-    """
-    if not note_paths:
-        return {}
-
-    result: dict[str, float] = {p: 0.0 for p in note_paths}
-    now = time.time()
-
-    placeholders = ",".join("?" for _ in note_paths)
-    rows = conn.execute(
-        f"SELECT note_path, timestamp FROM access_log "
-        f"WHERE note_path IN ({placeholders})",
-        note_paths,
-    ).fetchall()
-
-    accesses: dict[str, list[float]] = defaultdict(list)
-    for row in rows:
-        accesses[row[0]].append(row[1])
-
-    for path, timestamps in accesses.items():
-        summation = 0.0
-        for ts in timestamps:
-            dt = max(now - ts, 0.001)
-            summation += dt ** (-decay)
-        if summation > 0.0:
-            result[path] = math.log(summation)
-
-    return result
-
-
 def _importance_bucket(importance: int) -> str:
     """Map importance score to distribution bucket."""
+    if importance is None:
+        importance = 5
     if importance <= 3:
         return "trivial"
     elif importance <= 6:
@@ -87,13 +51,21 @@ def compute_stats(db_path: str, project: str) -> str:
         conn = sqlite3.connect(db_path, timeout=5.0)
         conn.execute("PRAGMA journal_mode=WAL")
         conn.row_factory = sqlite3.Row
-    except Exception as exc:
-        return json.dumps({"error": str(exc)})
+    except sqlite3.Error as exc:
+        print(f"[vault-stats] DB error: {exc}", file=sys.stderr)
+        return json.dumps({"error": f"Database error: {exc}"})
+    except OSError as exc:
+        print(f"[vault-stats] file error: {exc}", file=sys.stderr)
+        return json.dumps({"error": f"File error: {exc}"})
 
     try:
         return _compute_stats_inner(conn, db_path, project)
-    except Exception as exc:
-        return json.dumps({"error": str(exc)})
+    except sqlite3.Error as exc:
+        print(f"[vault-stats] DB error: {exc}", file=sys.stderr)
+        return json.dumps({"error": f"Database error: {exc}"})
+    except OSError as exc:
+        print(f"[vault-stats] file error: {exc}", file=sys.stderr)
+        return json.dumps({"error": f"File error: {exc}"})
     finally:
         conn.close()
 
@@ -107,7 +79,10 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
     # --- vault_wide ---
 
     total_notes = conn.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
-    db_size_bytes = os.path.getsize(db_path)
+    try:
+        db_size_bytes = os.path.getsize(db_path)
+    except OSError:
+        db_size_bytes = 0
     access_log_entries = conn.execute("SELECT COUNT(*) FROM access_log").fetchone()[0]
 
     # Oldest access
@@ -136,7 +111,7 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
     has_importance_set = {
         r[0]
         for r in conn.execute(
-            "SELECT path FROM notes WHERE importance != 5"
+            "SELECT path FROM notes WHERE COALESCE(importance, 5) != 5"
         ).fetchall()
     }
 
@@ -169,14 +144,14 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
 
     top_paths = [r[0] for r in top_rows]
     top_counts = {r[0]: r[1] for r in top_rows}
-    activations = _compute_activations(conn, top_paths)
+    activations = vault_index.batch_activations(db_path, top_paths)
 
     # Get importance for top paths
     importance_map: dict[str, int] = {}
     if top_paths:
         placeholders = ",".join("?" for _ in top_paths)
         for r in conn.execute(
-            f"SELECT path, importance FROM notes WHERE path IN ({placeholders})",
+            f"SELECT path, COALESCE(importance, 5) FROM notes WHERE path IN ({placeholders})",
             top_paths,
         ).fetchall():
             importance_map[r[0]] = r[1]
@@ -194,7 +169,7 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
 
     # Importance distribution
     dist = {"trivial": 0, "standard": 0, "significant": 0, "critical": 0}
-    for r in conn.execute("SELECT importance FROM notes").fetchall():
+    for r in conn.execute("SELECT COALESCE(importance, 5) FROM notes").fetchall():
         bucket = _importance_bucket(r[0])
         dist[bucket] += 1
 
@@ -232,7 +207,7 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
         proj_activated = len(has_activation_set & set(proj_note_paths))
 
     proj_importance = conn.execute(
-        "SELECT COUNT(*) FROM notes WHERE project = ? AND importance != 5",
+        "SELECT COUNT(*) FROM notes WHERE project = ? AND COALESCE(importance, 5) != 5",
         (project,),
     ).fetchone()[0]
 
@@ -254,13 +229,13 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
 
     proj_top_paths = [r[0] for r in proj_top_rows]
     proj_top_counts = {r[0]: r[1] for r in proj_top_rows}
-    proj_activations = _compute_activations(conn, proj_top_paths)
+    proj_activations = vault_index.batch_activations(db_path, proj_top_paths)
 
     proj_imp_map: dict[str, int] = {}
     if proj_top_paths:
         placeholders = ",".join("?" for _ in proj_top_paths)
         for r in conn.execute(
-            f"SELECT path, importance FROM notes WHERE path IN ({placeholders})",
+            f"SELECT path, COALESCE(importance, 5) FROM notes WHERE path IN ({placeholders})",
             proj_top_paths,
         ).fetchall():
             proj_imp_map[r[0]] = r[1]
@@ -297,4 +272,7 @@ if __name__ == "__main__":
     if len(sys.argv) < 3:
         print(f"Usage: {sys.argv[0]} <db_path> <project>", file=sys.stderr)
         sys.exit(1)
-    print(compute_stats(sys.argv[1], sys.argv[2]))
+    result = compute_stats(sys.argv[1], sys.argv[2])
+    print(result)
+    if '"error"' in result:
+        sys.exit(1)

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -5,6 +5,7 @@ Single entry point: compute_stats(db_path, project) -> JSON string.
 
 from __future__ import annotations
 
+import datetime
 import json
 import os
 import sqlite3
@@ -21,16 +22,55 @@ import vault_index
 
 def _importance_bucket(importance: int) -> str:
     """Map importance score to distribution bucket."""
-    if importance is None:
-        importance = 5
     if importance <= 3:
         return "trivial"
-    elif importance <= 6:
+    if importance <= 6:
         return "standard"
-    elif importance <= 8:
+    if importance <= 8:
         return "significant"
-    else:
-        return "critical"
+    return "critical"
+
+
+def _enrich_top_accessed(
+    conn: sqlite3.Connection,
+    db_path: str,
+    rows: list,
+) -> list[dict]:
+    """Build enriched top-accessed list from ranked query rows.
+
+    Each row must have (note_path, cnt) columns.  Returns a list of dicts
+    with path, basename, accesses, activation, and importance.
+    """
+    paths = [r[0] for r in rows]
+    counts = {r[0]: r[1] for r in rows}
+    activations = vault_index.batch_activations(db_path, paths)
+
+    importance_map: dict[str, int] = {}
+    if paths:
+        placeholders = ",".join("?" for _ in paths)
+        for r in conn.execute(
+            f"SELECT path, COALESCE(importance, 5) FROM notes "
+            f"WHERE path IN ({placeholders})",
+            paths,
+        ).fetchall():
+            importance_map[r[0]] = r[1]
+
+    return [
+        {
+            "path": p,
+            "basename": os.path.basename(p),
+            "accesses": counts[p],
+            "activation": round(activations.get(p, 0.0), 4),
+            "importance": importance_map.get(p, 5),
+        }
+        for p in paths
+    ]
+
+
+def _handle_error(label: str, exc: Exception) -> str:
+    """Log error to stderr and return JSON error payload."""
+    print(f"[vault-stats] {label}: {exc}", file=sys.stderr)
+    return json.dumps({"error": f"{label}: {exc}"})
 
 
 # ---------------------------------------------------------------------------
@@ -52,25 +92,15 @@ def compute_stats(db_path: str, project: str) -> str:
         conn = sqlite3.connect(db_path, timeout=5.0)
         conn.execute("PRAGMA journal_mode=WAL")
         conn.row_factory = sqlite3.Row
-    except sqlite3.Error as exc:
+    except (sqlite3.Error, OSError) as exc:
         if conn is not None:
             conn.close()
-        print(f"[vault-stats] DB error: {exc}", file=sys.stderr)
-        return json.dumps({"error": f"Database error: {exc}"})
-    except OSError as exc:
-        if conn is not None:
-            conn.close()
-        print(f"[vault-stats] file error: {exc}", file=sys.stderr)
-        return json.dumps({"error": f"File error: {exc}"})
+        return _handle_error("DB open error", exc)
 
     try:
         return _compute_stats_inner(conn, db_path, project)
-    except sqlite3.Error as exc:
-        print(f"[vault-stats] DB error: {exc}", file=sys.stderr)
-        return json.dumps({"error": f"Database error: {exc}"})
-    except OSError as exc:
-        print(f"[vault-stats] file error: {exc}", file=sys.stderr)
-        return json.dumps({"error": f"File error: {exc}"})
+    except (sqlite3.Error, OSError) as exc:
+        return _handle_error("DB error", exc)
     finally:
         conn.close()
 
@@ -94,8 +124,6 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
     row = conn.execute("SELECT MIN(timestamp) FROM access_log").fetchone()
     oldest_ts = row[0] if row else None
     if oldest_ts is not None:
-        import datetime
-
         oldest_access = datetime.datetime.fromtimestamp(oldest_ts).strftime("%Y-%m-%d")
     else:
         oldest_access = None
@@ -147,31 +175,7 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
         "INNER JOIN notes n ON n.path = a.note_path "
         "GROUP BY a.note_path ORDER BY cnt DESC LIMIT 10"
     ).fetchall()
-
-    top_paths = [r[0] for r in top_rows]
-    top_counts = {r[0]: r[1] for r in top_rows}
-    activations = vault_index.batch_activations(db_path, top_paths)
-
-    # Get importance for top paths
-    importance_map: dict[str, int] = {}
-    if top_paths:
-        placeholders = ",".join("?" for _ in top_paths)
-        for r in conn.execute(
-            f"SELECT path, COALESCE(importance, 5) FROM notes WHERE path IN ({placeholders})",
-            top_paths,
-        ).fetchall():
-            importance_map[r[0]] = r[1]
-
-    top_accessed = []
-    for path in top_paths:
-        basename = os.path.basename(path)
-        top_accessed.append({
-            "path": path,
-            "basename": basename,
-            "accesses": top_counts[path],
-            "activation": round(activations.get(path, 0.0), 4),
-            "importance": importance_map.get(path, 5),
-        })
+    top_accessed = _enrich_top_accessed(conn, db_path, top_rows)
 
     # Importance distribution
     dist = {"trivial": 0, "standard": 0, "significant": 0, "critical": 0}
@@ -234,29 +238,7 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
         "GROUP BY a.note_path ORDER BY cnt DESC LIMIT 5",
         (project, project),
     ).fetchall()
-
-    proj_top_paths = [r[0] for r in proj_top_rows]
-    proj_top_counts = {r[0]: r[1] for r in proj_top_rows}
-    proj_activations = vault_index.batch_activations(db_path, proj_top_paths)
-
-    proj_imp_map: dict[str, int] = {}
-    if proj_top_paths:
-        placeholders = ",".join("?" for _ in proj_top_paths)
-        for r in conn.execute(
-            f"SELECT path, COALESCE(importance, 5) FROM notes WHERE path IN ({placeholders})",
-            proj_top_paths,
-        ).fetchall():
-            proj_imp_map[r[0]] = r[1]
-
-    proj_top_accessed = []
-    for path in proj_top_paths:
-        proj_top_accessed.append({
-            "path": path,
-            "basename": os.path.basename(path),
-            "accesses": proj_top_counts[path],
-            "activation": round(proj_activations.get(path, 0.0), 4),
-            "importance": proj_imp_map.get(path, 5),
-        })
+    proj_top_accessed = _enrich_top_accessed(conn, db_path, proj_top_rows)
 
     project_data = {
         "name": project,

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -1,0 +1,300 @@
+"""Vault statistics module — compute aggregate stats from the vault index DB.
+
+Single entry point: compute_stats(db_path, project) -> JSON string.
+Standalone module — no vault_index imports. Uses only Python stdlib.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sqlite3
+import sys
+import time
+from collections import defaultdict
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_activations(
+    conn: sqlite3.Connection, note_paths: list[str], decay: float = 0.5
+) -> dict[str, float]:
+    """Compute ACT-R base-level activation for each note path.
+
+    Formula: ln(Σ t_i^(-decay)) where t_i = seconds since access.
+    Returns {path: activation} with 0.0 for notes with no access history.
+    Uses the existing connection (does NOT open a new one).
+    """
+    if not note_paths:
+        return {}
+
+    result: dict[str, float] = {p: 0.0 for p in note_paths}
+    now = time.time()
+
+    placeholders = ",".join("?" for _ in note_paths)
+    rows = conn.execute(
+        f"SELECT note_path, timestamp FROM access_log "
+        f"WHERE note_path IN ({placeholders})",
+        note_paths,
+    ).fetchall()
+
+    accesses: dict[str, list[float]] = defaultdict(list)
+    for row in rows:
+        accesses[row[0]].append(row[1])
+
+    for path, timestamps in accesses.items():
+        summation = 0.0
+        for ts in timestamps:
+            dt = max(now - ts, 0.001)
+            summation += dt ** (-decay)
+        if summation > 0.0:
+            result[path] = math.log(summation)
+
+    return result
+
+
+def _importance_bucket(importance: int) -> str:
+    """Map importance score to distribution bucket."""
+    if importance <= 3:
+        return "trivial"
+    elif importance <= 6:
+        return "standard"
+    elif importance <= 8:
+        return "significant"
+    else:
+        return "critical"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_stats(db_path: str, project: str) -> str:
+    """Compute vault-wide and project-scoped statistics.
+
+    Returns a JSON string with two top-level keys: vault_wide and project.
+    On error, returns {"error": "..."}.
+    """
+    if not os.path.exists(db_path):
+        return json.dumps({"error": f"DB not found: {db_path}"})
+
+    try:
+        conn = sqlite3.connect(db_path, timeout=5.0)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.row_factory = sqlite3.Row
+    except Exception as exc:
+        return json.dumps({"error": str(exc)})
+
+    try:
+        return _compute_stats_inner(conn, db_path, project)
+    except Exception as exc:
+        return json.dumps({"error": str(exc)})
+    finally:
+        conn.close()
+
+
+def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -> str:
+    """Core stats computation using an open connection."""
+    now = time.time()
+    thirty_days_ago = now - 30 * 86400
+    seven_days_ago = now - 7 * 86400
+
+    # --- vault_wide ---
+
+    total_notes = conn.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
+    db_size_bytes = os.path.getsize(db_path)
+    access_log_entries = conn.execute("SELECT COUNT(*) FROM access_log").fetchone()[0]
+
+    # Oldest access
+    row = conn.execute("SELECT MIN(timestamp) FROM access_log").fetchone()
+    oldest_ts = row[0] if row else None
+    if oldest_ts is not None:
+        import datetime
+
+        oldest_access = datetime.datetime.fromtimestamp(oldest_ts).strftime("%Y-%m-%d")
+    else:
+        oldest_access = None
+
+    # Signal coverage
+    has_activation_set = {
+        r[0]
+        for r in conn.execute(
+            "SELECT DISTINCT note_path FROM access_log"
+        ).fetchall()
+    }
+    # Filter to only notes that actually exist in the notes table
+    all_note_paths = {
+        r[0] for r in conn.execute("SELECT path FROM notes").fetchall()
+    }
+    has_activation_set &= all_note_paths
+
+    has_importance_set = {
+        r[0]
+        for r in conn.execute(
+            "SELECT path FROM notes WHERE importance != 5"
+        ).fetchall()
+    }
+
+    has_both = len(has_activation_set & has_importance_set)
+    has_activation = len(has_activation_set)
+    has_importance = len(has_importance_set)
+    has_neither = total_notes - has_activation - has_importance + has_both
+
+    signal_coverage = {
+        "has_activation": has_activation,
+        "has_importance": has_importance,
+        "has_both": has_both,
+        "has_neither": has_neither,
+    }
+
+    # Access by context (last 30 days)
+    access_by_context: dict[str, int] = {}
+    for r in conn.execute(
+        "SELECT context_type, COUNT(*) FROM access_log "
+        "WHERE timestamp >= ? GROUP BY context_type",
+        (thirty_days_ago,),
+    ).fetchall():
+        access_by_context[r[0]] = r[1]
+
+    # Top accessed (top 10 by access count)
+    top_rows = conn.execute(
+        "SELECT note_path, COUNT(*) as cnt FROM access_log "
+        "GROUP BY note_path ORDER BY cnt DESC LIMIT 10"
+    ).fetchall()
+
+    top_paths = [r[0] for r in top_rows]
+    top_counts = {r[0]: r[1] for r in top_rows}
+    activations = _compute_activations(conn, top_paths)
+
+    # Get importance for top paths
+    importance_map: dict[str, int] = {}
+    if top_paths:
+        placeholders = ",".join("?" for _ in top_paths)
+        for r in conn.execute(
+            f"SELECT path, importance FROM notes WHERE path IN ({placeholders})",
+            top_paths,
+        ).fetchall():
+            importance_map[r[0]] = r[1]
+
+    top_accessed = []
+    for path in top_paths:
+        basename = os.path.basename(path)
+        top_accessed.append({
+            "path": path,
+            "basename": basename,
+            "accesses": top_counts[path],
+            "activation": round(activations.get(path, 0.0), 4),
+            "importance": importance_map.get(path, 5),
+        })
+
+    # Importance distribution
+    dist = {"trivial": 0, "standard": 0, "significant": 0, "critical": 0}
+    for r in conn.execute("SELECT importance FROM notes").fetchall():
+        bucket = _importance_bucket(r[0])
+        dist[bucket] += 1
+
+    vault_wide = {
+        "total_notes": total_notes,
+        "db_size_bytes": db_size_bytes,
+        "access_log_entries": access_log_entries,
+        "oldest_access": oldest_access,
+        "signal_coverage": signal_coverage,
+        "access_by_context": access_by_context,
+        "top_accessed": top_accessed,
+        "importance_distribution": dist,
+    }
+
+    # --- project ---
+
+    proj_total = conn.execute(
+        "SELECT COUNT(*) FROM notes WHERE project = ?", (project,)
+    ).fetchone()[0]
+
+    proj_access_events = conn.execute(
+        "SELECT COUNT(*) FROM access_log WHERE project = ?", (project,)
+    ).fetchone()[0]
+
+    avg_accesses = round(proj_access_events / proj_total, 2) if proj_total > 0 else 0.0
+
+    proj_activated = 0
+    if proj_total > 0:
+        proj_note_paths = [
+            r[0]
+            for r in conn.execute(
+                "SELECT path FROM notes WHERE project = ?", (project,)
+            ).fetchall()
+        ]
+        proj_activated = len(has_activation_set & set(proj_note_paths))
+
+    proj_importance = conn.execute(
+        "SELECT COUNT(*) FROM notes WHERE project = ? AND importance != 5",
+        (project,),
+    ).fetchone()[0]
+
+    # Recent activity (last 7 days, project-scoped)
+    recent_activity: dict[str, int] = {}
+    for r in conn.execute(
+        "SELECT context_type, COUNT(*) FROM access_log "
+        "WHERE timestamp >= ? AND project = ? GROUP BY context_type",
+        (seven_days_ago, project),
+    ).fetchall():
+        recent_activity[r[0]] = r[1]
+
+    # Top 5 project notes by access count
+    proj_top_rows = conn.execute(
+        "SELECT note_path, COUNT(*) as cnt FROM access_log "
+        "WHERE project = ? GROUP BY note_path ORDER BY cnt DESC LIMIT 5",
+        (project,),
+    ).fetchall()
+
+    proj_top_paths = [r[0] for r in proj_top_rows]
+    proj_top_counts = {r[0]: r[1] for r in proj_top_rows}
+    proj_activations = _compute_activations(conn, proj_top_paths)
+
+    proj_imp_map: dict[str, int] = {}
+    if proj_top_paths:
+        placeholders = ",".join("?" for _ in proj_top_paths)
+        for r in conn.execute(
+            f"SELECT path, importance FROM notes WHERE path IN ({placeholders})",
+            proj_top_paths,
+        ).fetchall():
+            proj_imp_map[r[0]] = r[1]
+
+    proj_top_accessed = []
+    for path in proj_top_paths:
+        proj_top_accessed.append({
+            "path": path,
+            "basename": os.path.basename(path),
+            "accesses": proj_top_counts[path],
+            "activation": round(proj_activations.get(path, 0.0), 4),
+            "importance": proj_imp_map.get(path, 5),
+        })
+
+    project_data = {
+        "name": project,
+        "total_notes": proj_total,
+        "access_events": proj_access_events,
+        "avg_accesses": avg_accesses,
+        "notes_with_activation": proj_activated,
+        "notes_with_importance": proj_importance,
+        "recent_activity": recent_activity,
+        "top_accessed": proj_top_accessed,
+    }
+
+    return json.dumps({"vault_wide": vault_wide, "project": project_data})
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <db_path> <project>", file=sys.stderr)
+        sys.exit(1)
+    print(compute_stats(sys.argv[1], sys.argv[2]))

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -47,14 +47,19 @@ def compute_stats(db_path: str, project: str) -> str:
     if not os.path.exists(db_path):
         return json.dumps({"error": f"DB not found: {db_path}"})
 
+    conn = None
     try:
         conn = sqlite3.connect(db_path, timeout=5.0)
         conn.execute("PRAGMA journal_mode=WAL")
         conn.row_factory = sqlite3.Row
     except sqlite3.Error as exc:
+        if conn is not None:
+            conn.close()
         print(f"[vault-stats] DB error: {exc}", file=sys.stderr)
         return json.dumps({"error": f"Database error: {exc}"})
     except OSError as exc:
+        if conn is not None:
+            conn.close()
         print(f"[vault-stats] file error: {exc}", file=sys.stderr)
         return json.dumps({"error": f"File error: {exc}"})
 
@@ -136,10 +141,11 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
     ).fetchall():
         access_by_context[r[0]] = r[1]
 
-    # Top accessed (top 10 by access count)
+    # Top accessed (top 10 by access count, restricted to notes that still exist)
     top_rows = conn.execute(
-        "SELECT note_path, COUNT(*) as cnt FROM access_log "
-        "GROUP BY note_path ORDER BY cnt DESC LIMIT 10"
+        "SELECT a.note_path, COUNT(*) as cnt FROM access_log a "
+        "INNER JOIN notes n ON n.path = a.note_path "
+        "GROUP BY a.note_path ORDER BY cnt DESC LIMIT 10"
     ).fetchall()
 
     top_paths = [r[0] for r in top_rows]
@@ -220,11 +226,13 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
     ).fetchall():
         recent_activity[r[0]] = r[1]
 
-    # Top 5 project notes by access count
+    # Top 5 project notes by access count (restricted to notes that still exist)
     proj_top_rows = conn.execute(
-        "SELECT note_path, COUNT(*) as cnt FROM access_log "
-        "WHERE project = ? GROUP BY note_path ORDER BY cnt DESC LIMIT 5",
-        (project,),
+        "SELECT a.note_path, COUNT(*) as cnt FROM access_log a "
+        "INNER JOIN notes n ON n.path = a.note_path "
+        "WHERE a.project = ? AND n.project = ? "
+        "GROUP BY a.note_path ORDER BY cnt DESC LIMIT 5",
+        (project, project),
     ).fetchall()
 
     proj_top_paths = [r[0] for r in proj_top_rows]

--- a/skills/vault-stats/SKILL.md
+++ b/skills/vault-stats/SKILL.md
@@ -134,7 +134,7 @@ Format the JSON into markdown tables and display to the user. Use this structure
 | <for each entry in project.top_accessed, numbered 1-N> |
 ```
 
-Compute percentages as `round(count / total_notes * 100)` — show as integer with `%`. If total_notes is 0, show `0%`.
+Compute percentages: `round(count / denominator * 100)` — show as integer with `%`. For any percentage, if the denominator is 0, show `0%`. This applies to all tables (signal coverage uses total_notes, access patterns uses sum of counts).
 
 Format large numbers with commas (e.g. `1,832`).
 
@@ -169,7 +169,7 @@ Use the **Write** tool to save to `$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-vault
 Then set permissions:
 
 ```bash
-chmod 644 "$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-vault-stats-<hash>.md"
+chmod 600 "$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-vault-stats-<hash>.md"
 ```
 
 ### Step 5 — Confirm

--- a/skills/vault-stats/SKILL.md
+++ b/skills/vault-stats/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: vault-stats
+description: "Vault health diagnostics and usage analytics — signal coverage, access patterns, importance distribution, top accessed notes. Saves report to vault for trend tracking. Use when: (1) /vault-stats command, (2) user wants to check vault health, (3) user wants to see access patterns or signal effectiveness."
+metadata:
+  version: 1.0.0
+---
+
+# Vault Stats — Health Diagnostics & Usage Analytics
+
+Shows vault-wide health metrics and current project usage analytics, then saves the report as a vault note for trend tracking.
+
+**Tools needed:** Bash, Write
+
+## Procedure
+
+Follow these steps exactly. Do not skip steps or reorder them.
+
+### Step 1 — Load config, derive project, compute stats
+
+Run a single call that loads config, derives the project name, and computes all stats:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 -c '
+import sys, os, json
+import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from obsidian_utils import load_config
+from vault_index import ensure_index
+from vault_stats import compute_stats
+c = load_config()
+if not c.get("vault_path"):
+    print(json.dumps({"error": "vault_path not configured. Run /obsidian-setup first."}))
+    sys.exit(0)
+vp = c["vault_path"]
+folders = [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")]
+db = ensure_index(vp, folders)
+project = os.path.basename(os.getcwd()).lower().replace(" ", "-")
+result = compute_stats(db, project)
+print("VAULT=" + vp)
+print("INS=" + c.get("insights_folder", "claude-insights"))
+print("PROJECT=" + project)
+print("STATS_JSON=" + result)
+'
+```
+
+Parse each output line as KEY=VALUE, splitting on the first `=`.
+
+If `STATS_JSON` contains `"error"`, display the error message and stop.
+
+Parse `STATS_JSON` as JSON into a variable `STATS`.
+
+### Step 2 — Check for empty/missing data
+
+If `STATS.vault_wide.total_notes == 0`:
+
+> No notes indexed. Run `/vault-reindex` first.
+
+Stop here.
+
+If `STATS.vault_wide.access_log_entries == 0`, note this for later — display the stats tables normally but append a note at the end.
+
+### Step 3 — Format and display
+
+Format the JSON into markdown tables and display to the user. Use this structure:
+
+**Vault-wide section:**
+
+```
+## Vault Health
+
+| Metric | Value |
+|---|---|
+| Total notes | <total_notes> |
+| DB size | <db_size_bytes formatted: >= 1048576 → "X.X MB", >= 1024 → "X.X KB", else "N bytes"> |
+| access_log entries | <access_log_entries with commas> |
+| Oldest access | <oldest_access or "None yet"> |
+
+## Signal Coverage
+
+| Signal | Coverage | Notes |
+|---|---|---|
+| Activation (access history) | <pct>% (<has_activation>/<total_notes>) | <total_notes - has_activation> notes never accessed |
+| Importance (non-default) | <pct>% (<has_importance>/<total_notes>) | <total_notes - has_importance> notes at default 5 |
+| Both signals active | <pct>% (<has_both>/<total_notes>) | Full 7-signal scoring |
+| Neither signal | <pct>% (<has_neither>/<total_notes>) | Using 5-signal fallback |
+
+## Access Patterns (last 30 days)
+
+| Context | Count | % |
+|---|---|---|
+| <for each entry in access_by_context, sorted by count desc> |
+
+## Top 10 Most Accessed Notes
+
+| # | Note | Accesses | Activation | Importance |
+|---|---|---|---|---|
+| <for each entry in top_accessed, numbered 1-N> |
+
+## Importance Distribution
+
+| Score | Count |
+|---|---|
+| 1-3 (trivial) | <trivial> |
+| 4-6 (standard) | <standard> |
+| 7-8 (significant) | <significant> |
+| 9-10 (critical) | <critical> |
+```
+
+**Project section:**
+
+```
+---
+
+## Project: <project.name>
+
+| Metric | Value |
+|---|---|
+| Notes | <total_notes> |
+| Access events | <access_events> |
+| Avg accesses/note | <avg_accesses> |
+| Notes with activation | <notes_with_activation> (<pct>%) |
+| Notes with importance != 5 | <notes_with_importance> (<pct>%) |
+
+## Recent Activity (last 7 days)
+
+| Context | Count |
+|---|---|
+| <for each entry in recent_activity, sorted by count desc> |
+
+## Top 5 Most Accessed (this project)
+
+| # | Note | Accesses | Activation | Importance |
+|---|---|---|---|---|
+| <for each entry in project.top_accessed, numbered 1-N> |
+```
+
+Compute percentages as `round(count / total_notes * 100)` — show as integer with `%`. If total_notes is 0, show `0%`.
+
+Format large numbers with commas (e.g. `1,832`).
+
+If `access_log_entries == 0`, append after the tables:
+
+> Access tracking is active. Run `/vault-search` and `/recall` to start building history.
+
+### Step 4 — Save vault note
+
+Generate filename:
+1. Date: today's date `YYYY-MM-DD`
+2. Hash: 4-character hex from `date +%s | md5 | cut -c29-32` (macOS) or `date +%s | md5sum | cut -c1-4` (Linux). Do NOT use `tail -c 4`.
+3. Filename: `YYYY-MM-DD-vault-stats-<hash>.md`
+
+Compose the full note: frontmatter + the markdown output from Step 3.
+
+Frontmatter:
+
+```yaml
+---
+type: claude-stats
+date: YYYY-MM-DD
+project: <PROJECT>
+tags:
+  - claude/stats
+  - claude/project/<PROJECT>
+---
+```
+
+Use the **Write** tool to save to `$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-vault-stats-<hash>.md`.
+
+Then set permissions:
+
+```bash
+chmod 644 "$VAULT_PATH/$INSIGHTS_FOLDER/YYYY-MM-DD-vault-stats-<hash>.md"
+```
+
+### Step 5 — Confirm
+
+Print:
+
+> Stats saved to `<full path>`. View in Obsidian to track trends over time.

--- a/skills/vault-stats/SKILL.md
+++ b/skills/vault-stats/SKILL.md
@@ -29,7 +29,7 @@ from vault_index import ensure_index
 from vault_stats import compute_stats
 c = load_config()
 if not c.get("vault_path"):
-    print(json.dumps({"error": "vault_path not configured. Run /obsidian-setup first."}))
+    print("ERROR=vault_path not configured. Run /obsidian-setup first.")
     sys.exit(0)
 vp = c["vault_path"]
 folders = [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")]
@@ -44,6 +44,8 @@ print("STATS_JSON=" + result)
 ```
 
 Parse each output line as KEY=VALUE, splitting on the first `=`.
+
+If an `ERROR` key is present, display its value and stop.
 
 If `STATS_JSON` contains `"error"`, display the error message and stop.
 

--- a/tests/test_vault_stats.py
+++ b/tests/test_vault_stats.py
@@ -341,3 +341,107 @@ class TestComputeStatsDBSize:
         db_path = _setup_db(tmp_vault)
         result = json.loads(vault_stats.compute_stats(db_path, "p"))
         assert result["vault_wide"]["db_size_bytes"] >= 0
+
+
+class TestImportanceBucketBoundaries:
+    """Verify _importance_bucket boundary values."""
+
+    @pytest.mark.parametrize("value,expected", [
+        (1, "trivial"),
+        (2, "trivial"),
+        (3, "trivial"),
+        (4, "standard"),
+        (5, "standard"),
+        (6, "standard"),
+        (7, "significant"),
+        (8, "significant"),
+        (9, "critical"),
+        (10, "critical"),
+    ])
+    def test_bucket_boundaries(self, value, expected):
+        assert vault_stats._importance_bucket(value) == expected
+
+
+class TestOrphanedAccessLogEntries:
+    """Verify that access_log entries for deleted notes don't appear in stats."""
+
+    def test_orphaned_access_excluded_from_top_accessed(self, tmp_vault):
+        """Access events for notes deleted from vault don't appear in top_accessed."""
+        now = time.time()
+        notes = [
+            {
+                "filename": "exists.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+            },
+        ]
+        accesses = [
+            # This note exists
+            {"note_path": "claude-sessions/exists.md", "timestamp": now - 100, "context_type": "search"},
+            # This note does NOT exist in vault (orphaned access)
+            {"note_path": "/vault/deleted-note.md", "timestamp": now - 50, "context_type": "search"},
+            {"note_path": "/vault/deleted-note.md", "timestamp": now - 60, "context_type": "recall"},
+            {"note_path": "/vault/deleted-note.md", "timestamp": now - 70, "context_type": "search"},
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes, accesses=accesses)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        top_paths = [t["path"] for t in result["vault_wide"]["top_accessed"]]
+        assert "/vault/deleted-note.md" not in top_paths
+
+    def test_orphaned_access_excluded_from_signal_coverage(self, tmp_vault):
+        """Orphaned access events don't inflate has_activation count."""
+        now = time.time()
+        notes = [
+            {
+                "filename": "real.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+            },
+        ]
+        accesses = [
+            {"note_path": "/vault/ghost.md", "timestamp": now - 50, "context_type": "search"},
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes, accesses=accesses)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        # Ghost note shouldn't count as activation
+        assert result["vault_wide"]["signal_coverage"]["has_activation"] == 0
+        assert result["vault_wide"]["signal_coverage"]["has_neither"] == 1
+
+
+class TestAvgAccessesEdgeCases:
+    """Verify avg_accesses handles edge cases."""
+
+    def test_zero_accesses_returns_zero(self, tmp_vault):
+        """Project with notes but zero access events → avg_accesses = 0.0."""
+        notes = [
+            {
+                "filename": "a.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+            },
+            {
+                "filename": "b.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+            },
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        assert result["project"]["avg_accesses"] == 0.0
+
+    def test_fractional_avg(self, tmp_vault):
+        """5 accesses / 2 notes = 2.5."""
+        now = time.time()
+        notes = [
+            {
+                "filename": "n1.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+            },
+            {
+                "filename": "n2.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+            },
+        ]
+        accesses = [
+            {"note_path": "claude-sessions/n1.md", "timestamp": now - i * 10, "context_type": "search", "project": "p"}
+            for i in range(5)
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes, accesses=accesses)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        assert result["project"]["avg_accesses"] == 2.5

--- a/tests/test_vault_stats.py
+++ b/tests/test_vault_stats.py
@@ -1,0 +1,343 @@
+"""Tests for hooks/vault_stats.py — vault statistics module."""
+
+import json
+import os
+import sqlite3
+import time
+
+import pytest
+
+import vault_index
+import vault_stats
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_note(path, frontmatter: dict, body: str = ""):
+    """Write a markdown note with YAML frontmatter."""
+    lines = ["---"]
+    for k, v in frontmatter.items():
+        if isinstance(v, list):
+            lines.append(f"{k}:")
+            for item in v:
+                lines.append(f"  - {item}")
+        else:
+            lines.append(f"{k}: {v}")
+    lines.append("---")
+    lines.append("")
+    if body:
+        lines.append(body)
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _setup_db(tmp_vault, notes=None, accesses=None):
+    """Create and populate a test DB.
+
+    notes: list of dicts with keys: filename, frontmatter, body (optional)
+    accesses: list of dicts with keys: note_path, timestamp, context_type, project (optional)
+    """
+    db_path = str(tmp_vault / "test.db")
+    vault_index.ensure_index(
+        str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db_path
+    )
+
+    if notes:
+        for note in notes:
+            folder = note.get("folder", "claude-sessions")
+            note_path = tmp_vault / folder / note["filename"]
+            _write_note(note_path, note["frontmatter"], note.get("body", ""))
+
+        # Re-index to pick up new files
+        vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions", "claude-insights"], db_path=db_path
+        )
+
+        # Update importance via direct SQL if specified
+        conn = sqlite3.connect(db_path)
+        for note in notes:
+            if "importance" in note:
+                abs_path = str(tmp_vault / note.get("folder", "claude-sessions") / note["filename"])
+                conn.execute(
+                    "UPDATE notes SET importance = ? WHERE path = ?",
+                    (note["importance"], abs_path),
+                )
+        conn.commit()
+        conn.close()
+
+    if accesses:
+        conn = sqlite3.connect(db_path)
+        for acc in accesses:
+            # Convert relative paths to absolute (matching vault_index storage)
+            note_p = acc["note_path"]
+            if not os.path.isabs(note_p):
+                note_p = str(tmp_vault / note_p)
+            conn.execute(
+                "INSERT INTO access_log (note_path, timestamp, context_type, project) "
+                "VALUES (?, ?, ?, ?)",
+                (
+                    note_p,
+                    acc["timestamp"],
+                    acc["context_type"],
+                    acc.get("project"),
+                ),
+            )
+        conn.commit()
+        conn.close()
+
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Test classes
+# ---------------------------------------------------------------------------
+
+
+class TestComputeStatsEmptyDB:
+    def test_empty_db_returns_zero_counts(self, tmp_vault):
+        db_path = _setup_db(tmp_vault)
+        result = json.loads(vault_stats.compute_stats(db_path, "test-project"))
+
+        assert result["vault_wide"]["total_notes"] == 0
+        assert result["vault_wide"]["access_log_entries"] == 0
+        assert result["vault_wide"]["oldest_access"] is None
+        assert result["vault_wide"]["top_accessed"] == []
+        assert result["project"]["total_notes"] == 0
+        assert result["project"]["access_events"] == 0
+        assert result["project"]["avg_accesses"] == 0.0
+
+    def test_empty_db_signal_coverage_all_neither(self, tmp_vault):
+        db_path = _setup_db(tmp_vault)
+        result = json.loads(vault_stats.compute_stats(db_path, "test-project"))
+        sc = result["vault_wide"]["signal_coverage"]
+        assert sc["has_activation"] == 0
+        assert sc["has_importance"] == 0
+        assert sc["has_both"] == 0
+        assert sc["has_neither"] == 0
+
+
+class TestComputeStatsWithNotes:
+    def test_total_notes_counted(self, tmp_vault):
+        notes = [
+            {
+                "filename": "note1.md",
+                "frontmatter": {
+                    "type": "claude-session",
+                    "date": "2026-04-01",
+                    "project": "proj-a",
+                },
+            },
+            {
+                "filename": "note2.md",
+                "frontmatter": {
+                    "type": "claude-session",
+                    "date": "2026-04-02",
+                    "project": "proj-b",
+                },
+            },
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes)
+        result = json.loads(vault_stats.compute_stats(db_path, "proj-a"))
+        assert result["vault_wide"]["total_notes"] == 2
+
+    def test_importance_distribution_bucketed(self, tmp_vault):
+        notes = [
+            {
+                "filename": "n1.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+                "importance": 2,  # trivial
+            },
+            {
+                "filename": "n2.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-02", "project": "p"},
+                "importance": 5,  # standard
+            },
+            {
+                "filename": "n3.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-03", "project": "p"},
+                "importance": 7,  # significant
+            },
+            {
+                "filename": "n4.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-04", "project": "p"},
+                "importance": 10,  # critical
+            },
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        dist = result["vault_wide"]["importance_distribution"]
+        assert dist["trivial"] == 1
+        assert dist["standard"] == 1
+        assert dist["significant"] == 1
+        assert dist["critical"] == 1
+
+
+class TestComputeStatsWithAccessLog:
+    def test_access_by_context_grouped(self, tmp_vault):
+        now = time.time()
+        notes = [
+            {
+                "filename": "a.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+            },
+        ]
+        accesses = [
+            {"note_path": "claude-sessions/a.md", "timestamp": now - 100, "context_type": "recall"},
+            {"note_path": "claude-sessions/a.md", "timestamp": now - 200, "context_type": "recall"},
+            {"note_path": "claude-sessions/a.md", "timestamp": now - 300, "context_type": "search"},
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes, accesses=accesses)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        abc = result["vault_wide"]["access_by_context"]
+        assert abc["recall"] == 2
+        assert abc["search"] == 1
+
+    def test_top_accessed_sorted(self, tmp_vault):
+        now = time.time()
+        notes = [
+            {
+                "filename": f"note{i}.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+            }
+            for i in range(3)
+        ]
+        accesses = []
+        # note0: 1 access, note1: 3 accesses, note2: 2 accesses
+        for _ in range(1):
+            accesses.append({"note_path": "claude-sessions/note0.md", "timestamp": now - 100, "context_type": "recall"})
+        for _ in range(3):
+            accesses.append({"note_path": "claude-sessions/note1.md", "timestamp": now - 100, "context_type": "recall"})
+        for _ in range(2):
+            accesses.append({"note_path": "claude-sessions/note2.md", "timestamp": now - 100, "context_type": "recall"})
+
+        db_path = _setup_db(tmp_vault, notes=notes, accesses=accesses)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        top = result["vault_wide"]["top_accessed"]
+        assert len(top) == 3
+        assert top[0]["accesses"] == 3
+        assert top[0]["path"].endswith("claude-sessions/note1.md")
+        assert top[1]["accesses"] == 2
+        assert top[2]["accesses"] == 1
+
+
+class TestComputeStatsProjectScoping:
+    def test_project_filter_only_counts_matching(self, tmp_vault):
+        now = time.time()
+        notes = [
+            {
+                "filename": "pa1.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "alpha"},
+            },
+            {
+                "filename": "pa2.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-02", "project": "alpha"},
+            },
+            {
+                "filename": "pb1.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-03", "project": "beta"},
+            },
+        ]
+        accesses = [
+            {"note_path": "claude-sessions/pa1.md", "timestamp": now - 100, "context_type": "recall", "project": "alpha"},
+            {"note_path": "claude-sessions/pa2.md", "timestamp": now - 200, "context_type": "recall", "project": "alpha"},
+            {"note_path": "claude-sessions/pb1.md", "timestamp": now - 300, "context_type": "recall", "project": "beta"},
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes, accesses=accesses)
+        result = json.loads(vault_stats.compute_stats(db_path, "alpha"))
+        assert result["project"]["name"] == "alpha"
+        assert result["project"]["total_notes"] == 2
+        assert result["project"]["access_events"] == 2
+        assert result["project"]["avg_accesses"] == 1.0
+
+    def test_project_top_accessed_limited_to_5(self, tmp_vault):
+        now = time.time()
+        notes = [
+            {
+                "filename": f"p{i}.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "proj"},
+            }
+            for i in range(7)
+        ]
+        accesses = [
+            {"note_path": f"claude-sessions/p{i}.md", "timestamp": now - 100, "context_type": "recall", "project": "proj"}
+            for i in range(7)
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes, accesses=accesses)
+        result = json.loads(vault_stats.compute_stats(db_path, "proj"))
+        assert len(result["project"]["top_accessed"]) <= 5
+
+
+class TestComputeStatsSignalCoverage:
+    def test_signal_coverage_sets(self, tmp_vault):
+        now = time.time()
+        notes = [
+            {  # has both activation and importance
+                "filename": "both.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+                "importance": 8,
+            },
+            {  # has activation only (importance = 5 is default)
+                "filename": "act_only.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-02", "project": "p"},
+                "importance": 5,
+            },
+            {  # has importance only (no access)
+                "filename": "imp_only.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-03", "project": "p"},
+                "importance": 9,
+            },
+            {  # has neither
+                "filename": "neither.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-04", "project": "p"},
+                "importance": 5,
+            },
+        ]
+        accesses = [
+            {"note_path": "claude-sessions/both.md", "timestamp": now - 100, "context_type": "recall"},
+            {"note_path": "claude-sessions/act_only.md", "timestamp": now - 200, "context_type": "recall"},
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes, accesses=accesses)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        sc = result["vault_wide"]["signal_coverage"]
+        assert sc["has_activation"] == 2
+        assert sc["has_importance"] == 2
+        assert sc["has_both"] == 1
+        assert sc["has_neither"] == 1
+
+
+class TestComputeStatsActivation:
+    def test_top_accessed_includes_nonzero_activation(self, tmp_vault):
+        now = time.time()
+        notes = [
+            {
+                "filename": "active.md",
+                "frontmatter": {"type": "claude-session", "date": "2026-04-01", "project": "p"},
+            },
+        ]
+        accesses = [
+            {"note_path": "claude-sessions/active.md", "timestamp": now - 60, "context_type": "recall"},
+            {"note_path": "claude-sessions/active.md", "timestamp": now - 120, "context_type": "recall"},
+        ]
+        db_path = _setup_db(tmp_vault, notes=notes, accesses=accesses)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        top = result["vault_wide"]["top_accessed"]
+        assert len(top) == 1
+        assert top[0]["activation"] != 0.0
+        assert isinstance(top[0]["activation"], float)
+
+
+class TestComputeStatsMissingDB:
+    def test_missing_db_returns_error_json(self, tmp_vault):
+        result = json.loads(vault_stats.compute_stats("/nonexistent/path.db", "p"))
+        assert "error" in result
+        assert "not found" in result["error"].lower() or "DB not found" in result["error"]
+
+
+class TestComputeStatsDBSize:
+    def test_db_size_bytes_nonnegative(self, tmp_vault):
+        db_path = _setup_db(tmp_vault)
+        result = json.loads(vault_stats.compute_stats(db_path, "p"))
+        assert result["vault_wide"]["db_size_bytes"] >= 0


### PR DESCRIPTION
## Summary
- New `/vault-stats` skill — vault health diagnostics and usage analytics
- `hooks/vault_stats.py` — `compute_stats()` Python module returning JSON with vault-wide + project-scoped metrics
- Signal coverage (activation, importance, both, neither), access patterns by context, top accessed notes with ACT-R activation scores, importance distribution
- Saves report to vault as `claude-stats` note for trend tracking over time
- README Core Skills table updated, CHANGELOG entry added

## Test plan
- [x] 446 tests passing, 91.31% coverage
- [x] `test_vault_stats.py` — 12 tests: empty DB, note counting, importance bucketing, access grouping, project scoping, signal coverage, activation scores, missing DB, DB size
- [ ] `/dev-test install` + `/vault-stats` in fresh CC session

🤖 Generated with [Claude Code](https://claude.com/claude-code)