### PR TITLE
feat(recall): parallel Haiku pipelines replace sub-agent batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **recall**: Replace sub-agent batch summarization (Wave 1-2-3) with parallel Haiku pipelines; sub-agents demoted to per-note fallback only
+
 ## [2.3.0] - 2026-04-16
 
 ### Added

--- a/scripts/create-test-notes.sh
+++ b/scripts/create-test-notes.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# create-test-notes.sh — Create unsummarized test session notes for /recall testing.
+#
+# Creates N notes (default 3) of varying sizes in the vault's sessions folder.
+# Reads vault_path and sessions_folder from ~/.claude/obsidian-brain-config.json.
+# Can be run from any directory / any project.
+#
+# Usage:
+#   ./scripts/create-test-notes.sh          # 3 notes (small, medium, large)
+#   ./scripts/create-test-notes.sh 5        # 5 notes
+#   ./scripts/create-test-notes.sh cleanup  # remove all test notes
+
+set -euo pipefail
+
+CONFIG="$HOME/.claude/obsidian-brain-config.json"
+
+if [[ ! -f "$CONFIG" ]]; then
+  echo "ERROR: Config not found at $CONFIG. Run /obsidian-setup first." >&2
+  exit 1
+fi
+
+VAULT_PATH=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["vault_path"])' "$CONFIG")
+SESS_FOLDER=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("sessions_folder","claude-sessions"))' "$CONFIG")
+SESS_DIR="$VAULT_PATH/$SESS_FOLDER"
+
+if [[ ! -d "$SESS_DIR" ]]; then
+  echo "ERROR: Sessions dir not found: $SESS_DIR" >&2
+  exit 1
+fi
+
+# Cleanup mode
+if [[ "${1:-}" == "cleanup" ]]; then
+  removed=0
+  for f in "$SESS_DIR"/*-test-recall-*.md; do
+    [[ -f "$f" ]] || continue
+    rm -f "$f"
+    echo "Removed: $(basename "$f")"
+    removed=$((removed + 1))
+  done
+  echo "Cleaned up $removed test note(s)."
+  exit 0
+fi
+
+N="${1:-3}"
+DATE=$(date +%Y-%m-%d)
+PROJECT="test-recall-project"
+
+# Size profiles: lines of fake conversation content
+sizes=(small medium large huge giant)
+size_lines=(10 40 120 300 600)
+
+created=0
+for i in $(seq 1 "$N"); do
+  idx=$(( (i - 1) % ${#sizes[@]} ))
+  size_name="${sizes[$idx]}"
+  num_lines="${size_lines[$idx]}"
+
+  # Generate a unique 4-char hash
+  hash=$(echo "${DATE}-${i}-${RANDOM}" | md5sum 2>/dev/null | cut -c1-4 || echo "${DATE}-${i}-${RANDOM}" | md5 | cut -c29-32)
+
+  filename="${DATE}-test-recall-${size_name}-${hash}.md"
+  filepath="$SESS_DIR/$filename"
+
+  # Build fake conversation content
+  conversation=""
+  for line_num in $(seq 1 "$num_lines"); do
+    if (( line_num % 2 == 1 )); then
+      conversation+="**User:** This is test message $line_num in a $size_name test session note for /recall testing. It contains enough text to simulate real conversation content with various technical terms like Python, subprocess, vault index, and FTS5 search.\n"
+    else
+      conversation+="**Assistant:** Acknowledged test message $line_num. Working on implementing the requested feature with proper error handling, atomic writes, and post-write verification.\n"
+    fi
+  done
+
+  cat > "$filepath" <<HEREDOC
+---
+type: claude-session
+date: ${DATE}
+session_id: test-${hash}-${size_name}-$(printf '%04d' "$i")
+project: obsidian-brain
+project_path: "/Users/test/dev/obsidian-brain"
+git_branch: "feature/test-branch"
+duration_minutes: $((num_lines * 3))
+resumed: false
+tags:
+  - claude/session
+  - claude/project/obsidian-brain
+  - claude/auto
+status: auto-logged
+---
+
+# Session: obsidian-brain (feature/test-branch)
+
+## Summary
+Session in **obsidian-brain** ($((num_lines * 3)).0 min). AI summary unavailable — raw extraction below.
+
+## Key Decisions
+_Not extracted (AI summary unavailable)._
+
+## Changes Made
+- /dev/test/file1.py
+- /dev/test/file2.md
+
+## Conversation (raw)
+$(echo -e "$conversation")
+
+## Session Metadata
+- Started: ${DATE}T10:00:00
+- Duration: $((num_lines * 3)) minutes
+- Branch: feature/test-branch
+HEREDOC
+
+  chmod 600 "$filepath"
+  echo "Created: $filename ($size_name, ~$num_lines conversation lines)"
+  created=$((created + 1))
+done
+
+echo ""
+echo "Created $created test note(s) in $SESS_DIR"
+echo "Run '/recall' in a fresh CC session to test summarization."
+echo "Run '$0 cleanup' to remove test notes when done."

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -2,7 +2,7 @@
 name: recall
 description: "Loads historical context from the Obsidian vault for the current project. Summarizes any unsummarized session notes, then presents a context brief with recent sessions, open items, and curated insights. Also auto-detects open items completed in the most recent loaded session and offers to check them off. Use when: (1) /recall command, (2) /recall <project-name>, (3) resuming work on a project and wanting prior context."
 metadata:
-  version: 1.4.0
+  version: 1.5.0
 ---
 
 # Recall — Load Project Context from Obsidian Vault

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -122,7 +122,7 @@ When all return, parse each result:
 - Starts with `Failed:` → add to fallback list
 
 If N <= 5: update each sub-task accordingly (succeeded or `Failed: <basename>`).
-If N > 5: update task #2 subject to `Upgrade N notes: M succeeded, F failed`.
+If N > 5: update task #2 subject to `Upgrade N notes: M succeeded, F pending fallback`.
 
 ##### Phase 2 — Sub-agent fallback (only for failed notes)
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -92,15 +92,19 @@ Update task #1 to completed. Update task #2 subject to `Summarize N unsummarized
 
 Update task #2 subject to `No unsummarized notes found` and set to `completed`. Skip to Step 3.
 
-#### Path B: N=1 (single note — Python pipeline)
+#### Path B: N>=1 (parallel Haiku pipelines with sub-agent fallback)
 
-Create a sub-task for the note:
+**Task management threshold:** If N <= 5, create a sub-task per note. If N > 5, skip per-note sub-tasks — use a single progress update on task #2 instead. This saves ~15-20s of parent round-trip overhead at large N.
+
+##### Phase 1 — Parallel Haiku upgrades
+
+If N <= 5, create a sub-task for each note:
 
 ```
-TaskCreate: subject="Haiku pipeline: <basename>", activeForm="Summarizing <basename> via Haiku"
+TaskCreate: subject="Upgrade: <basename>", activeForm="Upgrading <basename> via Haiku"
 ```
 
-Run the upgrade pipeline in Python:
+Launch N parallel Bash calls in a **single message turn** so they run concurrently:
 
 ```bash
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -113,19 +117,30 @@ print(status)
 ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
 ```
 
-If the status starts with "Failed:", use the sub-agent fallback:
+When all return, parse each result:
+- Does NOT start with `"Failed:"` → mark as succeeded
+- Starts with `"Failed:"` → add to fallback list
 
-1. Update the sub-task subject to `Sub-agent fallback: <basename>`.
-2. Spawn a single sub-agent that writes its summary to a temp file:
+If N <= 5: update each sub-task accordingly (succeeded or `Failed: <basename>`).
+If N > 5: update task #2 subject to `Upgrade N notes: M succeeded, F failed`.
 
-   ```
-   Agent({
-     description: "Summarize session note <basename>",
-     prompt: "Read the session note at <NOTE_PATH>. Produce a structured summary with these exact markdown sections:\n\n## Summary\n1-3 sentence overview of what was accomplished.\n\n## Key Decisions\n- Bullet list of important technical decisions. Write \"None noted.\" if none.\n\n## Changes Made\n- Bullet list of files modified/created with brief description. Write \"None noted.\" if none.\n\n## Errors Encountered\n- Bullet list of errors and how resolved. Write \"None.\" if none.\n\n## Open Questions / Next Steps\n- [ ] Checkbox list of unresolved items. Write \"None.\" if none.\n\nWrite the summary to ~/.claude/obsidian-brain/summary-<basename>.md using the Write tool. After the summary sections, add a final line:\nIMPORTANCE: N\nwhere N is 1-10. 1-3: trivial (config, interrupted). 4-6: standard work. 7-8: key decisions or error resolutions. 9-10: major releases or security audits.\n\nReturn ONLY the single line: WRITTEN:~/.claude/obsidian-brain/summary-<basename>.md"
-   })
-   ```
+##### Phase 2 — Sub-agent fallback (only for failed notes)
 
-3. If the sub-agent returns `WRITTEN:<path>`, write back via Python reading the temp file:
+If no failures, skip this phase entirely.
+
+For each failed note, spawn a sub-agent. If multiple notes failed, spawn all sub-agents in a **single message turn**:
+
+```
+Agent({
+  description: "Summarize session note <basename>",
+  prompt: "Read the session note at <NOTE_PATH>. Produce a structured summary with these exact markdown sections:\n\n## Summary\n1-3 sentence overview of what was accomplished.\n\n## Key Decisions\n- Bullet list of important technical decisions. Write \"None noted.\" if none.\n\n## Changes Made\n- Bullet list of files modified/created with brief description. Write \"None noted.\" if none.\n\n## Errors Encountered\n- Bullet list of errors and how resolved. Write \"None.\" if none.\n\n## Open Questions / Next Steps\n- [ ] Checkbox list of unresolved items. Write \"None.\" if none.\n\nWrite the summary to ~/.claude/obsidian-brain/summary-<basename>.md using the Write tool. After the summary sections, add a final line:\nIMPORTANCE: N\nwhere N is 1-10. 1-3: trivial (config, interrupted). 4-6: standard work. 7-8: key decisions or error resolutions. 9-10: major releases or security audits.\n\nReturn ONLY the single line: WRITTEN:~/.claude/obsidian-brain/summary-<basename>.md"
+})
+```
+
+When sub-agents return, for each:
+
+1. If the sub-agent returned `WRITTEN:<path>`, verify the file exists: `test -f <expanded_path> && echo "EXISTS" || echo "MISSING"`.
+2. If EXISTS, apply it via Python:
 
    ```bash
    cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -133,130 +148,29 @@ If the status starts with "Failed:", use the sub-agent fallback:
    import sys, os
    import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
    from obsidian_utils import upgrade_note_with_summary
-   with open(sys.argv[5], "r") as f:
+   with open(os.path.expanduser(sys.argv[6]), "r") as f:
        summary = f.read()
-   status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4])
+   status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
    print(status)
-   ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "~/.claude/obsidian-brain/summary-<basename>.md"
+   ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "sub-agent" "$SUMMARY_TEMP_PATH"
    ```
 
-   Then clean up: `rm -f ~/.claude/obsidian-brain/summary-<basename>.md`
+3. If MISSING or sub-agent didn't return `WRITTEN:` → note stays unsummarized for next `/recall`.
 
-Mark the sub-task and task #2 as completed. Report the result.
-
-#### Path C: N>=2 (batch — sub-agent-first, three waves)
-
-**Task management threshold:** If N <= 5, create per-note sub-tasks for each wave (prep, summarize, write-back). If N > 5, skip per-note sub-tasks — use a single progress update on task #2 per wave instead (e.g. `Summarize 10 notes: Wave 1 prep complete`). This saves ~15-20s of parent round-trip overhead at large N.
-
-##### Wave 1 — Prep (parallel Bash calls)
-
-If N <= 5, create a prep sub-task for each note:
-
-```
-TaskCreate: subject="Prep: <basename>", activeForm="Prepping <basename>"
-```
-
-For each unsummarized note, run a parallel Bash call:
+Clean up any temp files from Phase 2 (specific paths only — avoids racing with concurrent `/recall` invocations):
 
 ```bash
-cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-python3 -c '
-import sys, os
-import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from obsidian_utils import prepare_summary_input
-result = prepare_summary_input(sys.argv[1])
-print(result)
-' "$NOTE_PATH"
+rm -f ~/.claude/obsidian-brain/summary-<basename_1>.md ~/.claude/obsidian-brain/summary-<basename_2>.md ...
 ```
 
-Launch all N Bash calls in a single message turn so they run in parallel.
+##### Completion
 
-When all return:
-- If N <= 5: update each prep sub-task to completed (include result in subject: e.g. `Prep: ...2322.md (RAW_OK)`).
-- If N > 5: update task #2 subject to `Summarize N notes: Wave 1 prep complete`.
+Mark task #2 as completed. Report results:
+- How many upgraded via Haiku pipeline
+- How many upgraded via sub-agent fallback
+- How many failed (stay unsummarized for next `/recall`)
 
-Parse each result:
-- `RAW_OK:<note_path>` → sub-agent will read the raw note path
-- `JSONL_PREPPED:<temp_path>:<note_path>` → sub-agent will read the temp file path; track `<note_path>` for Wave 3
-- `NO_CONTENT:<note_path>` → skip this note, report to user
-
-##### Wave 2 — Summarize and write to temp files (parallel sub-agents)
-
-If N <= 5, create a summarize sub-task for each note (excluding NO_CONTENT):
-
-```
-TaskCreate: subject="Summarize: <basename>", activeForm="Summarizing <basename>"
-```
-
-Spawn all sub-agents in a **single message turn** so they run in parallel. Each sub-agent writes its summary to a temp file instead of returning it — this keeps summary text out of the parent context (~800 tokens saved per note):
-
-```
-Agent({
-  description: "Summarize session note <basename>",
-  prompt: "Read the file at <READ_PATH>. Produce a structured summary with these exact markdown sections:\n\n## Summary\n1-3 sentence overview of what was accomplished.\n\n## Key Decisions\n- Bullet list of important technical decisions. Write \"None noted.\" if none.\n\n## Changes Made\n- Bullet list of files modified/created with brief description. Write \"None noted.\" if none.\n\n## Errors Encountered\n- Bullet list of errors and how resolved. Write \"None.\" if none.\n\n## Open Questions / Next Steps\n- [ ] Checkbox list of unresolved items. Write \"None.\" if none.\n\nWrite the summary to the file ~/.claude/obsidian-brain/summary-<basename>.md using the Write tool. After the summary sections, add a final line:\nIMPORTANCE: N\nwhere N is 1-10. 1-3: trivial (config, interrupted). 4-6: standard work. 7-8: key decisions or error resolutions. 9-10: major releases or security audits.\n\nReturn ONLY the single line: WRITTEN:~/.claude/obsidian-brain/summary-<basename>.md"
-})
-```
-
-Where `<READ_PATH>` is:
-- For `RAW_OK` notes: the raw note path
-- For `JSONL_PREPPED` notes: the temp file path (e.g. `~/.claude/obsidian-brain/prep-{session_id}.md`)
-
-And `<basename>` is the note filename without extension (e.g. `2026-04-09-obsidian-brain-2322`).
-
-When all sub-agents return, check each result:
-- If the sub-agent returned `WRITTEN:<path>`, mark it as succeeded.
-- If the sub-agent returned an error, empty output, or anything else, mark it as failed. Exclude this note from Wave 3 — it stays unsummarized for the next `/recall`. Report the failure to the user.
-
-If N <= 5: update each summarize sub-task to completed (or `Failed: <basename>`).
-If N > 5: update task #2 subject to `Summarize N notes: Wave 2 complete (M succeeded, F failed)`.
-
-##### Wave 3 — Write back from temp files (parallel Bash calls)
-
-If N <= 5, create a write-back sub-task for each note that got a `WRITTEN:` status:
-
-```
-TaskCreate: subject="Write back: <basename>", activeForm="Writing <basename>"
-```
-
-For each successful note, call Python to read the temp summary file and apply it — no heredoc needed, summary stays off parent context:
-
-```bash
-cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-python3 -c '
-import sys, os
-import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from obsidian_utils import upgrade_note_with_summary
-with open(sys.argv[6], "r") as f:
-    summary = f.read()
-status = upgrade_note_with_summary(sys.argv[1], summary, sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
-print(status)
-' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "sub-agent" "~/.claude/obsidian-brain/summary-<basename>.md"
-```
-
-**Important:** `$NOTE_PATH` is always the **original vault note path** (not the temp file), even for JSONL_PREPPED notes.
-
-Launch all write-back Bash calls in a single message turn.
-
-When all return, parse each result:
-- If the status does NOT start with "Failed:", mark as succeeded.
-- If the status starts with "Failed:", mark as failed. Count it in the failure tally.
-
-If N <= 5: update each write-back sub-task accordingly.
-If N > 5: update task #2 subject to `Summarize N notes: Wave 3 complete (M written, F failed)`.
-
-##### Cleanup
-
-Clean up all temp files created in Waves 1 and 2 (specific paths only — avoids racing with concurrent `/recall` invocations):
-
-```bash
-rm -f ~/.claude/obsidian-brain/prep-<session_id_1>.md ~/.claude/obsidian-brain/prep-<session_id_2>.md ~/.claude/obsidian-brain/summary-<basename_1>.md ~/.claude/obsidian-brain/summary-<basename_2>.md ...
-```
-
-Mark task #2 as completed. Report results: how many upgraded, how many skipped (NO_CONTENT), how many failed.
-
-If any sub-agents returned empty or invalid summaries, report those notes as still unsummarized — they will be retried on the next `/recall`.
-
-For `NO_CONTENT` notes, inform the user: "Note `<basename>` has no session_id or conversation content. Manually edit it in Obsidian to add a summary, or delete it if it's empty."
+For failed notes: "Note `<basename>` could not be summarized. It will be retried on the next `/recall`."
 
 ### Step 3 — Build context brief (Python)
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -139,7 +139,7 @@ Agent({
 
 When sub-agents return, for each:
 
-1. If the sub-agent returned `WRITTEN:<path>`, extract the path after `WRITTEN:` as `SUMMARY_TEMP_PATH` (expand `~` to `$HOME`). Verify the file exists: `test -f "$SUMMARY_TEMP_PATH" && echo "EXISTS" || echo "MISSING"`.
+1. If the sub-agent returned `WRITTEN:<path>`, extract the path after `WRITTEN:` and replace the leading `~` with `$HOME` to get an absolute path. Store this as `SUMMARY_TEMP_PATH`. Verify the file exists: `test -f "$SUMMARY_TEMP_PATH" && echo "EXISTS" || echo "MISSING"`.
 2. If EXISTS, apply it via Python:
 
    ```bash
@@ -159,10 +159,10 @@ When sub-agents return, for each:
 
 3. If MISSING or sub-agent didn't return `WRITTEN:` → note stays unsummarized for next `/recall`.
 
-**Always** clean up temp files from Phase 2 after all write-backs complete, regardless of outcome (specific paths only — avoids racing with concurrent `/recall` invocations):
+**Always** clean up temp files from Phase 2 after all write-backs complete, regardless of outcome. Use the actual `SUMMARY_TEMP_PATH` values collected from each sub-agent's `WRITTEN:` response (not placeholder names):
 
 ```bash
-rm -f ~/.claude/obsidian-brain/summary-<basename_1>.md ~/.claude/obsidian-brain/summary-<basename_2>.md ...
+rm -f "$SUMMARY_TEMP_PATH_1" "$SUMMARY_TEMP_PATH_2" ...
 ```
 
 If N > 5: update task #2 subject to reflect final Phase 2 results (e.g. `Upgrade N notes: M Haiku + F fallback succeeded, K failed`).
@@ -172,7 +172,7 @@ If N > 5: update task #2 subject to reflect final Phase 2 results (e.g. `Upgrade
 Mark task #2 as completed. Report results:
 - How many upgraded via Haiku pipeline (Phase 1 successes)
 - How many upgraded via sub-agent fallback (Phase 2 write-back successes)
-- How many permanently failed (Phase 1 failed + Phase 2 failed or skipped — stay unsummarized for next `/recall`)
+- How many permanently failed (notes where both Phase 1 Haiku AND Phase 2 sub-agent fallback failed or were skipped — these stay unsummarized for next `/recall`)
 
 For failed notes: "Note `<basename>` could not be summarized. It will be retried on the next `/recall`."
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -118,8 +118,8 @@ print(status)
 ```
 
 When all return, parse each result:
-- Does NOT start with `"Failed:"` → mark as succeeded
-- Starts with `"Failed:"` → add to fallback list
+- Does NOT start with `Failed:` → mark as succeeded
+- Starts with `Failed:` → add to fallback list
 
 If N <= 5: update each sub-task accordingly (succeeded or `Failed: <basename>`).
 If N > 5: update task #2 subject to `Upgrade N notes: M succeeded, F failed`.
@@ -139,7 +139,7 @@ Agent({
 
 When sub-agents return, for each:
 
-1. If the sub-agent returned `WRITTEN:<path>`, verify the file exists: `test -f <expanded_path> && echo "EXISTS" || echo "MISSING"`.
+1. If the sub-agent returned `WRITTEN:<path>`, extract the path after `WRITTEN:` as `SUMMARY_TEMP_PATH` (expand `~` to `$HOME`). Verify the file exists: `test -f "$SUMMARY_TEMP_PATH" && echo "EXISTS" || echo "MISSING"`.
 2. If EXISTS, apply it via Python:
 
    ```bash
@@ -155,20 +155,24 @@ When sub-agents return, for each:
    ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "sub-agent" "$SUMMARY_TEMP_PATH"
    ```
 
+   If the write-back status starts with `Failed:`, count this note as permanently failed — do NOT count it as upgraded.
+
 3. If MISSING or sub-agent didn't return `WRITTEN:` → note stays unsummarized for next `/recall`.
 
-Clean up any temp files from Phase 2 (specific paths only — avoids racing with concurrent `/recall` invocations):
+**Always** clean up temp files from Phase 2 after all write-backs complete, regardless of outcome (specific paths only — avoids racing with concurrent `/recall` invocations):
 
 ```bash
 rm -f ~/.claude/obsidian-brain/summary-<basename_1>.md ~/.claude/obsidian-brain/summary-<basename_2>.md ...
 ```
 
+If N > 5: update task #2 subject to reflect final Phase 2 results (e.g. `Upgrade N notes: M Haiku + F fallback succeeded, K failed`).
+
 ##### Completion
 
 Mark task #2 as completed. Report results:
-- How many upgraded via Haiku pipeline
-- How many upgraded via sub-agent fallback
-- How many failed (stay unsummarized for next `/recall`)
+- How many upgraded via Haiku pipeline (Phase 1 successes)
+- How many upgraded via sub-agent fallback (Phase 2 write-back successes)
+- How many permanently failed (Phase 1 failed + Phase 2 failed or skipped — stay unsummarized for next `/recall`)
 
 For failed notes: "Note `<basename>` could not be summarized. It will be retried on the next `/recall`."
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -155,9 +155,11 @@ When sub-agents return, for each:
    ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT" "sub-agent" "$SUMMARY_TEMP_PATH"
    ```
 
-   If the write-back status starts with `Failed:`, count this note as permanently failed — do NOT count it as upgraded.
+   If the write-back status starts with `Failed:`, count this note as permanently failed — do NOT count it as upgraded. If N <= 5, update the per-note sub-task to `Permanently failed: <basename>`.
 
-3. If MISSING or sub-agent didn't return `WRITTEN:` → note stays unsummarized for next `/recall`.
+   If the write-back succeeds, and N <= 5, update the per-note sub-task to `Fallback succeeded: <basename>`.
+
+3. If MISSING or sub-agent didn't return `WRITTEN:` → note stays unsummarized for next `/recall`. If N <= 5, update the per-note sub-task to `Permanently failed: <basename>`.
 
 **Always** clean up temp files from Phase 2 after all write-backs complete, regardless of outcome. Use the actual `SUMMARY_TEMP_PATH` values collected from each sub-agent's `WRITTEN:` response (not placeholder names):
 


### PR DESCRIPTION
## Summary
- Replace 3-wave sub-agent batch summarization (Wave 1 prep → Wave 2 sub-agents → Wave 3 write-back) with N parallel `upgrade_unsummarized_note()` Haiku pipeline calls
- Sub-agents demoted to per-note fallback: only triggered when Haiku pipeline returns `Failed:` for a specific note
- Adds `test -f` verification before reading sub-agent temp files (addresses phantom-write failure)
- ~86 lines of SKILL.md complexity removed (Waves, prep sub-tasks, write-back sub-tasks, cleanup)

## Motivation
Two production failures on 2026-04-16:
1. Sub-agent returned `WRITTEN:<path>` but file didn't exist → `FileNotFoundError`
2. `upgrade_note_with_summary()` returned success but note reverted to `auto-logged`

The Haiku pipeline handles everything in a single process and has never exhibited these failures.

## Review fixes (8694780)
- Define `$SUMMARY_TEMP_PATH` extraction from `WRITTEN:` return value
- Handle `upgrade_note_with_summary()` failures in Phase 2 write-back
- Remove inner double-quotes from `Failed:` checks
- Make temp file cleanup unconditional
- Add N>5 task update after Phase 2 completes
- Distinguish 3 result categories: Haiku succeeded, sub-agent fallback succeeded, permanently failed

## Performance targets
- Parent rounds: <= 9 (was ~9 with Wave 1-2-3)
- Step 2 parent rounds: <= 3 (was ~4)
- Parent tokens: <= 5,750
- No wall time regression at comparable N

## Test plan
- [ ] `/dev-test install` + fresh CC session
- [ ] N=0: confirm skip path works
- [ ] N=1: confirm single Haiku pipeline succeeds
- [ ] N>=2: confirm parallel Bash calls (check tool trace)
- [ ] Measure parent rounds and wall time, compare to baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)