### PR TITLE
feat: Friston Phase 2 — TF-IDF vectorization + incremental theme clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - **vault-index**: `_sync()` uses `Path.is_relative_to()` instead of prefix-only `startswith()` so sibling folders like `claude-sessions-archive` are no longer incorrectly treated as nested inside `claude-sessions` (Phase 1 Copilot review deferred item)
 - **vault-index**: `_prior_terms_for()` → `_prior_tokens_for()` — re-tokenises the stored note body instead of reading the top-K=50 truncated `tfidf_vector` keys, so common-but-low-IDF terms (outside the top-50 cutoff) are no longer incremented on every reindex without a matching decrement. Fixes `term_df.df` drifting upward past the total note count across repeated `index_note` calls (caught by Phase 2 dev-test Step 11 invariant checker, missed by 522 pytest + 27 validator assertions). Existing drift clears on `rebuild_index()`. Regression gates: pytest `test_reindex_does_not_drift_term_df` + validator `test_reindex_invariance`
+- **vault-index**: `rebuild_index()` now calls `_ensure_access_log_indexes()` alongside `_ensure_theme_indexes()` so `idx_access_note` / `idx_access_time` are present immediately after a full rebuild, matching `ensure_index()`'s invariants. Previously a rebuilt DB was missing access-log indexes until the next `ensure_index()` call. Regression gate: pytest `TestRebuildIndex` now asserts both indexes exist post-rebuild (Phase 2 Copilot round 4)
+- **validate_phase2**: Module-level hook resolution now short-circuits when `-h`/`--help` is present in `sys.argv`, so `--help` produces argparse usage output even when the plugin cache path cannot be located (Phase 2 Copilot round 4)
 
 ## [2.3.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **vault-index**: Phase 2 theme engine — `themes`, `theme_members`, and `term_df` tables; `tfidf_vector` JSON column on `notes` (auto-migrated on first `ensure_index()` call)
+- **vault-index**: `_tokenize_for_tfidf()`, `_compute_tfidf_vector()` (smoothed IDF), `_cosine_similarity()` for sparse dict vectors, `_update_term_df()` for incremental IDF maintenance
+- **vault-index**: `assign_to_theme()` — incremental cosine-similarity clustering after note summarization; notes joining a theme update its centroid via running average under a BEGIN IMMEDIATE transaction so concurrent callers cannot clobber each other
+- **vault-index**: `detect_surprise()` — negation-proximity contradiction score persisted on `theme_members.surprise` for Phase 4 retrieval boosting
+- **recall**: `upgrade_note_with_summary()` now re-indexes the summarized note, runs incremental theme assignment, and persists a surprise score when the note joins a theme. All theme-side errors are non-fatal — the note upgrade itself is never rolled back by a theme-pipeline failure
+- **obsidian-setup**: Step 8.7 Performance Dependencies — optional `numpy`/`scipy` install prompt with idempotent persistence (`optional_deps_prompted`, `optional_deps_declined` config fields); `/obsidian-setup --deps` re-triggers the prompt
+- **config**: `check_optional_deps()` returns import-availability for numpy and scipy
+
 ### Changed
 - **recall**: Replace sub-agent batch summarization (Wave 1-2-3) with parallel Haiku pipelines; sub-agents demoted to per-note fallback only
+- **vault-index**: `search_vault()` and `query_related_notes()` now batch their access-log writes via `executemany` on the existing connection (1 commit instead of N, Phase 1 Copilot review deferred item)
+
+### Fixed
+- **vault-index**: `_sync()` uses `Path.is_relative_to()` instead of prefix-only `startswith()` so sibling folders like `claude-sessions-archive` are no longer incorrectly treated as nested inside `claude-sessions` (Phase 1 Copilot review deferred item)
 
 ## [2.3.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **vault-index**: `_sync()` uses `Path.is_relative_to()` instead of prefix-only `startswith()` so sibling folders like `claude-sessions-archive` are no longer incorrectly treated as nested inside `claude-sessions` (Phase 1 Copilot review deferred item)
+- **vault-index**: `_prior_terms_for()` → `_prior_tokens_for()` — re-tokenises the stored note body instead of reading the top-K=50 truncated `tfidf_vector` keys, so common-but-low-IDF terms (outside the top-50 cutoff) are no longer incremented on every reindex without a matching decrement. Fixes `term_df.df` drifting upward past the total note count across repeated `index_note` calls (caught by Phase 2 dev-test Step 11 invariant checker, missed by 522 pytest + 27 validator assertions). Existing drift clears on `rebuild_index()`. Regression gates: pytest `test_reindex_does_not_drift_term_df` + validator `test_reindex_invariance`
 
 ## [2.3.0] - 2026-04-16
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -326,6 +326,8 @@ _DEFAULTS: dict = {
     "auto_log_enabled": True,
     "snapshot_on_compact": True,
     "snapshot_on_clear": True,
+    "optional_deps_prompted": False,
+    "optional_deps_declined": [],
 }
 
 
@@ -377,6 +379,23 @@ def load_config() -> dict:
 
     cache_set(sid, "config", config)
     return config
+
+
+def check_optional_deps(packages: tuple[str, ...] = ("numpy", "scipy")) -> dict[str, bool]:
+    """Return {package: is_importable} for each optional performance dep.
+
+    Used by /obsidian-setup to decide whether to offer installation, and
+    by callers that want a stdlib fallback when a fast-path dep is missing.
+    """
+    import importlib
+    result: dict[str, bool] = {}
+    for pkg in packages:
+        try:
+            importlib.import_module(pkg)
+            result[pkg] = True
+        except ImportError:
+            result[pkg] = False
+    return result
 
 
 def check_hook_status() -> dict:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -2762,6 +2762,72 @@ def upgrade_note_with_summary(
         print(f"[obsidian-brain] importance write-back failed for "
               f"{os.path.basename(note_path)}: {exc}", file=sys.stderr)
 
+    # Phase 2: Incremental theme assignment.
+    # Best-effort — runs only when vault_index is importable and the DB file
+    # exists. A failure in this block MUST NEVER mask the successful upgrade.
+    try:
+        if _vault_index is not None:
+            _db = _vault_index._default_db_path()
+            if os.path.isfile(_db):
+                # Re-index the just-written note so its tfidf_vector reflects
+                # the final summarized body, then run incremental theme assignment.
+                try:
+                    _vault_index.index_note(_db, note_path)
+                except Exception as _exc:
+                    print(f"[obsidian-brain] theme re-index failed for "
+                          f"{os.path.basename(note_path)}: {_exc}", file=sys.stderr)
+                else:
+                    try:
+                        _assignment = _vault_index.assign_to_theme(
+                            _db, note_path, project=project,
+                        )
+                    except Exception as _exc:
+                        print(f"[obsidian-brain] assign_to_theme failed for "
+                              f"{os.path.basename(note_path)}: {_exc}",
+                              file=sys.stderr)
+                        _assignment = None
+
+                    if _assignment is not None:
+                        try:
+                            with open(note_path, "r", encoding="utf-8") as _f:
+                                _body = _f.read()
+                            _conn = _vault_index._connect(_db)
+                            try:
+                                _row = _conn.execute(
+                                    "SELECT tfidf_vector FROM notes WHERE path = ?",
+                                    (note_path,),
+                                ).fetchone()
+                                _note_vec = (
+                                    json.loads(_row["tfidf_vector"])
+                                    if _row and _row["tfidf_vector"] else {}
+                                )
+                                _row2 = _conn.execute(
+                                    "SELECT centroid FROM themes WHERE id = ?",
+                                    (_assignment["theme_id"],),
+                                ).fetchone()
+                                _centroid = (
+                                    json.loads(_row2["centroid"])
+                                    if _row2 and _row2["centroid"] else {}
+                                )
+                                _surprise = _vault_index.detect_surprise(
+                                    _body, _note_vec, _centroid,
+                                )
+                                _conn.execute(
+                                    "UPDATE theme_members SET surprise = ? "
+                                    "WHERE theme_id = ? AND note_path = ?",
+                                    (_surprise, _assignment["theme_id"], note_path),
+                                )
+                                _conn.commit()
+                            finally:
+                                _conn.close()
+                        except Exception as _exc:
+                            print(f"[obsidian-brain] surprise scoring failed "
+                                  f"for {os.path.basename(note_path)}: {_exc}",
+                                  file=sys.stderr)
+    except Exception as _exc:
+        print(f"[obsidian-brain] theme pipeline unexpected error "
+              f"for {os.path.basename(note_path)}: {_exc}", file=sys.stderr)
+
     # Run dedup pass (non-fatal — note is already upgraded)
     removed = []
     dedup_failed = False

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -2793,12 +2793,16 @@ def upgrade_note_with_summary(
             if os.path.isfile(_db):
                 # Re-index the just-written note so its tfidf_vector reflects
                 # the final summarized body, then run incremental theme assignment.
+                _reindex_ok = False
                 try:
-                    _vault_index.index_note(_db, note_path)
+                    # index_note() signals failure by returning False, not by
+                    # raising — swallowing the exception branch alone would
+                    # still let assign_to_theme run on a stale/missing vector.
+                    _reindex_ok = bool(_vault_index.index_note(_db, note_path))
                 except Exception as _exc:
                     print(f"[obsidian-brain] theme re-index failed for "
                           f"{os.path.basename(note_path)}: {_exc}", file=sys.stderr)
-                else:
+                if _reindex_ok:
                     try:
                         _assignment = _vault_index.assign_to_theme(
                             _db, note_path, project=project,

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -347,7 +347,12 @@ def load_config() -> dict:
     if cached is not None:
         return cached
 
-    config = dict(_DEFAULTS)
+    # dict(_DEFAULTS) is a shallow copy — any list/dict values in _DEFAULTS
+    # would be shared across calls, so an in-place mutation on
+    # config["optional_deps_declined"] (or a future list default) would
+    # leak back into _DEFAULTS and future callers. deepcopy severs that link.
+    import copy as _copy
+    config = _copy.deepcopy(_DEFAULTS)
     try:
         with open(_CONFIG_PATH, "r", encoding="utf-8") as fh:
             user_cfg = json.load(fh)

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -393,7 +393,10 @@ def check_optional_deps(packages: tuple[str, ...] = ("numpy", "scipy")) -> dict[
         try:
             importlib.import_module(pkg)
             result[pkg] = True
-        except ImportError:
+        except Exception:
+            # Compiled optional deps (numpy/scipy) can raise OSError for
+            # missing shared libs, ValueError for ABI mismatch, etc. —
+            # treat any failure as "unavailable" rather than crashing setup.
             result[pkg] = False
     return result
 

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -8,6 +8,7 @@ DB location: ~/.claude/obsidian-brain-vault.db (outside vault, alongside config)
 
 from __future__ import annotations
 
+import json
 import math
 import os
 import re
@@ -276,33 +277,68 @@ def _parse_note(file_path: str) -> dict | None:
 # ---------------------------------------------------------------------------
 
 
+def _prior_terms_for(conn: sqlite3.Connection, note_path: str) -> set[str]:
+    """Return the set of tokens previously stored on this note's tfidf_vector.
+
+    Returns an empty set if the note is new, the vector column is NULL, or
+    the stored JSON cannot be decoded.
+    """
+    row = conn.execute(
+        "SELECT tfidf_vector FROM notes WHERE path = ?", (note_path,)
+    ).fetchone()
+    if not row or not row[0]:
+        return set()
+    try:
+        return set(json.loads(row[0]).keys())
+    except (json.JSONDecodeError, TypeError, AttributeError):
+        return set()
+
+
 def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: float, size: int) -> None:
-    """Insert or replace a note in the index + FTS table.
+    """Insert or replace a note + FTS row + maintain term_df + tfidf_vector.
 
     For contentless FTS5 (content=''), deletes require passing the old
-    column values via the special 'delete' command, not DELETE FROM.
+    column values via the special 'delete' command, not DELETE FROM. We
+    sidestep that by deleting the notes row (freeing its rowid) and letting
+    the orphaned FTS entry be a harmless no-op (it won't join).
     """
-    row = conn.execute("SELECT rowid, title, tags, importance FROM notes WHERE path = ?", (rel_path,)).fetchone()
-    existing_importance = None
-    if row:
-        existing_importance = row["importance"]
-        # Contentless FTS5 delete: must pass old values
-        # Read old body from the FTS shadow tables isn't possible with contentless,
-        # so we need to read it from the note file or accept that we can't do
-        # precise deletes. Instead, drop and recreate the entire FTS table entry
-        # by using DELETE on the notes table first, then rebuild.
-        # Simpler approach: just delete the notes row and skip FTS delete.
-        # The stale FTS entry will be overwritten by the new INSERT with the same rowid.
-        # Actually, contentless FTS doesn't support any form of delete without old values.
-        # The cleanest approach: delete the notes row (rowid freed), insert new one
-        # (gets new rowid), insert new FTS entry. The orphaned FTS entry for the old
-        # rowid is harmless — it won't join with any notes row.
+    row = conn.execute(
+        "SELECT rowid, title, tags, importance FROM notes WHERE path = ?",
+        (rel_path,),
+    ).fetchone()
+    existing_importance = row["importance"] if row else None
+    is_new = row is None
+
+    # --- TF-IDF maintenance (before the DELETE so _prior_terms_for can read
+    # the old vector). ---
+    old_terms = _prior_terms_for(conn, rel_path)
+
+    full_text = " ".join([
+        parsed.get("title", "") or "",
+        parsed.get("tags", "") or "",
+        parsed.get("body", "") or "",
+    ])
+    tokens = _tokenize_for_tfidf(full_text)
+    new_terms = set(tokens)
+
+    # Apply df diff BEFORE computing this note's TF-IDF so its own term
+    # contribution is included in the IDF denominator.
+    _update_term_df(conn, old_terms=old_terms, new_terms=new_terms)
+
+    total_docs = conn.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
+    if is_new:
+        total_docs += 1  # this note is about to be inserted
+    term_df = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+    tfidf_vec = _compute_tfidf_vector(tokens, term_df, total_docs, top_k=50)
+    tfidf_json = json.dumps(tfidf_vec, separators=(",", ":")) if tfidf_vec else None
+
+    if not is_new:
         conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
 
     conn.execute(
         "INSERT INTO notes (path, type, date, project, title, source_session, "
-        "source_note, tags, status, mtime, size, body, importance) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "source_note, tags, status, mtime, size, body, importance, tfidf_vector) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         (
             rel_path,
             parsed.get("type", "unknown"),
@@ -317,24 +353,37 @@ def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: f
             size,
             parsed.get("body", ""),
             existing_importance if existing_importance is not None else 5,
+            tfidf_json,
         ),
     )
 
     # Get the rowid for FTS insert
-    rowid = conn.execute("SELECT rowid FROM notes WHERE path = ?", (rel_path,)).fetchone()["rowid"]
+    rowid = conn.execute(
+        "SELECT rowid FROM notes WHERE path = ?", (rel_path,)
+    ).fetchone()["rowid"]
     conn.execute(
         "INSERT INTO notes_fts (rowid, title, body, tags) VALUES (?, ?, ?, ?)",
-        (rowid, parsed.get("title", ""), parsed.get("body", ""), parsed.get("tags", "")),
+        (
+            rowid,
+            parsed.get("title", ""),
+            parsed.get("body", ""),
+            parsed.get("tags", ""),
+        ),
     )
 
 
 def _delete_note(conn: sqlite3.Connection, rel_path: str) -> None:
-    """Remove a note from the index + FTS table.
+    """Remove a note + FTS row + its term_df contribution + theme memberships.
 
     For contentless FTS5, we can only delete the notes row. The orphaned
     FTS entry won't match any JOIN since the notes rowid is gone.
     """
+    old_terms = _prior_terms_for(conn, rel_path)
     conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
+    # Drop any theme membership rows pointing at the deleted note.
+    conn.execute("DELETE FROM theme_members WHERE note_path = ?", (rel_path,))
+    if old_terms:
+        _update_term_df(conn, old_terms=old_terms, new_terms=set())
 
 
 def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict:

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1109,6 +1109,34 @@ def _compute_tfidf_vector(
     return dict(top)
 
 
+def _cosine_similarity(v1: dict[str, float], v2: dict[str, float]) -> float:
+    """Cosine similarity between two sparse dict vectors. Returns 0.0 on empty input.
+
+    Iterates the smaller dict to compute the dot product, which keeps the
+    inner loop bounded even when one vector is much larger than the other.
+    """
+    if not v1 or not v2:
+        return 0.0
+
+    if len(v1) > len(v2):
+        v1, v2 = v2, v1
+
+    dot = 0.0
+    for term, w in v1.items():
+        other = v2.get(term)
+        if other is not None:
+            dot += w * other
+
+    if dot == 0.0:
+        return 0.0
+
+    norm1 = math.sqrt(sum(w * w for w in v1.values()))
+    norm2 = math.sqrt(sum(w * w for w in v2.values()))
+    if norm1 == 0.0 or norm2 == 0.0:
+        return 0.0
+    return dot / (norm1 * norm2)
+
+
 # ---------------------------------------------------------------------------
 # Keyword extraction
 # ---------------------------------------------------------------------------

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -426,7 +426,13 @@ def _delete_note(conn: sqlite3.Connection, rel_path: str) -> None:
         count = theme_row["note_count"] or 0
         if count <= 1:
             # Last member — drop the theme entirely rather than leave it
-            # with count=0 and a stale centroid.
+            # with count=0 and a stale centroid. Cascade-delete any stray
+            # theme_members rows pointing at this theme_id as defense-in-
+            # depth (count=1 should mean only one member, but any earlier
+            # invariant violation shouldn't leave zombie rows behind).
+            conn.execute(
+                "DELETE FROM theme_members WHERE theme_id = ?", (theme_id,)
+            )
             conn.execute("DELETE FROM themes WHERE id = ?", (theme_id,))
             continue
         try:
@@ -477,6 +483,10 @@ def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict
     """Incremental sync: add new/changed files, remove deleted ones.
 
     Returns {"inserted": N, "skipped": M, "deleted": D, "by_type": {...}}.
+
+    Wraps the entire pass in BEGIN IMMEDIATE + commit/rollback so a mid-
+    loop failure doesn't leave a half-applied transaction attached to
+    the connection (which would poison subsequent callers).
     """
     vault = Path(vault_path)
     stats = {"inserted": 0, "skipped": 0, "deleted": 0, "by_type": {}}
@@ -496,45 +506,53 @@ def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict
         for row in conn.execute("SELECT path, mtime FROM notes").fetchall()
     }
 
-    # Delete removed files (only if they belong to a scanned folder).
-    # Use Path.is_relative_to() rather than str.startswith() so that
-    # sibling folders with a shared prefix (e.g. 'claude-sessions-archive'
-    # vs 'claude-sessions') are not treated as nested.
-    scanned_roots = [vault / f for f in folders]
-    for abs_path_str in list(indexed.keys()):
-        if abs_path_str not in disk_files:
-            indexed_path = Path(abs_path_str)
-            if any(
-                _is_under(indexed_path, root) for root in scanned_roots
-            ):
-                _delete_note(conn, abs_path_str)
-                stats["deleted"] += 1
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        # Delete removed files (only if they belong to a scanned folder).
+        # Use Path.is_relative_to() rather than str.startswith() so that
+        # sibling folders with a shared prefix (e.g. 'claude-sessions-archive'
+        # vs 'claude-sessions') are not treated as nested.
+        scanned_roots = [vault / f for f in folders]
+        for abs_path_str in list(indexed.keys()):
+            if abs_path_str not in disk_files:
+                indexed_path = Path(abs_path_str)
+                if any(
+                    _is_under(indexed_path, root) for root in scanned_roots
+                ):
+                    _delete_note(conn, abs_path_str)
+                    stats["deleted"] += 1
 
-    # Insert/update files
-    for abs_path_str, abs_path in disk_files.items():
+        # Insert/update files
+        for abs_path_str, abs_path in disk_files.items():
+            try:
+                st = abs_path.stat()
+            except OSError:
+                continue  # File deleted/moved between rglob and stat
+            file_mtime = st.st_mtime
+            file_size = st.st_size
+
+            # Skip if mtime unchanged (0.001 tolerance)
+            if abs_path_str in indexed and abs(file_mtime - indexed[abs_path_str]) < 0.001:
+                stats["skipped"] += 1
+                continue
+
+            parsed = _parse_note(str(abs_path))
+            if parsed is None:
+                stats["skipped"] += 1
+                continue
+
+            _upsert_note(conn, abs_path_str, parsed, file_mtime, file_size)
+            note_type = parsed.get("type", "unknown")
+            stats["by_type"][note_type] = stats["by_type"].get(note_type, 0) + 1
+            stats["inserted"] += 1
+
+        conn.commit()
+    except Exception:
         try:
-            st = abs_path.stat()
-        except OSError:
-            continue  # File deleted/moved between rglob and stat
-        file_mtime = st.st_mtime
-        file_size = st.st_size
-
-        # Skip if mtime unchanged (0.001 tolerance)
-        if abs_path_str in indexed and abs(file_mtime - indexed[abs_path_str]) < 0.001:
-            stats["skipped"] += 1
-            continue
-
-        parsed = _parse_note(str(abs_path))
-        if parsed is None:
-            stats["skipped"] += 1
-            continue
-
-        _upsert_note(conn, abs_path_str, parsed, file_mtime, file_size)
-        note_type = parsed.get("type", "unknown")
-        stats["by_type"][note_type] = stats["by_type"].get(note_type, 0) + 1
-        stats["inserted"] += 1
-
-    conn.commit()
+            conn.rollback()
+        except sqlite3.Error:
+            pass
+        raise
     return stats
 
 
@@ -772,18 +790,35 @@ def index_note(db_path: str, note_path: str) -> bool:
 
     try:
         conn = _connect(db_path)
+    except sqlite3.Error as exc:
+        # Previously this branch silently returned False — the caller
+        # (upgrade_note_with_summary) would then skip theme assignment with
+        # no trace in stderr, leaving operators guessing. Always leave a
+        # breadcrumb so theme-pipeline declines are diagnosable.
+        print(f"[vault-index] index_note could not open {db_path}: {exc}",
+              file=sys.stderr)
+        return False
+
+    try:
         try:
+            # BEGIN IMMEDIATE so _upsert_note's read-modify-write
+            # (_prior_terms_for → _update_term_df → SELECT COUNT → INSERT)
+            # is serialized against other writers (concurrent hooks,
+            # _sync runs). Matches assign_to_theme's locking discipline.
+            conn.execute("BEGIN IMMEDIATE")
             _upsert_note(conn, note_path, parsed, st.st_mtime, st.st_size)
             conn.commit()
             return True
         except sqlite3.Error as exc:
+            try:
+                conn.rollback()
+            except sqlite3.Error:
+                pass
             print(f"[vault-index] index_note failed for {note_path}: {exc}",
                   file=sys.stderr)
             return False
-        finally:
-            conn.close()
-    except sqlite3.Error:
-        return False
+    finally:
+        conn.close()
 
 
 # ---------------------------------------------------------------------------
@@ -1619,12 +1654,17 @@ def assign_to_theme(
 
 
 _NEGATION_TERMS = frozenset({
+    # Simple negation / failure words
     "not", "never", "failed", "broken", "wrong", "mistake",
-    "avoid", "dont", "no", "cannot", "cant",
-    # Note: detect_surprise() strips apostrophes from note_text before
-    # tokenizing, so "don't"/"can't" in source text collapse to "dont"
-    # /"cant" and match the bare forms above. Apostrophed variants are
-    # intentionally omitted here — they would never match post-tokenization.
+    "avoid", "no", "cannot",
+    # Contractions — bare forms only. detect_surprise() strips apostrophes
+    # from note_text before tokenizing, so "don't"/"won't"/"isn\u2019t"
+    # in source text collapse to "dont"/"wont"/"isnt" and match here.
+    # Apostrophed variants (e.g. "don't") would never match post-
+    # tokenization and are intentionally omitted.
+    "dont", "cant", "wont", "isnt", "arent", "wasnt", "werent",
+    "didnt", "doesnt", "couldnt", "shouldnt", "wouldnt",
+    "hasnt", "havent", "hadnt",
 })
 
 

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1063,13 +1063,19 @@ def _tokenize_for_tfidf(text: str) -> list[str]:
 
     Order is preserved (token occurrences count — duplicates are kept) so the
     caller can compute TF by counting. Returns [] for empty or all-stopword input.
+
+    Single-character tokens (both letters like "a" and digits like "3" or "9"
+    from expressions such as "Python-3.9") are dropped. Single digits appear
+    in few documents initially, which inflates their IDF and lets them
+    outrank real semantic terms in the sparse top-k — so letter and digit
+    noise are both removed uniformly.
     """
     if not text:
         return []
     lowered = text.lower()
     return [
         t for t in _TOKEN_RE.findall(lowered)
-        if t not in _STOPWORDS and (len(t) > 1 or t.isdigit())
+        if len(t) > 1 and t not in _STOPWORDS
     ]
 
 
@@ -1144,9 +1150,11 @@ def _update_term_df(
 ) -> None:
     """Adjust document-frequency counts for a note whose terms changed.
 
-    Compares the two sets and applies a +1 / -1 per term. Terms whose df
-    falls to zero are deleted from the table so the IDF denominator stays
-    clean.
+    Compares the two sets and applies a +1 / -1 per term via executemany.
+    Terms whose df falls to zero are deleted so the IDF denominator stays
+    clean. The caller is responsible for committing the transaction — this
+    helper writes through ``conn`` but does not commit, so it can be
+    batched atomically with a note upsert or delete.
     """
     removed = old_terms - new_terms
     added = new_terms - old_terms
@@ -1168,8 +1176,6 @@ def _update_term_df(
             [(t,) for t in removed],
         )
         cur.execute("DELETE FROM term_df WHERE df <= 0")
-
-    conn.commit()
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -277,21 +277,24 @@ def _parse_note(file_path: str) -> dict | None:
 # ---------------------------------------------------------------------------
 
 
-def _prior_terms_for(conn: sqlite3.Connection, note_path: str) -> set[str]:
-    """Return the set of tokens previously stored on this note's tfidf_vector.
+def _prior_tokens_for(conn: sqlite3.Connection, note_path: str) -> set[str]:
+    """Return the full token set of the note's currently-stored content.
 
-    Returns an empty set if the note is new, the vector column is NULL, or
-    the stored JSON cannot be decoded.
+    Re-tokenises title+tags+body (the same inputs _upsert_note uses for the
+    new document) so the set is symmetric with ``new_terms`` during a
+    reindex. Reading the stored ``tfidf_vector`` would be wrong here — it
+    is truncated to top-K=50, and any common-but-low-IDF term outside that
+    cutoff would be incremented on every reindex without ever being
+    decremented, drifting ``term_df.df`` upward. Returns an empty set if
+    the note does not exist.
     """
     row = conn.execute(
-        "SELECT tfidf_vector FROM notes WHERE path = ?", (note_path,)
+        "SELECT title, body, tags FROM notes WHERE path = ?", (note_path,)
     ).fetchone()
-    if not row or not row[0]:
+    if not row:
         return set()
-    try:
-        return set(json.loads(row[0]).keys())
-    except (json.JSONDecodeError, TypeError, AttributeError):
-        return set()
+    full_text = " ".join([row["title"] or "", row["tags"] or "", row["body"] or ""])
+    return set(_tokenize_for_tfidf(full_text))
 
 
 def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: float, size: int) -> None:
@@ -310,9 +313,9 @@ def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: f
     existing_importance = row["importance"] if row else None
     is_new = row is None
 
-    # --- TF-IDF maintenance (before the DELETE so _prior_terms_for can read
-    # the old vector). ---
-    old_terms = _prior_terms_for(conn, rel_path)
+    # --- TF-IDF maintenance (before the DELETE so _prior_tokens_for can read
+    # the old body). ---
+    old_terms = _prior_tokens_for(conn, rel_path)
 
     full_text = " ".join([
         parsed.get("title", "") or "",
@@ -395,7 +398,7 @@ def _delete_note(conn: sqlite3.Connection, rel_path: str) -> None:
     prior column values before DROPping the notes row, so the FTS index
     doesn't accumulate orphan entries across the vault's lifetime.
     """
-    old_terms = _prior_terms_for(conn, rel_path)
+    old_terms = _prior_tokens_for(conn, rel_path)
 
     # Fetch the note's tfidf_vector AND FTS payload BEFORE deletion —
     # needed for both centroid unfolding and the FTS special delete.
@@ -802,7 +805,7 @@ def index_note(db_path: str, note_path: str) -> bool:
     try:
         try:
             # BEGIN IMMEDIATE so _upsert_note's read-modify-write
-            # (_prior_terms_for → _update_term_df → SELECT COUNT → INSERT)
+            # (_prior_tokens_for → _update_term_df → SELECT COUNT → INSERT)
             # is serialized against other writers (concurrent hooks,
             # _sync runs). Matches assign_to_theme's locking discipline.
             conn.execute("BEGIN IMMEDIATE")

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1424,63 +1424,80 @@ def assign_to_theme(
         return None
 
     try:
-        row = conn.execute(
-            "SELECT tfidf_vector FROM notes WHERE path = ?", (note_path,)
-        ).fetchone()
-        if not row or not row["tfidf_vector"]:
-            return None
+        # Take the write lock BEFORE reading candidates so the
+        # read-modify-write cycle is atomic against concurrent writers.
+        # Other callers block for up to the connection's timeout (5s in
+        # _connect()) before sqlite3 raises OperationalError.
+        conn.execute("BEGIN IMMEDIATE")
         try:
-            note_vec = json.loads(row["tfidf_vector"])
-        except json.JSONDecodeError:
-            return None
-        if not note_vec:
-            return None
-
-        candidates = conn.execute(
-            "SELECT id, centroid, note_count FROM themes "
-            "WHERE project = ? OR project IS NULL",
-            (project,),
-        ).fetchall()
-
-        best: tuple[float, int, dict, int] | None = None
-        for cand in candidates:
-            if not cand["centroid"]:
-                continue
+            row = conn.execute(
+                "SELECT tfidf_vector FROM notes WHERE path = ?", (note_path,)
+            ).fetchone()
+            if not row or not row["tfidf_vector"]:
+                conn.commit()
+                return None
             try:
-                centroid = json.loads(cand["centroid"])
+                note_vec = json.loads(row["tfidf_vector"])
             except json.JSONDecodeError:
-                continue
-            sim = _cosine_similarity(note_vec, centroid)
-            if best is None or sim > best[0]:
-                best = (sim, cand["id"], centroid, cand["note_count"])
+                conn.commit()
+                return None
+            if not note_vec:
+                conn.commit()
+                return None
 
-        if best is None or best[0] < similarity_threshold:
-            return None
+            candidates = conn.execute(
+                "SELECT id, centroid, note_count FROM themes "
+                "WHERE project = ? OR project IS NULL",
+                (project,),
+            ).fetchall()
 
-        sim, theme_id, centroid, count = best
-        new_centroid: dict[str, float] = {}
-        all_terms = set(centroid) | set(note_vec)
-        for term in all_terms:
-            c_val = centroid.get(term, 0.0)
-            v_val = note_vec.get(term, 0.0)
-            new_centroid[term] = (c_val * count + v_val) / (count + 1)
+            best: tuple[float, int, dict, int] | None = None
+            for cand in candidates:
+                if not cand["centroid"]:
+                    continue
+                try:
+                    centroid = json.loads(cand["centroid"])
+                except json.JSONDecodeError:
+                    continue
+                sim = _cosine_similarity(note_vec, centroid)
+                if best is None or sim > best[0]:
+                    best = (sim, cand["id"], centroid, cand["note_count"])
 
-        today = date.today().isoformat()
-        conn.execute(
-            "UPDATE themes "
-            "SET centroid = ?, note_count = ?, updated_date = ? "
-            "WHERE id = ?",
-            (json.dumps(new_centroid, separators=(",", ":")),
-             count + 1, today, theme_id),
-        )
-        conn.execute(
-            "INSERT OR REPLACE INTO theme_members "
-            "(theme_id, note_path, similarity, surprise, added_date) "
-            "VALUES (?, ?, ?, 0.0, ?)",
-            (theme_id, note_path, sim, today),
-        )
-        conn.commit()
-        return {"theme_id": theme_id, "similarity": sim}
+            if best is None or best[0] < similarity_threshold:
+                conn.commit()
+                return None
+
+            sim, theme_id, centroid, count = best
+            new_centroid: dict[str, float] = {}
+            all_terms = set(centroid) | set(note_vec)
+            for term in all_terms:
+                c_val = centroid.get(term, 0.0)
+                v_val = note_vec.get(term, 0.0)
+                new_centroid[term] = (c_val * count + v_val) / (count + 1)
+
+            today = date.today().isoformat()
+            conn.execute(
+                "UPDATE themes "
+                "SET centroid = ?, note_count = ?, updated_date = ? "
+                "WHERE id = ?",
+                (json.dumps(new_centroid, separators=(",", ":")),
+                 count + 1, today, theme_id),
+            )
+            # Preserve surprise + added_date on reassignment — only
+            # similarity is refreshed from the latest cosine computation.
+            conn.execute(
+                "INSERT INTO theme_members "
+                "(theme_id, note_path, similarity, surprise, added_date) "
+                "VALUES (?, ?, ?, 0.0, ?) "
+                "ON CONFLICT(theme_id, note_path) DO UPDATE SET "
+                "similarity = excluded.similarity",
+                (theme_id, note_path, sim, today),
+            )
+            conn.commit()
+            return {"theme_id": theme_id, "similarity": sim}
+        except Exception:
+            conn.rollback()
+            raise
     finally:
         conn.close()
 

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -419,6 +419,33 @@ def log_access(db_path: str, note_path: str, context_type: str, project: str | N
         print(f"[vault-index] log_access failed for {note_path!r}: {exc}", file=sys.stderr)
 
 
+def _batch_log_access(
+    conn: sqlite3.Connection,
+    note_paths: list[str],
+    context_type: str,
+    project: str | None = None,
+) -> None:
+    """Insert N access-log rows on an existing connection in one round-trip.
+
+    Reuses the caller's connection (no new connect/close) and commits once
+    via executemany. Falls through silently on error — access logging is
+    observability, not a blocker.
+    """
+    if not note_paths:
+        return
+    try:
+        now = time.time()
+        conn.executemany(
+            "INSERT INTO access_log (note_path, timestamp, context_type, project) "
+            "VALUES (?, ?, ?, ?)",
+            [(p, now, context_type, project) for p in note_paths],
+        )
+        conn.commit()
+    except Exception as exc:
+        print(f"[vault-index] _batch_log_access failed for "
+              f"{len(note_paths)} paths: {exc}", file=sys.stderr)
+
+
 def batch_activations(
     db_path: str, note_paths: list[str], decay: float = 0.5
 ) -> dict[str, float]:
@@ -905,9 +932,13 @@ def search_vault(
             candidates, query_terms, limit,
             db_path=db_path, task_context=task_context,
         )
-        # Log access for returned results
-        for r in results:
-            log_access(db_path, r["path"], "search", project=r.get("project"))
+        # Log access for returned results (single connection, one commit)
+        _batch_log_access(
+            conn,
+            [r["path"] for r in results],
+            "search",
+            project=project,
+        )
         # Strip body — callers don't need it
         for r in results:
             r.pop("body", None)
@@ -1071,9 +1102,13 @@ def query_related_notes(
                         print(f"[vault-index] Layer 3 (FTS) query failed: {exc}",
                               file=sys.stderr)
 
-        # Log access for returned results
-        for r in results[:limit]:
-            log_access(db_path, r["path"], "related", project)
+        # Log access for returned results (single connection, one commit)
+        _batch_log_access(
+            conn,
+            [r["path"] for r in results[:limit]],
+            "related",
+            project=project,
+        )
         return results[:limit]
     finally:
         conn.close()

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -764,6 +764,7 @@ def rebuild_index(vault_path: str, folders: list[str], db_path: str | None = Non
     conn = _connect(db_path)
     try:
         _init_schema(conn)
+        _ensure_access_log_indexes(conn)
         _ensure_theme_indexes(conn)
         stats = _sync(conn, vault_path, folders)
     finally:

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -37,7 +37,8 @@ CREATE TABLE IF NOT EXISTS notes (
     mtime           REAL NOT NULL,
     size            INTEGER,
     body            TEXT DEFAULT '',
-    importance      INTEGER DEFAULT 5
+    importance      INTEGER DEFAULT 5,
+    tfidf_vector    TEXT
 );
 
 CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
@@ -53,6 +54,32 @@ CREATE TABLE IF NOT EXISTS access_log (
     timestamp       REAL NOT NULL,
     context_type    TEXT NOT NULL,
     project         TEXT
+);
+
+CREATE TABLE IF NOT EXISTS themes (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    name            TEXT NOT NULL,
+    summary         TEXT NOT NULL DEFAULT '',
+    centroid        TEXT,
+    note_count      INTEGER NOT NULL DEFAULT 0,
+    activation      REAL NOT NULL DEFAULT 0.0,
+    created_date    TEXT NOT NULL,
+    updated_date    TEXT NOT NULL,
+    project         TEXT
+);
+
+CREATE TABLE IF NOT EXISTS theme_members (
+    theme_id        INTEGER NOT NULL,
+    note_path       TEXT NOT NULL,
+    similarity      REAL NOT NULL,
+    surprise        REAL NOT NULL DEFAULT 0.0,
+    added_date      TEXT NOT NULL,
+    PRIMARY KEY (theme_id, note_path)
+);
+
+CREATE TABLE IF NOT EXISTS term_df (
+    term            TEXT PRIMARY KEY,
+    df              INTEGER NOT NULL
 );
 """
 
@@ -141,6 +168,31 @@ def _needs_importance_migration(conn: sqlite3.Connection) -> bool:
 def _add_importance_column(conn: sqlite3.Connection) -> None:
     """Add importance column to existing notes table."""
     conn.execute("ALTER TABLE notes ADD COLUMN importance INTEGER DEFAULT 5")
+    conn.commit()
+
+
+def _needs_tfidf_vector_migration(conn: sqlite3.Connection) -> bool:
+    """Return True if the notes table is missing the tfidf_vector column."""
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(notes)").fetchall()}
+    return "tfidf_vector" not in cols
+
+
+def _add_tfidf_vector_column(conn: sqlite3.Connection) -> None:
+    """Add tfidf_vector column to existing notes table."""
+    conn.execute("ALTER TABLE notes ADD COLUMN tfidf_vector TEXT")
+    conn.commit()
+
+
+def _ensure_theme_indexes(conn: sqlite3.Connection) -> None:
+    """Create secondary indexes for themes + theme_members if missing."""
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_theme_members_note "
+        "ON theme_members (note_path)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_themes_project "
+        "ON themes (project)"
+    )
     conn.commit()
 
 
@@ -373,6 +425,9 @@ def ensure_index(vault_path: str, folders: list[str], db_path: str | None = None
             _ensure_access_log_indexes(conn)
             if _needs_importance_migration(conn):
                 _add_importance_column(conn)
+            if _needs_tfidf_vector_migration(conn):
+                _add_tfidf_vector_column(conn)
+            _ensure_theme_indexes(conn)
             if _needs_body_migration(conn):
                 print(f"[vault-index] Missing body column; rebuilding {db_path}",
                       file=sys.stderr)
@@ -389,6 +444,9 @@ def ensure_index(vault_path: str, folders: list[str], db_path: str | None = None
                 _ensure_access_log_indexes(conn)
                 if _needs_importance_migration(conn):
                     _add_importance_column(conn)
+                if _needs_tfidf_vector_migration(conn):
+                    _add_tfidf_vector_column(conn)
+                _ensure_theme_indexes(conn)
                 if _needs_body_migration(conn):
                     raise sqlite3.DatabaseError("body column missing after rebuild")
             _sync(conn, vault_path, folders)
@@ -409,6 +467,9 @@ def ensure_index(vault_path: str, folders: list[str], db_path: str | None = None
             _ensure_access_log_indexes(conn)
             if _needs_importance_migration(conn):
                 _add_importance_column(conn)
+            if _needs_tfidf_vector_migration(conn):
+                _add_tfidf_vector_column(conn)
+            _ensure_theme_indexes(conn)
             _sync(conn, vault_path, folders)
         finally:
             conn.close()
@@ -546,6 +607,7 @@ def rebuild_index(vault_path: str, folders: list[str], db_path: str | None = Non
     conn = _connect(db_path)
     try:
         _init_schema(conn)
+        _ensure_theme_indexes(conn)
         stats = _sync(conn, vault_path, folders)
     finally:
         conn.close()

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1137,6 +1137,41 @@ def _cosine_similarity(v1: dict[str, float], v2: dict[str, float]) -> float:
     return dot / (norm1 * norm2)
 
 
+def _update_term_df(
+    conn: sqlite3.Connection,
+    old_terms: set[str],
+    new_terms: set[str],
+) -> None:
+    """Adjust document-frequency counts for a note whose terms changed.
+
+    Compares the two sets and applies a +1 / -1 per term. Terms whose df
+    falls to zero are deleted from the table so the IDF denominator stays
+    clean.
+    """
+    removed = old_terms - new_terms
+    added = new_terms - old_terms
+    if not removed and not added:
+        return
+
+    cur = conn.cursor()
+
+    if added:
+        cur.executemany(
+            "INSERT INTO term_df (term, df) VALUES (?, 1) "
+            "ON CONFLICT(term) DO UPDATE SET df = df + 1",
+            [(t,) for t in added],
+        )
+
+    if removed:
+        cur.executemany(
+            "UPDATE term_df SET df = df - 1 WHERE term = ?",
+            [(t,) for t in removed],
+        )
+        cur.execute("DELETE FROM term_df WHERE df <= 0")
+
+    conn.commit()
+
+
 # ---------------------------------------------------------------------------
 # Keyword extraction
 # ---------------------------------------------------------------------------

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1483,3 +1483,56 @@ def assign_to_theme(
         return {"theme_id": theme_id, "similarity": sim}
     finally:
         conn.close()
+
+
+_NEGATION_TERMS = frozenset({
+    "not", "never", "failed", "broken", "wrong", "mistake",
+    "avoid", "don't", "dont", "no", "cannot", "cant", "can't",
+})
+
+
+def detect_surprise(
+    note_text: str,
+    note_vec: dict[str, float],
+    theme_centroid: dict[str, float],
+    window: int = 8,
+    top_shared: int = 10,
+) -> float:
+    """Heuristic Free-Energy surprise score for a note vs. its theme centroid.
+
+    Returns the fraction of the top_shared shared TF-IDF terms that appear
+    within ``window`` tokens of a negation word in ``note_text``. Clamped
+    to [0.0, 1.0]. Zero on missing overlap or empty input.
+    """
+    if not note_text or not note_vec or not theme_centroid:
+        return 0.0
+
+    shared = [
+        (t, min(note_vec[t], theme_centroid[t]))
+        for t in set(note_vec) & set(theme_centroid)
+    ]
+    if not shared:
+        return 0.0
+    shared.sort(key=lambda kv: (-kv[1], kv[0]))
+    shared_terms = [t for t, _ in shared[:top_shared]]
+
+    tokens = _TOKEN_RE.findall(note_text.lower())
+    if not tokens:
+        return 0.0
+
+    negation_positions = [
+        i for i, t in enumerate(tokens) if t in _NEGATION_TERMS
+    ]
+    if not negation_positions:
+        return 0.0
+
+    hits = 0
+    for term in shared_terms:
+        term_positions = [i for i, t in enumerate(tokens) if t == term]
+        for p in term_positions:
+            if any(abs(p - n) <= window for n in negation_positions):
+                hits += 1
+                break
+
+    score = hits / len(shared_terms)
+    return max(0.0, min(1.0, score))

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1387,3 +1387,99 @@ def query_related_notes(
         return results[:limit]
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Theme assignment (incremental)
+# ---------------------------------------------------------------------------
+
+
+_THEME_SIMILARITY_THRESHOLD = 0.3
+
+
+def assign_to_theme(
+    db_path: str,
+    note_path: str,
+    project: str | None = None,
+    similarity_threshold: float = _THEME_SIMILARITY_THRESHOLD,
+) -> dict | None:
+    """Incrementally assign a summarized note to its nearest theme (if any).
+
+    Reads the note's tfidf_vector and compares against every project-scoped
+    theme centroid plus any cross-project themes (project IS NULL). If the
+    best similarity exceeds ``similarity_threshold``, adds a theme_members
+    row and updates the theme's centroid via running average.
+
+    Returns {"theme_id": int, "similarity": float} on assignment, or None
+    if no theme was close enough (or the note has no vector).
+    """
+    if not os.path.isfile(db_path):
+        return None
+
+    try:
+        conn = _connect(db_path)
+    except sqlite3.Error as exc:
+        print(f"[vault-index] assign_to_theme could not connect: {exc}",
+              file=sys.stderr)
+        return None
+
+    try:
+        row = conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (note_path,)
+        ).fetchone()
+        if not row or not row["tfidf_vector"]:
+            return None
+        try:
+            note_vec = json.loads(row["tfidf_vector"])
+        except json.JSONDecodeError:
+            return None
+        if not note_vec:
+            return None
+
+        candidates = conn.execute(
+            "SELECT id, centroid, note_count FROM themes "
+            "WHERE project = ? OR project IS NULL",
+            (project,),
+        ).fetchall()
+
+        best: tuple[float, int, dict, int] | None = None
+        for cand in candidates:
+            if not cand["centroid"]:
+                continue
+            try:
+                centroid = json.loads(cand["centroid"])
+            except json.JSONDecodeError:
+                continue
+            sim = _cosine_similarity(note_vec, centroid)
+            if best is None or sim > best[0]:
+                best = (sim, cand["id"], centroid, cand["note_count"])
+
+        if best is None or best[0] < similarity_threshold:
+            return None
+
+        sim, theme_id, centroid, count = best
+        new_centroid: dict[str, float] = {}
+        all_terms = set(centroid) | set(note_vec)
+        for term in all_terms:
+            c_val = centroid.get(term, 0.0)
+            v_val = note_vec.get(term, 0.0)
+            new_centroid[term] = (c_val * count + v_val) / (count + 1)
+
+        today = date.today().isoformat()
+        conn.execute(
+            "UPDATE themes "
+            "SET centroid = ?, note_count = ?, updated_date = ? "
+            "WHERE id = ?",
+            (json.dumps(new_centroid, separators=(",", ":")),
+             count + 1, today, theme_id),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO theme_members "
+            "(theme_id, note_path, similarity, surprise, added_date) "
+            "VALUES (?, ?, ?, 0.0, ?)",
+            (theme_id, note_path, sim, today),
+        )
+        conn.commit()
+        return {"theme_id": theme_id, "similarity": sim}
+    finally:
+        conn.close()

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -79,17 +79,10 @@ _STOPWORDS = frozenset(
 def _is_under(child: Path, parent: Path) -> bool:
     """True iff `child` lives inside `parent` (proper containment, not prefix match).
 
-    Uses Path.is_relative_to() on 3.9+, with a 3.8-safe fallback via relative_to.
+    Prevents sibling-prefix folder folders (e.g. 'claude-sessions-archive')
+    from being treated as nested inside 'claude-sessions'.
     """
-    try:
-        return child.is_relative_to(parent)
-    except AttributeError:
-        # Python 3.8 fallback — relative_to raises ValueError when not nested.
-        try:
-            child.relative_to(parent)
-            return True
-        except ValueError:
-            return False
+    return child.is_relative_to(parent)
 
 
 # ---------------------------------------------------------------------------
@@ -450,22 +443,36 @@ def _batch_log_access(
     conn: sqlite3.Connection,
     note_paths: list[str],
     context_type: str,
-    project: str | None = None,
+    project: str | None | list[str | None] = None,
 ) -> None:
     """Insert N access-log rows on an existing connection in one round-trip.
 
+    ``project`` may be a single value applied to every row, or a list of the
+    same length as ``note_paths`` to preserve per-row project attribution.
     Reuses the caller's connection (no new connect/close) and commits once
-    via executemany. Falls through silently on error — access logging is
-    observability, not a blocker.
+    via executemany. Swallows exceptions but logs to stderr — access logging
+    is observability, not a blocker.
     """
     if not note_paths:
         return
+    if isinstance(project, list):
+        if len(project) != len(note_paths):
+            raise ValueError(
+                f"_batch_log_access: project list length "
+                f"{len(project)} != note_paths length {len(note_paths)}"
+            )
+        projects = project
+    else:
+        projects = [project] * len(note_paths)
     try:
         now = time.time()
         conn.executemany(
             "INSERT INTO access_log (note_path, timestamp, context_type, project) "
             "VALUES (?, ?, ?, ?)",
-            [(p, now, context_type, project) for p in note_paths],
+            [
+                (p, now, context_type, proj)
+                for p, proj in zip(note_paths, projects)
+            ],
         )
         conn.commit()
     except Exception as exc:
@@ -959,12 +966,14 @@ def search_vault(
             candidates, query_terms, limit,
             db_path=db_path, task_context=task_context,
         )
-        # Log access for returned results (single connection, one commit)
+        # Log access for returned results (single connection, one commit).
+        # Per-row project preserves each note's project attribution for
+        # per-project analytics, even when the search itself was unscoped.
         _batch_log_access(
             conn,
             [r["path"] for r in results],
             "search",
-            project=project,
+            project=[r.get("project") for r in results],
         )
         # Strip body — callers don't need it
         for r in results:

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -373,14 +373,74 @@ def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: f
 
 
 def _delete_note(conn: sqlite3.Connection, rel_path: str) -> None:
-    """Remove a note + FTS row + its term_df contribution + theme memberships.
+    """Remove a note + FTS row + term_df contribution + theme memberships.
+
+    Also reverses the note's contribution to any theme centroid it was a
+    member of, so that `themes.note_count` and the running-average
+    centroid stay consistent with the surviving `theme_members` rows.
+    If the note was the theme's last member, the theme is dropped.
 
     For contentless FTS5, we can only delete the notes row. The orphaned
     FTS entry won't match any JOIN since the notes rowid is gone.
     """
     old_terms = _prior_terms_for(conn, rel_path)
+
+    # Fetch the note's tfidf_vector BEFORE deletion — needed to subtract
+    # its contribution from theme centroids.
+    note_vec: dict[str, float] = {}
+    vec_row = conn.execute(
+        "SELECT tfidf_vector FROM notes WHERE path = ?", (rel_path,)
+    ).fetchone()
+    if vec_row and vec_row["tfidf_vector"]:
+        try:
+            note_vec = json.loads(vec_row["tfidf_vector"]) or {}
+        except json.JSONDecodeError:
+            note_vec = {}
+
+    # Update each theme the note was a member of. Walk the memberships
+    # before deleting them so we know which themes to touch.
+    memberships = conn.execute(
+        "SELECT theme_id FROM theme_members WHERE note_path = ?", (rel_path,)
+    ).fetchall()
+    today = date.today().isoformat()
+    for m in memberships:
+        theme_id = m["theme_id"]
+        theme_row = conn.execute(
+            "SELECT centroid, note_count FROM themes WHERE id = ?", (theme_id,)
+        ).fetchone()
+        if not theme_row:
+            continue
+        count = theme_row["note_count"] or 0
+        if count <= 1:
+            # Last member — drop the theme entirely rather than leave it
+            # with count=0 and a stale centroid.
+            conn.execute("DELETE FROM themes WHERE id = ?", (theme_id,))
+            continue
+        try:
+            centroid = json.loads(theme_row["centroid"]) if theme_row["centroid"] else {}
+        except json.JSONDecodeError:
+            centroid = {}
+        new_count = count - 1
+        new_centroid: dict[str, float] = {}
+        all_terms = set(centroid) | set(note_vec)
+        for term in all_terms:
+            c_val = centroid.get(term, 0.0)
+            v_val = note_vec.get(term, 0.0)
+            # Reverse the running-average fold:
+            # old_centroid = (centroid*count - note_vec) / (count - 1)
+            new_val = (c_val * count - v_val) / new_count
+            # Prune near-zero terms to keep the centroid sparse.
+            if abs(new_val) > 1e-9:
+                new_centroid[term] = new_val
+        conn.execute(
+            "UPDATE themes "
+            "SET centroid = ?, note_count = ?, updated_date = ? "
+            "WHERE id = ?",
+            (json.dumps(new_centroid, separators=(",", ":")),
+             new_count, today, theme_id),
+        )
+
     conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
-    # Drop any theme membership rows pointing at the deleted note.
     conn.execute("DELETE FROM theme_members WHERE note_path = ?", (rel_path,))
     if old_terms:
         _update_term_df(conn, old_terms=old_terms, new_terms=set())

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1051,6 +1051,29 @@ def search_vault(
 
 
 # ---------------------------------------------------------------------------
+# TF-IDF primitives (stdlib-first, numpy optional)
+# ---------------------------------------------------------------------------
+
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize_for_tfidf(text: str) -> list[str]:
+    """Tokenize text for TF-IDF: lowercase alphanumerics, drop stopwords + single chars.
+
+    Order is preserved (token occurrences count — duplicates are kept) so the
+    caller can compute TF by counting. Returns [] for empty or all-stopword input.
+    """
+    if not text:
+        return []
+    lowered = text.lower()
+    return [
+        t for t in _TOKEN_RE.findall(lowered)
+        if t not in _STOPWORDS and (len(t) > 1 or t.isdigit())
+    ]
+
+
+# ---------------------------------------------------------------------------
 # Keyword extraction
 # ---------------------------------------------------------------------------
 

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -297,13 +297,14 @@ def _prior_terms_for(conn: sqlite3.Connection, note_path: str) -> set[str]:
 def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: float, size: int) -> None:
     """Insert or replace a note + FTS row + maintain term_df + tfidf_vector.
 
-    For contentless FTS5 (content=''), deletes require passing the old
-    column values via the special 'delete' command, not DELETE FROM. We
-    sidestep that by deleting the notes row (freeing its rowid) and letting
-    the orphaned FTS entry be a harmless no-op (it won't join).
+    For contentless FTS5 (content=''), removal requires the special
+    'delete' command with the old column values — regular DELETE FROM is
+    rejected. We fetch the prior title/body/tags + rowid here so that on
+    update we can issue the delete before inserting the new FTS row,
+    keeping the FTS index from accumulating orphan entries across rewrites.
     """
     row = conn.execute(
-        "SELECT rowid, title, tags, importance FROM notes WHERE path = ?",
+        "SELECT rowid, title, body, tags, importance FROM notes WHERE path = ?",
         (rel_path,),
     ).fetchone()
     existing_importance = row["importance"] if row else None
@@ -333,6 +334,16 @@ def _upsert_note(conn: sqlite3.Connection, rel_path: str, parsed: dict, mtime: f
     tfidf_json = json.dumps(tfidf_vec, separators=(",", ":")) if tfidf_vec else None
 
     if not is_new:
+        # Remove the old FTS row before the notes DELETE so the notes_fts
+        # index doesn't accumulate orphan entries on every rewrite.
+        # Contentless FTS5 only accepts the special 'delete' command with
+        # the prior column values (SQLite docs: Inserting new rows into
+        # an external-content table with content='').
+        conn.execute(
+            "INSERT INTO notes_fts(notes_fts, rowid, title, body, tags) "
+            "VALUES('delete', ?, ?, ?, ?)",
+            (row["rowid"], row["title"] or "", row["body"] or "", row["tags"] or ""),
+        )
         conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
 
     conn.execute(
@@ -380,16 +391,18 @@ def _delete_note(conn: sqlite3.Connection, rel_path: str) -> None:
     centroid stay consistent with the surviving `theme_members` rows.
     If the note was the theme's last member, the theme is dropped.
 
-    For contentless FTS5, we can only delete the notes row. The orphaned
-    FTS entry won't match any JOIN since the notes rowid is gone.
+    For contentless FTS5, we issue the special 'delete' command with the
+    prior column values before DROPping the notes row, so the FTS index
+    doesn't accumulate orphan entries across the vault's lifetime.
     """
     old_terms = _prior_terms_for(conn, rel_path)
 
-    # Fetch the note's tfidf_vector BEFORE deletion — needed to subtract
-    # its contribution from theme centroids.
+    # Fetch the note's tfidf_vector AND FTS payload BEFORE deletion —
+    # needed for both centroid unfolding and the FTS special delete.
     note_vec: dict[str, float] = {}
     vec_row = conn.execute(
-        "SELECT tfidf_vector FROM notes WHERE path = ?", (rel_path,)
+        "SELECT rowid, title, body, tags, tfidf_vector FROM notes WHERE path = ?",
+        (rel_path,),
     ).fetchone()
     if vec_row and vec_row["tfidf_vector"]:
         try:
@@ -440,6 +453,20 @@ def _delete_note(conn: sqlite3.Connection, rel_path: str) -> None:
              new_count, today, theme_id),
         )
 
+    # Remove the FTS row before the notes DELETE. Contentless FTS5 rejects
+    # DELETE FROM; the special 'delete' command with the prior column
+    # values is the only supported removal path.
+    if vec_row is not None:
+        conn.execute(
+            "INSERT INTO notes_fts(notes_fts, rowid, title, body, tags) "
+            "VALUES('delete', ?, ?, ?, ?)",
+            (
+                vec_row["rowid"],
+                vec_row["title"] or "",
+                vec_row["body"] or "",
+                vec_row["tags"] or "",
+            ),
+        )
     conn.execute("DELETE FROM notes WHERE path = ?", (rel_path,))
     conn.execute("DELETE FROM theme_members WHERE note_path = ?", (rel_path,))
     if old_terms:

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -72,6 +72,27 @@ _STOPWORDS = frozenset(
 )
 
 # ---------------------------------------------------------------------------
+# Path helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_under(child: Path, parent: Path) -> bool:
+    """True iff `child` lives inside `parent` (proper containment, not prefix match).
+
+    Uses Path.is_relative_to() on 3.9+, with a 3.8-safe fallback via relative_to.
+    """
+    try:
+        return child.is_relative_to(parent)
+    except AttributeError:
+        # Python 3.8 fallback — relative_to raises ValueError when not nested.
+        try:
+            child.relative_to(parent)
+            return True
+        except ValueError:
+            return False
+
+
+# ---------------------------------------------------------------------------
 # DB helpers
 # ---------------------------------------------------------------------------
 
@@ -294,11 +315,17 @@ def _sync(conn: sqlite3.Connection, vault_path: str, folders: list[str]) -> dict
         for row in conn.execute("SELECT path, mtime FROM notes").fetchall()
     }
 
-    # Delete removed files (only if they belong to a scanned folder)
-    scanned_roots = [str(vault / f) for f in folders]
+    # Delete removed files (only if they belong to a scanned folder).
+    # Use Path.is_relative_to() rather than str.startswith() so that
+    # sibling folders with a shared prefix (e.g. 'claude-sessions-archive'
+    # vs 'claude-sessions') are not treated as nested.
+    scanned_roots = [vault / f for f in folders]
     for abs_path_str in list(indexed.keys()):
         if abs_path_str not in disk_files:
-            if any(abs_path_str.startswith(root) for root in scanned_roots):
+            indexed_path = Path(abs_path_str)
+            if any(
+                _is_under(indexed_path, root) for root in scanned_roots
+            ):
                 _delete_note(conn, abs_path_str)
                 stats["deleted"] += 1
 

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1620,7 +1620,11 @@ def assign_to_theme(
 
 _NEGATION_TERMS = frozenset({
     "not", "never", "failed", "broken", "wrong", "mistake",
-    "avoid", "don't", "dont", "no", "cannot", "cant", "can't",
+    "avoid", "dont", "no", "cannot", "cant",
+    # Note: detect_surprise() strips apostrophes from note_text before
+    # tokenizing, so "don't"/"can't" in source text collapse to "dont"
+    # /"cant" and match the bare forms above. Apostrophed variants are
+    # intentionally omitted here — they would never match post-tokenization.
 })
 
 
@@ -1649,7 +1653,18 @@ def detect_surprise(
     shared.sort(key=lambda kv: (-kv[1], kv[0]))
     shared_terms = [t for t, _ in shared[:top_shared]]
 
-    tokens = _TOKEN_RE.findall(note_text.lower())
+    # Strip apostrophes (straight + smart) before tokenizing so contractions
+    # like "don't" / "can't" collapse to "dont"/"cant" and match the
+    # negation set. Without this, _TOKEN_RE = [a-z0-9]+ would emit
+    # "don", "t" and the negation check would silently miss every
+    # apostrophed negation in the source text.
+    normalized = (
+        note_text.lower()
+        .replace("\u2019", "")  # right single quote (smart apostrophe)
+        .replace("\u2018", "")  # left single quote
+        .replace("'", "")       # straight apostrophe
+    )
+    tokens = _TOKEN_RE.findall(normalized)
     if not tokens:
         return 0.0
 

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1478,21 +1478,40 @@ def assign_to_theme(
                 return None
 
             sim, theme_id, centroid, count = best
-            new_centroid: dict[str, float] = {}
-            all_terms = set(centroid) | set(note_vec)
-            for term in all_terms:
-                c_val = centroid.get(term, 0.0)
-                v_val = note_vec.get(term, 0.0)
-                new_centroid[term] = (c_val * count + v_val) / (count + 1)
-
             today = date.today().isoformat()
-            conn.execute(
-                "UPDATE themes "
-                "SET centroid = ?, note_count = ?, updated_date = ? "
-                "WHERE id = ?",
-                (json.dumps(new_centroid, separators=(",", ":")),
-                 count + 1, today, theme_id),
-            )
+
+            # Detect reassignment: if the note is already a member, the
+            # centroid already reflects its contribution — updating count
+            # and re-averaging would double-count it and drift the centroid.
+            already_member = conn.execute(
+                "SELECT 1 FROM theme_members "
+                "WHERE theme_id = ? AND note_path = ?",
+                (theme_id, note_path),
+            ).fetchone() is not None
+
+            if not already_member:
+                new_centroid: dict[str, float] = {}
+                all_terms = set(centroid) | set(note_vec)
+                for term in all_terms:
+                    c_val = centroid.get(term, 0.0)
+                    v_val = note_vec.get(term, 0.0)
+                    new_centroid[term] = (c_val * count + v_val) / (count + 1)
+
+                conn.execute(
+                    "UPDATE themes "
+                    "SET centroid = ?, note_count = ?, updated_date = ? "
+                    "WHERE id = ?",
+                    (json.dumps(new_centroid, separators=(",", ":")),
+                     count + 1, today, theme_id),
+                )
+            else:
+                # Reassignment: bump updated_date but leave count/centroid
+                # alone. The member's similarity is refreshed below.
+                conn.execute(
+                    "UPDATE themes SET updated_date = ? WHERE id = ?",
+                    (today, theme_id),
+                )
+
             # Preserve surprise + added_date on reassignment — only
             # similarity is refreshed from the latest cosine computation.
             conn.execute(

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1073,6 +1073,42 @@ def _tokenize_for_tfidf(text: str) -> list[str]:
     ]
 
 
+def _compute_tfidf_vector(
+    tokens: list[str],
+    term_df: dict[str, int],
+    total_docs: int,
+    top_k: int = 50,
+) -> dict[str, float]:
+    """Compute a sparse TF×IDF vector keeping the top_k heaviest terms.
+
+    tokens:       output of _tokenize_for_tfidf() for the document
+    term_df:      {term: document_frequency} for the corpus
+    total_docs:   total indexed documents (including this one if it is new;
+                  callers using incremental updates should increment total_docs
+                  BEFORE calling this function for a newly-inserted note)
+    top_k:        maximum number of terms to retain in the sparse vector
+
+    Returns {} when tokens is empty. Uses smoothed IDF
+    (1 + ln((N + 1) / (df + 1))) so new / rare terms never produce 0 or NaN.
+    """
+    if not tokens:
+        return {}
+
+    tf: dict[str, int] = defaultdict(int)
+    for t in tokens:
+        tf[t] += 1
+
+    weights: dict[str, float] = {}
+    n_plus_one = total_docs + 1
+    for term, count in tf.items():
+        df = term_df.get(term, 0)
+        idf = 1.0 + math.log(n_plus_one / (df + 1))
+        weights[term] = count * idf
+
+    top = sorted(weights.items(), key=lambda kv: (-kv[1], kv[0]))[:top_k]
+    return dict(top)
+
+
 # ---------------------------------------------------------------------------
 # Keyword extraction
 # ---------------------------------------------------------------------------

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -1445,11 +1445,21 @@ def assign_to_theme(
                 conn.commit()
                 return None
 
-            candidates = conn.execute(
-                "SELECT id, centroid, note_count FROM themes "
-                "WHERE project = ? OR project IS NULL",
-                (project,),
-            ).fetchall()
+            # When project is None (global/unscoped recall), "project = ?"
+            # binds to NULL and matches no rows because `NULL = NULL` is
+            # false in SQL — only project-scoped themes with project IS
+            # NULL would match. Branch the query so unscoped callers see
+            # every theme, and scoped callers see their own + cross-project.
+            if project is None:
+                candidates = conn.execute(
+                    "SELECT id, centroid, note_count FROM themes"
+                ).fetchall()
+            else:
+                candidates = conn.execute(
+                    "SELECT id, centroid, note_count FROM themes "
+                    "WHERE project = ? OR project IS NULL",
+                    (project,),
+                ).fetchall()
 
             best: tuple[float, int, dict, int] | None = None
             for cand in candidates:

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -79,8 +79,8 @@ _STOPWORDS = frozenset(
 def _is_under(child: Path, parent: Path) -> bool:
     """True iff `child` lives inside `parent` (proper containment, not prefix match).
 
-    Prevents sibling-prefix folder folders (e.g. 'claude-sessions-archive')
-    from being treated as nested inside 'claude-sessions'.
+    Prevents sibling-prefix folders (e.g. 'claude-sessions-archive') from
+    being treated as nested inside 'claude-sessions'.
     """
     return child.is_relative_to(parent)
 
@@ -455,16 +455,16 @@ def _batch_log_access(
     """
     if not note_paths:
         return
-    if isinstance(project, list):
-        if len(project) != len(note_paths):
-            raise ValueError(
-                f"_batch_log_access: project list length "
-                f"{len(project)} != note_paths length {len(note_paths)}"
-            )
-        projects = project
-    else:
-        projects = [project] * len(note_paths)
     try:
+        if isinstance(project, list):
+            if len(project) != len(note_paths):
+                raise ValueError(
+                    f"_batch_log_access: project list length "
+                    f"{len(project)} != note_paths length {len(note_paths)}"
+                )
+            projects = project
+        else:
+            projects = [project] * len(note_paths)
         now = time.time()
         conn.executemany(
             "INSERT INTO access_log (note_path, timestamp, context_type, project) "

--- a/scripts/dev-test/DEV-TEST-PHASE2.md
+++ b/scripts/dev-test/DEV-TEST-PHASE2.md
@@ -42,18 +42,26 @@ ls ~/.claude/plugins/cache/claude-code-skills/obsidian-brain/*/hooks/ | grep vau
 
 ---
 
-## Step 2 — Rebuild the vault index with new schema
+## Step 2 — Upgrade-mode setup (DB migration + first-pass deps prompt)
 
-The Phase 2 changes add 3 new tables (`themes`, `theme_members`, `term_df`) and 1 new column (`notes.tfidf_vector`). `ensure_index()` migrates automatically, but `/vault-reindex` is safer for a clean starting point.
+Phase 2 adds 3 new tables (`themes`, `theme_members`, `term_df`) and 1 new column (`notes.tfidf_vector`). `/obsidian-setup` in upgrade mode calls `rebuild_index()` in Step 8.5 — same path as `/vault-reindex` — **and** exercises the new Step 8.7 optional-deps prompt in one invocation.
 
 ```
-/obsidian-brain:vault-reindex
+/obsidian-brain:obsidian-setup
 ```
 
-Expected terminal output:
-- "Rebuilding vault index…"
-- "Indexed N notes across M folders"
-- No stack traces, no `[ERROR]` lines
+When prompted for mode, choose **upgrade**. Expected flow:
+
+1. Step 5: folder mkdir (idempotent)
+2. Step 6: dashboard files (existing ones skipped)
+3. Step 7: config write — **skipped** in upgrade mode (existing config preserved)
+4. Step 8: vault access check
+5. Step 8.5: `rebuild_index()` drops + recreates all tables → "Indexed N notes across M folders"
+6. Step 8.7: first-time deps prompt (skip it here — Step 5 below covers all three branches)
+7. Step 9: claudeception nudge (idempotent)
+8. Step 10: success message
+
+This single invocation replaces both `/vault-reindex` AND the first-time-deps case of the old Step 5. No separate `/vault-reindex` call needed.
 
 Verify via `sqlite3`:
 
@@ -65,6 +73,8 @@ sqlite3 "$DB" "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('t
 sqlite3 "$DB" "PRAGMA table_info(notes)" | grep tfidf_vector
 # Expected: "X|tfidf_vector|TEXT|0||0"
 ```
+
+**Fallback:** if you only want to migrate the DB schema without re-running setup (e.g. config already known-good, just touching this branch), `/vault-reindex` does the schema work alone.
 
 ---
 
@@ -102,9 +112,11 @@ This hits the numerical paths that don't require a populated vault.
 
 ---
 
-## Step 5 — Exercise `/obsidian-setup --deps` (optional deps flow)
+## Step 5 — Exercise all three `/obsidian-setup --deps` branches
 
-This is the new Step 8.7 in `/obsidian-setup`. Two sub-paths to test — one per machine state.
+Step 2's upgrade-mode run already hit Step 8.7 once. This step uses the `--deps` flag — which jumps directly to Step 8.7 without re-running the rest of setup — to exercise **all three prompt branches** in isolation and validate idempotency.
+
+Each invocation is independent; re-running is safe.
 
 ### 5a. If numpy/scipy are NOT installed
 
@@ -348,7 +360,8 @@ ls ~/.claude/plugins/cache/claude-code-skills/obsidian-brain/
 All of the following must be true before `/finish` on PR #41:
 
 - [ ] Steps 1-11 all pass with no `❌` markers
-- [ ] `/obsidian-setup --deps` tested in at least one branch (install-yes OR skip+re-run for idempotency)
+- [ ] Step 2 `/obsidian-setup` (upgrade mode) exercised end-to-end — DB schema migrated, dashboards preserved, config untouched
+- [ ] `/obsidian-setup --deps` tested in at least one branch explicitly (install-yes OR skip+re-run for idempotency)
 - [ ] `/recall` produces theme rows in the DB
 - [ ] FTS5 orphan test shows count parity after 3x rewrite
 - [ ] Concurrency test shows no corruption

--- a/scripts/dev-test/DEV-TEST-PHASE2.md
+++ b/scripts/dev-test/DEV-TEST-PHASE2.md
@@ -1,0 +1,357 @@
+# Phase 2 Dev-Test Checklist
+
+Manual verification procedure for the Friston Phase 2 implementation (TF-IDF + themes + surprise + review fixes) on branch `feature/friston-phase2-tfidf-themes` / PR #41.
+
+Run this BEFORE `/finish` on the PR. The automated test suite (518 tests, 90% coverage) catches unit-level regressions; this procedure exercises the SKILL.md ↔ Python ↔ SQLite integration boundary that the test suite cannot reach.
+
+---
+
+## Step 0 — Prerequisites
+
+- [ ] Current branch is `feature/friston-phase2-tfidf-themes` (or your rebase of it)
+- [ ] Working tree clean (`git status --short` prints nothing)
+- [ ] Automated tests pass: `python3 -m pytest -q` → `518 passed`
+- [ ] Preflight clean: `./scripts/commit-preflight.sh --auto` → `✅ PREFLIGHT PASSED`
+- [ ] Config file exists at `~/.claude/obsidian-brain-config.json` with `vault_path` set
+- [ ] A vault with ≥2 summarized session notes from the same project exists (needed for theme-assignment exercise)
+
+If the vault has <2 notes on any single project, run `/vault-import 30d` first to seed history.
+
+---
+
+## Step 1 — Install dev version
+
+```bash
+cd ~/dev/claude_workspace/obsidian-brain
+# Claude Code: invoke the skill
+/obsidian-brain:dev-test install
+```
+
+Expected:
+- Backs up `~/.claude/plugins/cache/claude-code-skills/obsidian-brain/<version>/` → `<version>.bak/`
+- Copies `hooks/*.py` + `skills/*/` into the cache
+- Prints summary of files replaced
+
+Verify:
+```bash
+ls ~/.claude/plugins/cache/claude-code-skills/obsidian-brain/*/hooks/ | grep vault_index.py
+# confirm the dev version hook is in place
+```
+
+**Restart Claude Code** (close and reopen the session) so the new SKILL.md files are loaded.
+
+---
+
+## Step 2 — Rebuild the vault index with new schema
+
+The Phase 2 changes add 3 new tables (`themes`, `theme_members`, `term_df`) and 1 new column (`notes.tfidf_vector`). `ensure_index()` migrates automatically, but `/vault-reindex` is safer for a clean starting point.
+
+```
+/obsidian-brain:vault-reindex
+```
+
+Expected terminal output:
+- "Rebuilding vault index…"
+- "Indexed N notes across M folders"
+- No stack traces, no `[ERROR]` lines
+
+Verify via `sqlite3`:
+
+```bash
+DB="$HOME/.claude/obsidian-brain-vault.db"
+sqlite3 "$DB" "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('themes','theme_members','term_df')"
+# Expected 3 lines: themes, theme_members, term_df
+
+sqlite3 "$DB" "PRAGMA table_info(notes)" | grep tfidf_vector
+# Expected: "X|tfidf_vector|TEXT|0||0"
+```
+
+---
+
+## Step 3 — Run the automated invariant checker
+
+```bash
+bash scripts/dev-test/test-phase2-manual.sh
+```
+
+Expected:
+- `✅` marks across Schema, Indexes, Data population, term_df consistency, FTS cleanliness
+- `⏭` (skipped) for Theme invariants if themes haven't been created yet (run /recall first — Step 6)
+- No `❌` marks
+
+If any `❌` appears, **stop here** and diagnose before proceeding.
+
+---
+
+## Step 4 — Run the Python numerical checker
+
+```bash
+python3 scripts/dev-test/validate_phase2.py
+```
+
+Or with detail:
+```bash
+python3 scripts/dev-test/validate_phase2.py --verbose
+```
+
+Expected:
+- Tokenizer, TF-IDF compute, cosine similarity, detect_surprise, assign_to_theme idempotency, _delete_note centroid unfold, check_optional_deps, load_config deepcopy — all **PASS**
+- Exit code 0
+
+This hits the numerical paths that don't require a populated vault.
+
+---
+
+## Step 5 — Exercise `/obsidian-setup --deps` (optional deps flow)
+
+This is the new Step 8.7 in `/obsidian-setup`. Two sub-paths to test — one per machine state.
+
+### 5a. If numpy/scipy are NOT installed
+
+```
+/obsidian-brain:obsidian-setup --deps
+```
+
+Expected prompt:
+```
+Performance dependencies
+========================
+numpy: not installed
+scipy: not installed
+
+Install now? (yes/skip/not-now)
+```
+
+Test each branch:
+- **Type `skip`** → should write `optional_deps_declined: ["numpy", "scipy"]` + `optional_deps_prompted: true` to config. Verify:
+  ```bash
+  cat ~/.claude/obsidian-brain-config.json | python3 -m json.tool | grep optional_deps
+  ```
+- **Type `not-now`** → should write `optional_deps_prompted: false` (so it prompts again next run). Verify same config path.
+- **Type `yes`** → invokes `python3 -m pip install --user numpy scipy` (or platform equivalent). Should succeed if network available. After completion, re-run `/obsidian-setup --deps` — should detect they're installed and skip the prompt entirely (idempotent).
+
+### 5b. If numpy/scipy ARE already installed
+
+```
+/obsidian-brain:obsidian-setup --deps
+```
+
+Expected: detects installed packages, skips the prompt, prints "Performance dependencies: all present". No config write.
+
+### 5c. Atomic config write test
+
+Inspect the config file perms:
+```bash
+ls -l ~/.claude/obsidian-brain-config.json
+# Expected: -rw-------  (0o600)
+```
+
+If perms are anything else, the atomic write is regressing.
+
+### 5d. Verify deepcopy isolation (subtle bug from PR review round 3)
+
+```bash
+python3 -c "
+import sys, glob, os
+sys.path.insert(0, max(glob.glob(os.path.expanduser('~/.claude/plugins/cache/*/obsidian-brain/*/hooks'))))
+import obsidian_utils
+c1 = obsidian_utils.load_config()
+c1.setdefault('optional_deps_declined', []).append('TEST_POISON')
+obsidian_utils.cache_set(obsidian_utils._get_session_id_fast(), 'config', None)
+c2 = obsidian_utils.load_config()
+assert 'TEST_POISON' not in c2.get('optional_deps_declined', []), 'MUTABLE DEFAULT LEAKED'
+print('OK — deepcopy isolation holds')
+"
+```
+
+Expected: `OK — deepcopy isolation holds`
+
+---
+
+## Step 6 — Exercise `/recall` to trigger theme assignment
+
+This is the main Phase 2 integration point. `/recall` should:
+1. Find unsummarized notes via `find_unsummarized_notes()` (now includes the widened type filter).
+2. Summarize them via the sub-agent-first Wave 2 pipeline.
+3. On write-back, call `index_note()` → `assign_to_theme()` → write surprise via `detect_surprise()`.
+
+```
+/obsidian-brain:recall
+```
+
+Expected:
+- Normal `/recall` output (context brief, session history table, etc.)
+- `[INFO] Phase 2: theme assignment …` lines in stderr for each upgraded note (check the hidden messages or the Claude Code log)
+- No `[ERROR] theme pipeline unexpected error` entries
+- No `[WARN] theme re-index failed` entries unless a known cause (e.g. DB temporarily locked)
+
+Verify themes were created:
+```bash
+sqlite3 "$DB" "SELECT id, name, note_count, project FROM themes LIMIT 10"
+```
+
+Expected: at least one theme per project with ≥2 semantically-similar summarized notes. `note_count` should be ≥1. `name` may be blank (theme naming is a Phase 3 feature).
+
+Verify membership:
+```bash
+sqlite3 "$DB" "SELECT t.name, COUNT(tm.note_path) FROM themes t JOIN theme_members tm ON tm.theme_id = t.id GROUP BY t.id"
+```
+
+The COUNT per theme should match `themes.note_count`. (The `test-phase2-manual.sh` script also checks this invariant.)
+
+---
+
+## Step 7 — Surprise detection sanity check
+
+Find a theme_members row where surprise > 0:
+```bash
+sqlite3 "$DB" "SELECT theme_id, note_path, similarity, surprise FROM theme_members WHERE surprise > 0 ORDER BY surprise DESC LIMIT 5"
+```
+
+If rows exist with `surprise > 0`: open one of those notes in Obsidian and verify its content contains negation words near shared TF-IDF terms (the heuristic's intent). This is a sanity check; false positives are acceptable.
+
+If ALL surprise values are 0: either your vault has no contradictory content (fine), OR `detect_surprise` regressed (run `validate_phase2.py` Step 4).
+
+---
+
+## Step 8 — FTS5 orphan cleanup test (from PR review round 2)
+
+This is the "contentless FTS5 'delete'" fix. Verify that modifying a note multiple times doesn't accumulate `notes_fts` rows.
+
+```bash
+# Pick a note path to modify — one of your existing session notes is fine
+NOTE="$HOME/obsidian/claude-code-vault/claude-sessions/$(ls ~/obsidian/claude-code-vault/claude-sessions/*.md | head -1 | xargs basename)"
+
+# Current FTS count
+FTS_BEFORE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM notes_fts")
+NOTES_BEFORE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM notes")
+echo "Before: notes=$NOTES_BEFORE, fts=$FTS_BEFORE"
+
+# Touch mtime 3 times and reindex each time
+for i in 1 2 3; do
+    touch -A +002 "$NOTE"  # bump mtime by 2s
+    python3 -c "
+import sys, glob, os
+sys.path.insert(0, max(glob.glob(os.path.expanduser('~/.claude/plugins/cache/*/obsidian-brain/*/hooks'))))
+import vault_index
+from obsidian_utils import load_config
+c = load_config()
+vault_index.ensure_index(c['vault_path'], [c.get('sessions_folder', 'claude-sessions')])
+"
+done
+
+FTS_AFTER=$(sqlite3 "$DB" "SELECT COUNT(*) FROM notes_fts")
+NOTES_AFTER=$(sqlite3 "$DB" "SELECT COUNT(*) FROM notes")
+echo "After: notes=$NOTES_AFTER, fts=$FTS_AFTER"
+
+if [ "$FTS_AFTER" -eq "$NOTES_AFTER" ]; then
+    echo "✅ FTS count matches notes count — orphan cleanup works"
+else
+    echo "❌ FTS=$FTS_AFTER != notes=$NOTES_AFTER — orphans accumulating"
+fi
+```
+
+Expected: `FTS count matches notes count`.
+
+---
+
+## Step 9 — `/vault-search` smoke test
+
+Confirms access_log cascade (if you want to pre-verify the Section 7 design of the snapshot spec; skip for strict Phase 2 scope).
+
+```
+/obsidian-brain:vault-search retrieval scoring
+```
+
+Expected: results returned with ranking. Check `access_log`:
+
+```bash
+sqlite3 "$DB" "SELECT COUNT(*) FROM access_log WHERE timestamp > strftime('%s', 'now', '-5 minutes')"
+```
+
+Expected: >0 (recent events from the search).
+
+---
+
+## Step 10 — Concurrency smoke test (BEGIN IMMEDIATE)
+
+Two concurrent `index_note` calls should serialize cleanly, not deadlock or corrupt data.
+
+```bash
+python3 -c "
+import sys, glob, os, threading
+sys.path.insert(0, max(glob.glob(os.path.expanduser('~/.claude/plugins/cache/*/obsidian-brain/*/hooks'))))
+import vault_index
+from obsidian_utils import load_config
+c = load_config()
+db = os.path.expanduser('~/.claude/obsidian-brain-vault.db')
+
+import glob as g
+notes = g.glob(os.path.join(c['vault_path'], c.get('sessions_folder', 'claude-sessions'), '*.md'))[:4]
+if len(notes) < 2:
+    print('Need >=2 notes in sessions folder; aborting concurrency test')
+    exit()
+
+errors = []
+def worker(path):
+    try:
+        vault_index.index_note(db, path)
+    except Exception as e:
+        errors.append(f'{path}: {e}')
+
+threads = [threading.Thread(target=worker, args=(n,)) for n in notes]
+for t in threads: t.start()
+for t in threads: t.join()
+
+if errors:
+    print('❌ Concurrent index_note failures:')
+    for e in errors: print(f'  {e}')
+else:
+    print(f'✅ {len(notes)} concurrent index_note calls all succeeded')
+"
+```
+
+Expected: `✅ N concurrent index_note calls all succeeded`. SQLITE_BUSY warnings in stderr are acceptable (the retry should succeed within 5s timeout).
+
+---
+
+## Step 11 — Re-run invariant checker
+
+After all the above exercise, re-run the automated invariants to confirm no drift:
+
+```bash
+bash scripts/dev-test/test-phase2-manual.sh && python3 scripts/dev-test/validate_phase2.py
+```
+
+Expected: both exit 0, no `❌`.
+
+---
+
+## Step 12 — Restore original version
+
+```
+/obsidian-brain:dev-test restore
+```
+
+Verify:
+```bash
+ls ~/.claude/plugins/cache/claude-code-skills/obsidian-brain/
+# Should show only the original <version>/ directory, no <version>.bak/
+```
+
+**Restart Claude Code** one more time to confirm everything still works on the original version.
+
+---
+
+## Exit criteria
+
+All of the following must be true before `/finish` on PR #41:
+
+- [ ] Steps 1-11 all pass with no `❌` markers
+- [ ] `/obsidian-setup --deps` tested in at least one branch (install-yes OR skip+re-run for idempotency)
+- [ ] `/recall` produces theme rows in the DB
+- [ ] FTS5 orphan test shows count parity after 3x rewrite
+- [ ] Concurrency test shows no corruption
+- [ ] Original version restored cleanly via `/dev-test restore`
+
+If any fail, note the failure in the PR description and don't merge until resolved.

--- a/scripts/dev-test/test-phase2-manual.sh
+++ b/scripts/dev-test/test-phase2-manual.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# Manual smoke test for Phase 2: TF-IDF + Themes + Surprise + FTS orphan cleanup
+#
+# Run AFTER: /dev-test install + start a new CC session.
+# Usage: bash scripts/dev-test/test-phase2-manual.sh
+#
+# Invariants checked:
+# - Schema: themes, theme_members, term_df tables + tfidf_vector column
+# - Data: tfidf_vector populated for summarized notes
+# - Theme invariant: themes.note_count == count(theme_members WHERE theme_id=themes.id)
+# - FTS cleanliness: no orphan notes_fts rows
+# - Access cascade (Section 7 of snapshot spec is separate — here we only check
+#   Phase 2 access_log baseline)
+# - Numerical: cosine symmetric, surprise in [0,1], tfidf weights >= 0
+
+set -uo pipefail    # omit -e so individual test failures don't abort the whole run
+
+DB="$HOME/.claude/obsidian-brain-vault.db"
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  ✅ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  ⏭️  $1"; SKIP=$((SKIP + 1)); }
+
+echo "═══════════════════════════════════════════════════"
+echo "Phase 2 Smoke Test: TF-IDF + Themes + Surprise"
+echo "═══════════════════════════════════════════════════"
+echo ""
+echo "DB path: $DB"
+echo ""
+
+if [ ! -f "$DB" ]; then
+    fail "DB does not exist — run /vault-reindex or any vault op first, then re-run this script"
+    exit 1
+fi
+
+# ─── Test 1: Schema ───────────────────────────────────
+echo "Test 1: Schema migration"
+
+for table in themes theme_members term_df; do
+    if sqlite3 "$DB" ".tables" | tr -s ' ' '\n' | grep -qx "$table"; then
+        pass "$table table exists"
+    else
+        fail "$table table missing (run /vault-reindex to migrate)"
+    fi
+done
+
+if sqlite3 "$DB" "PRAGMA table_info(notes)" | awk -F'|' '{print $2}' | grep -qx "tfidf_vector"; then
+    pass "tfidf_vector column exists on notes"
+else
+    fail "tfidf_vector column missing on notes"
+fi
+
+echo ""
+
+# ─── Test 2: Indexes ──────────────────────────────────
+echo "Test 2: Supporting indexes"
+
+for idx in idx_theme_members_theme idx_theme_members_note idx_themes_project; do
+    if sqlite3 "$DB" ".indices" | grep -qx "$idx"; then
+        pass "index $idx exists"
+    else
+        skip "index $idx — naming may vary, check PRAGMA index_list(themes)"
+    fi
+done
+
+echo ""
+
+# ─── Test 3: Data population ──────────────────────────
+echo "Test 3: tfidf_vector populated"
+
+NOTE_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM notes")
+VEC_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM notes WHERE tfidf_vector IS NOT NULL AND tfidf_vector != ''")
+NULL_COUNT=$((NOTE_COUNT - VEC_COUNT))
+
+echo "  notes total:          $NOTE_COUNT"
+echo "  with tfidf_vector:    $VEC_COUNT"
+echo "  without tfidf_vector: $NULL_COUNT"
+
+if [ "$NOTE_COUNT" -eq 0 ]; then
+    skip "empty vault — nothing to validate"
+elif [ "$VEC_COUNT" -eq 0 ]; then
+    fail "tfidf_vector is NULL for ALL notes — /vault-reindex did not run or _upsert_note regressed"
+elif [ "$NULL_COUNT" -gt 0 ]; then
+    # Note: new raw (status=auto-logged) notes may not have tfidf_vector until summarized
+    # because bodies are placeholders. Check only summarized notes.
+    SUMMARIZED_WITHOUT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM notes WHERE status='summarized' AND (tfidf_vector IS NULL OR tfidf_vector = '')")
+    if [ "$SUMMARIZED_WITHOUT" -gt 0 ]; then
+        fail "$SUMMARIZED_WITHOUT summarized notes missing tfidf_vector"
+        sqlite3 "$DB" "SELECT path FROM notes WHERE status='summarized' AND (tfidf_vector IS NULL OR tfidf_vector = '') LIMIT 5" | sed 's/^/    - /'
+    else
+        pass "all summarized notes have tfidf_vector (only auto-logged notes are NULL, expected)"
+    fi
+else
+    pass "all $NOTE_COUNT notes have tfidf_vector"
+fi
+
+echo ""
+
+# ─── Test 4: term_df consistency ──────────────────────
+echo "Test 4: term_df consistency"
+
+TERM_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM term_df")
+echo "  term_df rows: $TERM_COUNT"
+
+if [ "$TERM_COUNT" -eq 0 ] && [ "$VEC_COUNT" -gt 0 ]; then
+    fail "term_df is empty but tfidf_vectors exist — _update_term_df regressed"
+elif [ "$TERM_COUNT" -gt 0 ]; then
+    NEG_DF=$(sqlite3 "$DB" "SELECT COUNT(*) FROM term_df WHERE df < 0")
+    if [ "$NEG_DF" -gt 0 ]; then
+        fail "$NEG_DF term_df rows have negative df (symmetric-diff regression)"
+    else
+        pass "no negative df values"
+    fi
+
+    MAX_DF=$(sqlite3 "$DB" "SELECT MAX(df) FROM term_df")
+    if [ "$MAX_DF" -gt "$NOTE_COUNT" ]; then
+        fail "max df=$MAX_DF exceeds note count=$NOTE_COUNT (over-counting)"
+    else
+        pass "df <= note count (max df=$MAX_DF)"
+    fi
+fi
+
+echo ""
+
+# ─── Test 5: Theme invariants ─────────────────────────
+echo "Test 5: Theme invariants"
+
+THEME_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM themes")
+MEMBER_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM theme_members")
+
+echo "  themes:        $THEME_COUNT"
+echo "  theme_members: $MEMBER_COUNT"
+
+if [ "$THEME_COUNT" -eq 0 ]; then
+    skip "no themes yet — run /recall on a project with >=2 similar notes"
+else
+    # Count mismatch check: themes.note_count should equal count of theme_members per theme
+    MISMATCH=$(sqlite3 "$DB" "
+        SELECT COUNT(*) FROM (
+            SELECT t.id, t.note_count, COALESCE(mc.cnt, 0) AS actual
+            FROM themes t
+            LEFT JOIN (SELECT theme_id, COUNT(*) AS cnt FROM theme_members GROUP BY theme_id) mc
+              ON mc.theme_id = t.id
+            WHERE t.note_count != COALESCE(mc.cnt, 0)
+        )
+    ")
+    if [ "$MISMATCH" -gt 0 ]; then
+        fail "$MISMATCH themes have note_count mismatching theme_members count"
+        sqlite3 "$DB" "
+            SELECT t.id, t.name, t.note_count, COALESCE(mc.cnt, 0)
+            FROM themes t
+            LEFT JOIN (SELECT theme_id, COUNT(*) AS cnt FROM theme_members GROUP BY theme_id) mc
+              ON mc.theme_id = t.id
+            WHERE t.note_count != COALESCE(mc.cnt, 0)
+            LIMIT 5
+        " | sed 's/^/    /'
+    else
+        pass "themes.note_count == COUNT(theme_members) for all themes"
+    fi
+
+    # Orphan theme_members (theme_id not in themes)
+    ORPHAN=$(sqlite3 "$DB" "SELECT COUNT(*) FROM theme_members tm LEFT JOIN themes t ON t.id = tm.theme_id WHERE t.id IS NULL")
+    if [ "$ORPHAN" -gt 0 ]; then
+        fail "$ORPHAN orphan theme_members rows (theme_id points to missing theme)"
+    else
+        pass "no orphan theme_members"
+    fi
+
+    # Centroid presence
+    NULL_CENTROID=$(sqlite3 "$DB" "SELECT COUNT(*) FROM themes WHERE centroid IS NULL OR centroid = '' OR centroid = '{}'")
+    if [ "$NULL_CENTROID" -gt 0 ] && [ "$THEME_COUNT" -gt 0 ]; then
+        fail "$NULL_CENTROID themes have empty centroid"
+    else
+        pass "all themes have populated centroid"
+    fi
+
+    # Surprise values in [0, 1]
+    OUT_OF_RANGE=$(sqlite3 "$DB" "SELECT COUNT(*) FROM theme_members WHERE surprise < 0 OR surprise > 1")
+    if [ "$OUT_OF_RANGE" -gt 0 ]; then
+        fail "$OUT_OF_RANGE theme_members rows have surprise outside [0,1]"
+    else
+        pass "all surprise values in [0, 1]"
+    fi
+
+    # Similarity values in [0, 1]
+    SIM_BAD=$(sqlite3 "$DB" "SELECT COUNT(*) FROM theme_members WHERE similarity < 0 OR similarity > 1.01")
+    if [ "$SIM_BAD" -gt 0 ]; then
+        fail "$SIM_BAD theme_members rows have similarity outside [0, 1.01]"
+    else
+        pass "all similarity values in [0, 1.01] tolerance band"
+    fi
+fi
+
+echo ""
+
+# ─── Test 6: FTS cleanliness (orphan rows from Section 5 fix) ─
+echo "Test 6: FTS5 orphan rows"
+
+# Every notes_fts rowid should correspond to a row in notes with the same rowid.
+FTS_ORPHAN=$(sqlite3 "$DB" "SELECT COUNT(*) FROM notes_fts WHERE rowid NOT IN (SELECT rowid FROM notes)")
+if [ "$FTS_ORPHAN" -gt 0 ]; then
+    fail "$FTS_ORPHAN orphan notes_fts rows (FTS5 'delete' command missing on upsert/delete)"
+else
+    pass "no orphan notes_fts rows (all FTS entries JOIN a notes row)"
+fi
+
+FTS_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM notes_fts")
+if [ "$FTS_COUNT" -ne "$NOTE_COUNT" ]; then
+    fail "notes_fts count ($FTS_COUNT) != notes count ($NOTE_COUNT)"
+else
+    pass "notes_fts count matches notes count"
+fi
+
+echo ""
+
+# ─── Test 7: Access log cascade baseline (Phase 1 feature) ─
+echo "Test 7: access_log sanity"
+
+ACC_COUNT=$(sqlite3 "$DB" "SELECT COUNT(*) FROM access_log")
+echo "  access_log rows: $ACC_COUNT"
+
+if [ "$ACC_COUNT" -eq 0 ]; then
+    skip "no access_log entries yet — run /vault-search or /recall first"
+else
+    # No access_log rows referencing missing notes
+    ORPHAN_ACCESS=$(sqlite3 "$DB" "SELECT COUNT(*) FROM access_log al LEFT JOIN notes n ON n.path = al.note_path WHERE n.path IS NULL")
+    if [ "$ORPHAN_ACCESS" -gt 0 ]; then
+        skip "$ORPHAN_ACCESS access_log rows reference missing notes (may be from deleted files — informational)"
+    else
+        pass "all access_log rows reference existing notes"
+    fi
+fi
+
+echo ""
+
+# ─── Summary ──────────────────────────────────────────
+echo "═══════════════════════════════════════════════════"
+echo "Summary: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "═══════════════════════════════════════════════════"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "❌ Phase 2 implementation has invariant violations."
+    echo "   Run: python3 scripts/dev-test/validate_phase2.py --verbose"
+    echo "   for deeper analysis."
+    exit 1
+fi
+
+echo ""
+echo "✅ Phase 2 invariants hold."
+echo "   Next: run validate_phase2.py for numerical checks (cosine, tokenizer)."

--- a/scripts/dev-test/validate_phase2.py
+++ b/scripts/dev-test/validate_phase2.py
@@ -1,0 +1,516 @@
+#!/usr/bin/env python3
+"""Phase 2 validation — numerical and behavioral checks beyond what bash can do.
+
+Run AFTER: `/dev-test install` + fresh CC session + /vault-reindex + a /recall cycle.
+Usage:
+    python3 scripts/dev-test/validate_phase2.py                    # use installed plugin cache
+    python3 scripts/dev-test/validate_phase2.py --dev-repo         # use local hooks/ (pre-install sanity check)
+    python3 scripts/dev-test/validate_phase2.py --verbose
+    python3 scripts/dev-test/validate_phase2.py --db /path/to/vault.db
+
+Exits 0 on all checks passing, 1 if any fail.
+
+Checks performed:
+- TF-IDF tokenizer: basic lowercasing, stopword drop, apostrophe handling
+- _compute_tfidf_vector math: smoothed IDF formula holds, top-K truncation
+- _cosine_similarity: symmetric, in [0, 1], identity == 1
+- detect_surprise: edge cases return 0.0, contractions match, out-of-window doesn't
+- assign_to_theme idempotency: calling twice on same note doesn't drift count/centroid
+- _delete_note centroid unfold: running-average reverse is algebraically correct
+- check_optional_deps: reports numpy/scipy status
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+# --- Hook resolution is argv-dependent; delay import until after flag parsing ---
+_EARLY_ARGS = sys.argv[1:]
+_USE_DEV_REPO = "--dev-repo" in _EARLY_ARGS
+
+
+def _find_dev_hooks() -> Path | None:
+    """Walk up from this file until we find a sibling `hooks/` directory.
+    Robust to different script locations (scripts/, scripts/dev-test/, etc.)."""
+    here = Path(__file__).resolve().parent
+    for parent in (here, *here.parents):
+        candidate = parent / "hooks"
+        if candidate.is_dir() and (candidate / "vault_index.py").exists():
+            return candidate
+    return None
+
+
+if _USE_DEV_REPO:
+    dev_hooks = _find_dev_hooks()
+    if dev_hooks is None:
+        print("ERROR: --dev-repo passed but no hooks/ directory found walking up from this script",
+              file=sys.stderr)
+        sys.exit(1)
+    sys.path.insert(0, str(dev_hooks))
+else:
+    CACHE_GLOB = os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")
+    cache_hits = sorted(glob.glob(CACHE_GLOB))
+    if not cache_hits:
+        dev_hooks = _find_dev_hooks()
+        if dev_hooks is not None:
+            print(f"NOTE: no plugin cache found; falling back to {dev_hooks}")
+            sys.path.insert(0, str(dev_hooks))
+        else:
+            print("ERROR: cannot locate obsidian-brain hooks/ directory", file=sys.stderr)
+            sys.exit(1)
+    else:
+        sys.path.insert(0, cache_hits[-1])
+
+try:
+    import vault_index
+    import obsidian_utils
+except ImportError as e:
+    print(f"ERROR: failed to import hooks: {e}", file=sys.stderr)
+    sys.exit(1)
+
+# --- Reporting helpers ---
+PASS = 0
+FAIL = 0
+SKIP = 0
+VERBOSE = False
+
+
+def pass_(msg: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"  ✅ {msg}")
+
+
+def fail_(msg: str) -> None:
+    global FAIL
+    FAIL += 1
+    print(f"  ❌ {msg}")
+
+
+def skip_(msg: str) -> None:
+    global SKIP
+    SKIP += 1
+    print(f"  ⏭️  {msg}")
+
+
+def debug(msg: str) -> None:
+    if VERBOSE:
+        print(f"    · {msg}")
+
+
+def section(name: str) -> None:
+    print(f"\n{'─' * 50}")
+    print(name)
+    print("─" * 50)
+
+
+# --- Tests ---
+
+def test_tokenizer() -> None:
+    section("1. TF-IDF tokenizer")
+    toks = vault_index._tokenize_for_tfidf("Hello, World! Python-3.9.")
+    expected = ["hello", "world", "python"]
+    if toks == expected:
+        pass_(f"punctuation + single-digit stripped: {toks}")
+    else:
+        fail_(f"expected {expected}, got {toks}")
+
+    toks = vault_index._tokenize_for_tfidf("the quick brown fox is here")
+    for sw in ("the", "is", "here"):
+        if sw not in toks:
+            pass_(f"stopword '{sw}' dropped")
+        else:
+            fail_(f"stopword '{sw}' not dropped: {toks}")
+
+    # Length filter
+    toks = vault_index._tokenize_for_tfidf("a ab abc")
+    if "a" not in toks and "ab" in toks and "abc" in toks:
+        pass_("single-char tokens dropped, 2+ char kept")
+    else:
+        fail_(f"length filter unexpected: {toks}")
+
+
+def test_compute_tfidf() -> None:
+    section("2. _compute_tfidf_vector")
+    # Smoothed IDF: 1 + ln((N+1)/(df+1))
+    # For N=10, df=1: 1 + ln(11/2) ≈ 1 + 1.7047 = 2.7047
+    # For N=10, df=10: 1 + ln(11/11) = 1 + 0 = 1.0
+    tokens = ["retrieval", "scoring", "retrieval"]  # retrieval appears twice (TF=2/3), scoring once (TF=1/3)
+    term_df = {"retrieval": 1, "scoring": 10}
+    total_docs = 10
+
+    vec = vault_index._compute_tfidf_vector(tokens, term_df, total_docs, top_k=50)
+    if "retrieval" not in vec or "scoring" not in vec:
+        fail_(f"vec missing expected terms: {vec}")
+        return
+
+    # retrieval has higher IDF (rare) and higher TF (appears 2x) — must dominate
+    if vec["retrieval"] > vec["scoring"]:
+        pass_(f"rare term weight > common term weight ({vec['retrieval']:.3f} > {vec['scoring']:.3f})")
+    else:
+        fail_(f"rare term should dominate: retrieval={vec['retrieval']:.3f}, scoring={vec['scoring']:.3f}")
+
+    # Verify smoothed IDF formula approximately
+    expected_idf_rare = 1 + math.log((total_docs + 1) / (1 + 1))   # df=1
+    expected_idf_common = 1 + math.log((total_docs + 1) / (10 + 1))  # df=10
+    if expected_idf_common < 0.01:
+        expected_idf_common = 1.0  # smoothing keeps it >= some floor
+    debug(f"expected IDF rare ≈ {expected_idf_rare:.3f}, common ≈ {expected_idf_common:.3f}")
+
+    # Top-K truncation
+    big_tokens = [f"tok{i}" for i in range(100)]
+    big_df = {t: 1 for t in big_tokens}
+    big_vec = vault_index._compute_tfidf_vector(big_tokens, big_df, 100, top_k=50)
+    if len(big_vec) <= 50:
+        pass_(f"top-K truncation respected ({len(big_vec)} <= 50)")
+    else:
+        fail_(f"top-K not enforced: {len(big_vec)} entries")
+
+
+def test_cosine_similarity() -> None:
+    section("3. _cosine_similarity")
+    a = {"x": 1.0, "y": 1.0}
+    b = {"x": 1.0, "y": 1.0}
+    sim = vault_index._cosine_similarity(a, b)
+    if abs(sim - 1.0) < 1e-6:
+        pass_(f"identical vectors → 1.0 (got {sim:.6f})")
+    else:
+        fail_(f"identical should be 1.0, got {sim}")
+
+    # Symmetric
+    sim_ab = vault_index._cosine_similarity(a, {"x": 2.0})
+    sim_ba = vault_index._cosine_similarity({"x": 2.0}, a)
+    if abs(sim_ab - sim_ba) < 1e-9:
+        pass_(f"symmetric: cos(a,b)={sim_ab:.6f} = cos(b,a)={sim_ba:.6f}")
+    else:
+        fail_(f"asymmetric: cos(a,b)={sim_ab}, cos(b,a)={sim_ba}")
+
+    # Disjoint → 0
+    sim_disjoint = vault_index._cosine_similarity({"x": 1.0}, {"y": 1.0})
+    if abs(sim_disjoint) < 1e-6:
+        pass_(f"disjoint → 0.0 (got {sim_disjoint})")
+    else:
+        fail_(f"disjoint should be 0, got {sim_disjoint}")
+
+    # Empty
+    if vault_index._cosine_similarity({}, {"x": 1.0}) == 0.0:
+        pass_("empty vs populated → 0.0")
+    else:
+        fail_("empty should be 0.0")
+
+
+def test_detect_surprise() -> None:
+    section("4. detect_surprise")
+    centroid = {"retrieval": 1.0, "scoring": 1.0}
+    note_vec = {"retrieval": 1.0, "scoring": 1.0}
+
+    # Negated shared term
+    score = vault_index.detect_surprise(
+        "retrieval scoring is not reliable",
+        note_vec, centroid,
+    )
+    if score > 0:
+        pass_(f"negated shared term registers ({score:.3f})")
+    else:
+        fail_(f"negated shared term should score > 0, got {score}")
+
+    # Agreement text
+    score = vault_index.detect_surprise(
+        "retrieval scoring works great",
+        note_vec, centroid,
+    )
+    if score == 0.0:
+        pass_(f"agreement text → 0.0")
+    else:
+        fail_(f"agreement should be 0, got {score}")
+
+    # Apostrophe normalization — don't should match dont
+    score = vault_index.detect_surprise(
+        "don't trust retrieval scoring",
+        note_vec, centroid,
+    )
+    if score > 0:
+        pass_(f"straight apostrophe normalization works (score={score:.3f})")
+    else:
+        fail_(f"don't → dont normalization failed, score={score}")
+
+    # Smart quote
+    score = vault_index.detect_surprise(
+        "can\u2019t trust retrieval scoring",
+        note_vec, centroid,
+    )
+    if score > 0:
+        pass_(f"smart quote normalization works (score={score:.3f})")
+    else:
+        fail_(f"can\u2019t → cant normalization failed, score={score}")
+
+    # Empty inputs all return 0
+    for desc, args in [
+        ("empty text", ("", note_vec, centroid)),
+        ("empty vec", ("text", {}, centroid)),
+        ("empty centroid", ("text", note_vec, {})),
+    ]:
+        if vault_index.detect_surprise(*args) == 0.0:
+            pass_(f"{desc} → 0.0")
+        else:
+            fail_(f"{desc} should be 0.0")
+
+
+def test_assign_theme_idempotent(tmpdir: Path) -> None:
+    section("5. assign_to_theme idempotency (no count/centroid drift on reassignment)")
+
+    # Set up a synthetic vault + note
+    vault = tmpdir / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    note_path = vault / "claude-sessions" / "2026-04-17-test-abcd.md"
+    note_path.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-17\n"
+        "project: testproj\n"
+        "title: Test session\n"
+        "tags:\n  - claude/session\n"
+        "status: summarized\n"
+        "---\n"
+        "retrieval scoring activation importance proximity bm25 theme\n",
+        encoding="utf-8",
+    )
+    db_path = str(tmpdir / "test.db")
+    vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=db_path)
+
+    # Seed a theme matching the note's vector
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    vec = json.loads(conn.execute(
+        "SELECT tfidf_vector FROM notes WHERE path = ?", (str(note_path),)
+    ).fetchone()["tfidf_vector"])
+    conn.execute(
+        "INSERT INTO themes (name, summary, centroid, note_count, "
+        "created_date, updated_date, project) "
+        "VALUES (?, ?, ?, 3, ?, ?, ?)",
+        ("Test", "", json.dumps(vec), "2026-04-17", "2026-04-17", "testproj"),
+    )
+    theme_id = conn.execute("SELECT id FROM themes").fetchone()["id"]
+    conn.commit()
+    conn.close()
+
+    # First assignment: legitimately new member → count 3 → 4
+    r1 = vault_index.assign_to_theme(db_path, str(note_path), project="testproj")
+    if r1 is None:
+        fail_("first assign_to_theme returned None")
+        return
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT note_count, centroid FROM themes WHERE id = ?", (theme_id,)
+    ).fetchone()
+    count_1, centroid_1 = row["note_count"], json.loads(row["centroid"])
+    conn.close()
+
+    if count_1 == 4:
+        pass_(f"first assign bumps count 3 → 4")
+    else:
+        fail_(f"first assign: expected count=4, got {count_1}")
+
+    # Second assignment of same note: count + centroid must not change
+    r2 = vault_index.assign_to_theme(db_path, str(note_path), project="testproj")
+    if r2 is None:
+        fail_("second assign_to_theme returned None")
+        return
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT note_count, centroid FROM themes WHERE id = ?", (theme_id,)
+    ).fetchone()
+    count_2, centroid_2 = row["note_count"], json.loads(row["centroid"])
+    conn.close()
+
+    if count_2 == 4:
+        pass_(f"reassign keeps count at 4 (no double-count)")
+    else:
+        fail_(f"reassign drifted count: expected 4, got {count_2}")
+
+    drift = max((abs(centroid_2.get(k, 0) - centroid_1.get(k, 0))
+                 for k in set(centroid_1) | set(centroid_2)), default=0)
+    if drift < 1e-9:
+        pass_(f"reassign keeps centroid stable (max drift {drift:.2e})")
+    else:
+        fail_(f"centroid drifted on reassign, max delta={drift:.6f}")
+
+
+def test_delete_unfolds_centroid(tmpdir: Path) -> None:
+    section("6. _delete_note reverses running-average centroid")
+
+    # Build a theme with two members, delete one, verify centroid equals the other member's vec
+    vault = tmpdir / "vault2"
+    (vault / "claude-sessions").mkdir(parents=True)
+    a_path = vault / "claude-sessions" / "2026-04-17-proj-aaaa.md"
+    b_path = vault / "claude-sessions" / "2026-04-17-proj-bbbb.md"
+    for p, body in [
+        (a_path, "retrieval scoring activation"),
+        (b_path, "retrieval scoring importance proximity"),
+    ]:
+        p.write_text(
+            f"---\ntype: claude-session\ndate: 2026-04-17\nproject: proj\n"
+            f"title: {p.stem}\ntags:\n  - claude/session\nstatus: summarized\n---\n{body}\n",
+            encoding="utf-8",
+        )
+    db_path = str(tmpdir / "test2.db")
+    vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=db_path)
+
+    # Hand-build theme with A+B running-avg centroid
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    vec_a = json.loads(conn.execute("SELECT tfidf_vector FROM notes WHERE path=?", (str(a_path),)).fetchone()["tfidf_vector"])
+    vec_b = json.loads(conn.execute("SELECT tfidf_vector FROM notes WHERE path=?", (str(b_path),)).fetchone()["tfidf_vector"])
+    all_terms = set(vec_a) | set(vec_b)
+    centroid = {t: (vec_a.get(t, 0) + vec_b.get(t, 0)) / 2 for t in all_terms}
+    conn.execute(
+        "INSERT INTO themes (name, summary, centroid, note_count, "
+        "created_date, updated_date, project) "
+        "VALUES ('T', '', ?, 2, '2026-04-17', '2026-04-17', 'proj')",
+        (json.dumps(centroid),),
+    )
+    theme_id = conn.execute("SELECT id FROM themes").fetchone()["id"]
+    conn.executemany(
+        "INSERT INTO theme_members (theme_id, note_path, similarity, added_date) "
+        "VALUES (?, ?, 1.0, '2026-04-17')",
+        [(theme_id, str(a_path)), (theme_id, str(b_path))],
+    )
+    conn.commit()
+    conn.close()
+
+    # Delete A via the internal helper (simulating _sync's deletion path)
+    conn = vault_index._connect(db_path)
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        vault_index._delete_note(conn, str(a_path))
+        conn.commit()
+    finally:
+        conn.close()
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    row = conn.execute("SELECT note_count, centroid FROM themes WHERE id=?", (theme_id,)).fetchone()
+    if row is None:
+        fail_("theme disappeared unexpectedly (count was 2, should now be 1)")
+        conn.close()
+        return
+    count_after = row["note_count"]
+    centroid_after = json.loads(row["centroid"])
+    conn.close()
+
+    if count_after == 1:
+        pass_(f"note_count decremented 2 → 1")
+    else:
+        fail_(f"expected count=1, got {count_after}")
+
+    # After unfolding A, remaining centroid should equal vec_b (only member left)
+    max_err = max((abs(centroid_after.get(t, 0) - vec_b.get(t, 0)) for t in set(centroid_after) | set(vec_b)), default=0)
+    if max_err < 1e-6:
+        pass_(f"centroid unfolded to vec_b (max error {max_err:.2e})")
+    else:
+        fail_(f"centroid didn't unfold cleanly, max error {max_err:.6f}")
+
+
+def test_optional_deps() -> None:
+    section("7. check_optional_deps")
+    result = obsidian_utils.check_optional_deps()
+    if set(result) == {"numpy", "scipy"}:
+        pass_(f"reports numpy + scipy: numpy={result['numpy']}, scipy={result['scipy']}")
+    else:
+        fail_(f"expected numpy+scipy keys, got {result.keys()}")
+
+    # Catches broader exceptions
+    import importlib as _il
+    real = _il.import_module
+
+    def raising(name, *a, **kw):
+        if name == "numpy":
+            raise OSError("simulated broken binary")
+        return real(name, *a, **kw)
+
+    _il.import_module = raising
+    try:
+        result = obsidian_utils.check_optional_deps()
+        if result["numpy"] is False:
+            pass_(f"OSError during import → reports False (not raised)")
+        else:
+            fail_(f"OSError should result in False, got {result['numpy']}")
+    finally:
+        _il.import_module = real
+
+
+def test_config_deepcopy() -> None:
+    section("8. load_config deepcopy isolation")
+    # Snapshot _DEFAULTS, load_config, mutate returned dict, reload, verify
+    # the mutation didn't leak into subsequent loads or into _DEFAULTS itself.
+    original = list(obsidian_utils._DEFAULTS.get("optional_deps_declined", []))
+    try:
+        c1 = obsidian_utils.load_config()
+        c1.setdefault("optional_deps_declined", []).append("poisoned")
+        # Bust cache
+        sid = obsidian_utils._get_session_id_fast()
+        obsidian_utils.cache_set(sid, "config", None)
+        c2 = obsidian_utils.load_config()
+        if "poisoned" not in c2.get("optional_deps_declined", []):
+            pass_("mutation did not leak across load_config calls")
+        else:
+            fail_("mutation leaked — _DEFAULTS was shallow-copied")
+        if obsidian_utils._DEFAULTS["optional_deps_declined"] == original:
+            pass_("_DEFAULTS preserved")
+        else:
+            fail_(f"_DEFAULTS mutated: {obsidian_utils._DEFAULTS['optional_deps_declined']}")
+    finally:
+        # Restore _DEFAULTS if anything modified it
+        obsidian_utils._DEFAULTS["optional_deps_declined"] = original
+
+
+# --- Main ---
+
+def main() -> int:
+    global VERBOSE
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--verbose", "-v", action="store_true")
+    parser.add_argument("--db", default=os.path.expanduser("~/.claude/obsidian-brain-vault.db"))
+    parser.add_argument("--dev-repo", action="store_true",
+                        help="Import hooks from local hooks/ directory instead of installed plugin cache")
+    args = parser.parse_args()
+    VERBOSE = args.verbose
+
+    print("═══════════════════════════════════════════════════")
+    print("Phase 2 numerical + behavioral validation")
+    print("═══════════════════════════════════════════════════")
+    print(f"Hooks imported from: {sys.path[0]}")
+    print(f"DB (informational):  {args.db}")
+
+    test_tokenizer()
+    test_compute_tfidf()
+    test_cosine_similarity()
+    test_detect_surprise()
+    test_optional_deps()
+    test_config_deepcopy()
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmpdir = Path(tmp)
+        test_assign_theme_idempotent(tmpdir)
+        test_delete_unfolds_centroid(tmpdir)
+
+    print(f"\n{'═' * 50}")
+    print(f"Summary: {PASS} passed, {FAIL} failed, {SKIP} skipped")
+    print("═" * 50)
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev-test/validate_phase2.py
+++ b/scripts/dev-test/validate_phase2.py
@@ -36,6 +36,9 @@ from pathlib import Path
 # --- Hook resolution is argv-dependent; delay import until after flag parsing ---
 _EARLY_ARGS = sys.argv[1:]
 _USE_DEV_REPO = "--dev-repo" in _EARLY_ARGS
+# Short-circuit when the user just wants --help so hook resolution errors
+# don't mask argparse's usage output.
+_HELP_REQUESTED = any(a in ("-h", "--help") for a in _EARLY_ARGS)
 
 
 def _find_dev_hooks() -> Path | None:
@@ -49,33 +52,37 @@ def _find_dev_hooks() -> Path | None:
     return None
 
 
-if _USE_DEV_REPO:
-    dev_hooks = _find_dev_hooks()
-    if dev_hooks is None:
-        print("ERROR: --dev-repo passed but no hooks/ directory found walking up from this script",
-              file=sys.stderr)
-        sys.exit(1)
-    sys.path.insert(0, str(dev_hooks))
-else:
-    CACHE_GLOB = os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")
-    cache_hits = sorted(glob.glob(CACHE_GLOB))
-    if not cache_hits:
-        dev_hooks = _find_dev_hooks()
-        if dev_hooks is not None:
-            print(f"NOTE: no plugin cache found; falling back to {dev_hooks}")
-            sys.path.insert(0, str(dev_hooks))
-        else:
-            print("ERROR: cannot locate obsidian-brain hooks/ directory", file=sys.stderr)
-            sys.exit(1)
-    else:
-        sys.path.insert(0, cache_hits[-1])
+vault_index = None  # type: ignore[assignment]
+obsidian_utils = None  # type: ignore[assignment]
 
-try:
-    import vault_index
-    import obsidian_utils
-except ImportError as e:
-    print(f"ERROR: failed to import hooks: {e}", file=sys.stderr)
-    sys.exit(1)
+if not _HELP_REQUESTED:
+    if _USE_DEV_REPO:
+        dev_hooks = _find_dev_hooks()
+        if dev_hooks is None:
+            print("ERROR: --dev-repo passed but no hooks/ directory found walking up from this script",
+                  file=sys.stderr)
+            sys.exit(1)
+        sys.path.insert(0, str(dev_hooks))
+    else:
+        CACHE_GLOB = os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")
+        cache_hits = sorted(glob.glob(CACHE_GLOB))
+        if not cache_hits:
+            dev_hooks = _find_dev_hooks()
+            if dev_hooks is not None:
+                print(f"NOTE: no plugin cache found; falling back to {dev_hooks}")
+                sys.path.insert(0, str(dev_hooks))
+            else:
+                print("ERROR: cannot locate obsidian-brain hooks/ directory", file=sys.stderr)
+                sys.exit(1)
+        else:
+            sys.path.insert(0, cache_hits[-1])
+
+    try:
+        import vault_index  # noqa: F811
+        import obsidian_utils  # noqa: F811
+    except ImportError as e:
+        print(f"ERROR: failed to import hooks: {e}", file=sys.stderr)
+        sys.exit(1)
 
 # --- Reporting helpers ---
 PASS = 0

--- a/scripts/dev-test/validate_phase2.py
+++ b/scripts/dev-test/validate_phase2.py
@@ -16,6 +16,7 @@ Checks performed:
 - _cosine_similarity: symmetric, in [0, 1], identity == 1
 - detect_surprise: edge cases return 0.0, contractions match, out-of-window doesn't
 - assign_to_theme idempotency: calling twice on same note doesn't drift count/centroid
+- reindex invariance: repeat index_note on same note does not drift term_df
 - _delete_note centroid unfold: running-average reverse is algebraically correct
 - check_optional_deps: reports numpy/scipy status
 """
@@ -348,8 +349,76 @@ def test_assign_theme_idempotent(tmpdir: Path) -> None:
         fail_(f"centroid drifted on reassign, max delta={drift:.6f}")
 
 
+def test_reindex_invariance(tmpdir: Path) -> None:
+    section("6. reindex invariance — term_df stays constant across repeated index_note")
+
+    # Seed a vault with one note containing many common-but-low-IDF tokens
+    # that would be pushed out of the top-50 tfidf_vector. If _prior_tokens_for
+    # reads the truncated stored vector, those tokens get re-incremented on
+    # every reindex and term_df.df drifts upward.
+    vault = tmpdir / "vault_reidx"
+    (vault / "claude-sessions").mkdir(parents=True)
+    note = vault / "claude-sessions" / "2026-04-17-reidx-abcd.md"
+    # Deliberately verbose body with > 50 distinct tokens so top-K truncation bites.
+    body_tokens = " ".join(f"common_term_{i:03d}" for i in range(120))
+    note.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-17\n"
+        "project: reidxproj\n"
+        "title: Reindex invariance probe\n"
+        "tags:\n  - claude/session\n"
+        "status: summarized\n"
+        "---\n"
+        f"project retrieval activation {body_tokens}\n",
+        encoding="utf-8",
+    )
+    db_path = str(tmpdir / "reidx.db")
+    vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=db_path)
+
+    def snapshot_df() -> dict[str, int]:
+        conn = sqlite3.connect(db_path)
+        try:
+            return dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        finally:
+            conn.close()
+
+    df_initial = snapshot_df()
+
+    # Bump mtime so index_note does not early-exit as unchanged, and reindex 3x.
+    import os as _os
+    for bump in range(1, 4):
+        st = _os.stat(note)
+        _os.utime(note, (st.st_mtime + bump * 5, st.st_mtime + bump * 5))
+        ok = vault_index.index_note(db_path, str(note))
+        if not ok:
+            fail_(f"index_note returned False on reindex #{bump}")
+            return
+
+    df_final = snapshot_df()
+
+    drifted = {
+        term: (df_initial.get(term, 0), df_final.get(term, 0))
+        for term in set(df_initial) | set(df_final)
+        if df_initial.get(term, 0) != df_final.get(term, 0)
+    }
+
+    if not drifted:
+        pass_(f"term_df stable across 3 reindexes ({len(df_final)} terms)")
+    else:
+        sample = list(drifted.items())[:5]
+        fail_(f"term_df drifted for {len(drifted)} term(s) on reindex; sample: {sample}")
+
+    total_docs = 1
+    over = {t: d for t, d in df_final.items() if d > total_docs}
+    if not over:
+        pass_(f"max(term_df.df) ≤ note_count after reindex loop")
+    else:
+        fail_(f"over-counting after reindex: {list(over.items())[:5]}")
+
+
 def test_delete_unfolds_centroid(tmpdir: Path) -> None:
-    section("6. _delete_note reverses running-average centroid")
+    section("7. _delete_note reverses running-average centroid")
 
     # Build a theme with two members, delete one, verify centroid equals the other member's vec
     vault = tmpdir / "vault2"
@@ -504,6 +573,7 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         tmpdir = Path(tmp)
         test_assign_theme_idempotent(tmpdir)
+        test_reindex_invariance(tmpdir)
         test_delete_unfolds_centroid(tmpdir)
 
     print(f"\n{'═' * 50}")

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -2,7 +2,7 @@
 name: obsidian-setup
 description: "First-run configuration and upgrade for the Obsidian Brain plugin. Sets up vault path, creates folders, copies dashboard templates, configures hookify nudges, and writes config. Idempotent — safe to re-run to pick up new features without overwriting existing config or dashboards. Use when: (1) first time installing obsidian-brain, (2) changing vault path, (3) /obsidian-setup command, (4) upgrading to a new version."
 metadata:
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 # Obsidian Brain Setup
@@ -16,6 +16,8 @@ Configure the obsidian-brain plugin for first use. This skill validates prerequi
 Follow these steps exactly. Do not skip steps or reorder them.
 
 ### Step 1 — Check for existing installation
+
+**Argument handling:** If the user ran `/obsidian-setup --deps`, skip the existing-config detection and jump directly to Step 8.7 (Performance Dependencies). `--deps` re-triggers the dependency prompt regardless of the `optional_deps_prompted` flag in config. After Step 8.7 completes, skip to Step 10 (success message).
 
 Check for existing config:
 
@@ -523,6 +525,110 @@ Parse the JSON output. If successful, store `N = counts["inserted"]` for the suc
 If the command fails (non-zero exit), warn but do not block setup:
 
 > ⚠️ Could not build vault index. Run `/vault-reindex` manually after setup.
+
+### Step 8.7 — Performance Dependencies (optional)
+
+Phase 2 theme clustering can use `numpy` (vectorized TF-IDF) and `scipy` (agglomerative batch clustering) for ~4-5x speedups on large vaults. They are strictly optional — every feature works on pure-Python stdlib fallbacks.
+
+**Idempotent detection.** Load the current config + installed status:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 -c '
+import sys, os, json
+import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from obsidian_utils import check_optional_deps, load_config
+cfg = load_config()
+status = check_optional_deps()
+print("NUMPY=" + ("1" if status["numpy"] else "0"))
+print("SCIPY=" + ("1" if status["scipy"] else "0"))
+print("PROMPTED=" + ("1" if cfg.get("optional_deps_prompted") else "0"))
+print("DECLINED=" + ",".join(cfg.get("optional_deps_declined", [])))
+'
+```
+
+Parse each line as `KEY=VALUE`.
+
+**Decision tree:**
+
+1. If `NUMPY=1` and `SCIPY=1` → both installed; skip the prompt entirely. Log one line `[setup] numpy + scipy available — theme clustering will use fast paths.` and continue to Step 9.
+2. If `PROMPTED=1` AND every missing package appears in `DECLINED` AND this run was NOT invoked with `--deps` → user already declined; skip the prompt silently. Continue to Step 9.
+3. Otherwise → show the prompt below.
+
+**Prompt the user** using AskUserQuestion:
+
+> Optional performance dependencies for Phase 2 theme clustering:
+>
+>   numpy: [installed / not installed]
+>   scipy: [installed / not installed]
+>
+> These accelerate batch clustering and TF-IDF math (numpy ~5x, scipy ~4x). Without them, everything still works via pure-Python stdlib fallbacks — daily use is unaffected; only bulk /consolidate runs are slower at very large vault sizes.
+>
+> 1. **Install missing packages** (runs `python3 -m pip install --user <missing>`)
+> 2. **Skip** — remember my choice (won't ask again; re-trigger anytime with `/obsidian-setup --deps`)
+> 3. **Not now** — ask again next time
+
+**Apply the choice:**
+
+- **Install:** run `python3 -m pip install --user` for every missing package. Report success/failure for each. After install, update config:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 -c '
+import sys, os, json
+import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from pathlib import Path
+
+cfg_path = Path.home() / ".claude" / "obsidian-brain-config.json"
+try:
+    cfg = json.loads(cfg_path.read_text())
+except FileNotFoundError:
+    cfg = {}
+cfg["optional_deps_prompted"] = True
+declined = set(cfg.get("optional_deps_declined", []))
+for pkg in ("numpy", "scipy"):
+    try:
+        __import__(pkg)
+        declined.discard(pkg)
+    except ImportError:
+        pass
+cfg["optional_deps_declined"] = sorted(declined)
+cfg_path.write_text(json.dumps(cfg, indent=2))
+os.chmod(cfg_path, 0o600)
+print("OK")
+'
+```
+
+If pip itself is missing or the install fails (restricted environments, e.g. Homebrew-managed Python), print the failure and continue — all features still work.
+
+- **Skip:** write both flags with every missing package added to `optional_deps_declined`:
+
+```bash
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+python3 - <<'PY'
+import json, os
+from pathlib import Path
+cfg_path = Path.home() / ".claude" / "obsidian-brain-config.json"
+try:
+    cfg = json.loads(cfg_path.read_text())
+except FileNotFoundError:
+    cfg = {}
+cfg["optional_deps_prompted"] = True
+missing = []
+for pkg in ("numpy", "scipy"):
+    try:
+        __import__(pkg)
+    except ImportError:
+        missing.append(pkg)
+declined = sorted(set(cfg.get("optional_deps_declined", [])) | set(missing))
+cfg["optional_deps_declined"] = declined
+cfg_path.write_text(json.dumps(cfg, indent=2))
+os.chmod(cfg_path, 0o600)
+print("OK")
+PY
+```
+
+- **Not now:** write neither flag. The next `/obsidian-setup` run will re-prompt.
 
 ### Step 9 — Configure claudeception nudge (idempotent)
 

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -58,6 +58,8 @@ If **upgrade**: store `MODE=upgrade`. Store `VAULT_PATH` from the existing confi
 - Step 6 (Install dashboards): only write dashboard files that do NOT already exist (`test -f` before each write)
 - Step 7 (Write config): SKIP entirely — preserve existing config
 - Step 8 (Verify vault access): runs normally
+- Step 8.5 (Build vault index): runs normally (idempotent ensure_index call)
+- Step 8.7 (Performance Dependencies): runs normally — has its own idempotency check via `optional_deps_prompted`/`optional_deps_declined` config fields; users with declined deps are NOT re-prompted unless they explicitly run `/obsidian-setup --deps`
 - Step 9 (Configure claudeception nudge): runs normally (has its own idempotency check)
 - Step 10 (Print success message): show upgrade-specific message
 
@@ -575,7 +577,7 @@ Parse each line as `KEY=VALUE`.
 ```bash
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
-import sys, os, json
+import sys, os, json, tempfile
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
 from pathlib import Path
 
@@ -593,8 +595,20 @@ for pkg in ("numpy", "scipy"):
     except ImportError:
         pass
 cfg["optional_deps_declined"] = sorted(declined)
-cfg_path.write_text(json.dumps(cfg, indent=2))
-os.chmod(cfg_path, 0o600)
+fd, tmp_path = tempfile.mkstemp(prefix=".obsidian-brain-config-", suffix=".json.tmp", dir=os.path.dirname(cfg_path))
+try:
+    with os.fdopen(fd, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.chmod(tmp_path, 0o600)
+    os.replace(tmp_path, cfg_path)
+except Exception:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
 print("OK")
 '
 ```
@@ -606,7 +620,7 @@ If pip itself is missing or the install fails (restricted environments, e.g. Hom
 ```bash
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 - <<'PY'
-import json, os
+import json, os, tempfile
 from pathlib import Path
 cfg_path = Path.home() / ".claude" / "obsidian-brain-config.json"
 try:
@@ -622,8 +636,20 @@ for pkg in ("numpy", "scipy"):
         missing.append(pkg)
 declined = sorted(set(cfg.get("optional_deps_declined", [])) | set(missing))
 cfg["optional_deps_declined"] = declined
-cfg_path.write_text(json.dumps(cfg, indent=2))
-os.chmod(cfg_path, 0o600)
+fd, tmp_path = tempfile.mkstemp(prefix=".obsidian-brain-config-", suffix=".json.tmp", dir=os.path.dirname(cfg_path))
+try:
+    with os.fdopen(fd, "w") as f:
+        json.dump(cfg, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.chmod(tmp_path, 0o600)
+    os.replace(tmp_path, cfg_path)
+except Exception:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
 print("OK")
 PY
 ```

--- a/tests/test_batch_access_logging.py
+++ b/tests/test_batch_access_logging.py
@@ -1,0 +1,57 @@
+"""Verifies batch access logging: one connection, one commit per search call."""
+
+import sqlite3
+
+import pytest
+
+import vault_index
+
+
+@pytest.fixture
+def indexed_vault(tmp_vault):
+    """Vault with three indexed notes matching the query 'foo'."""
+    sessions = tmp_vault / "claude-sessions"
+    for i, slug in enumerate(["a", "b", "c"]):
+        (sessions / f"2026-04-16-proj-{slug}.md").write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-16\n"
+            "project: proj\n"
+            f"title: Note {slug}\n"
+            "tags:\n  - claude/session\n"
+            "status: summarized\n"
+            "---\n"
+            "foo bar baz\n",
+            encoding="utf-8",
+        )
+    db_path = str(tmp_vault / "test.db")
+    vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+    return db_path
+
+
+def test_search_vault_logs_all_results_once(indexed_vault):
+    """One search returning N results must insert exactly N rows into access_log."""
+    results = vault_index.search_vault(indexed_vault, "foo", project="proj", limit=10)
+    assert len(results) >= 1, "Query should match at least one note"
+
+    conn = sqlite3.connect(indexed_vault)
+    count = conn.execute("SELECT COUNT(*) FROM access_log").fetchone()[0]
+    conn.close()
+    assert count == len(results)
+
+
+def test_search_vault_uses_single_connection(indexed_vault, monkeypatch):
+    """log_access should NOT be called in a loop — batch insert only."""
+    call_count = {"n": 0}
+    original = vault_index.log_access
+
+    def counting(*args, **kwargs):
+        call_count["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(vault_index, "log_access", counting)
+    vault_index.search_vault(indexed_vault, "foo", project="proj", limit=10)
+    assert call_count["n"] == 0, (
+        f"log_access was called {call_count['n']} times — "
+        "search_vault should use batch insert on its own connection instead."
+    )

--- a/tests/test_batch_access_logging.py
+++ b/tests/test_batch_access_logging.py
@@ -29,8 +29,61 @@ def indexed_vault(tmp_vault):
     return db_path
 
 
-def test_search_vault_logs_all_results_once(indexed_vault):
-    """One search returning N results must insert exactly N rows into access_log."""
+@pytest.fixture
+def indexed_vault_with_related(tmp_vault):
+    """Vault with an anchor session note and a related insight sharing a topic tag.
+
+    Both notes carry ``claude/topic/retrieval`` so ``query_related_notes``
+    Layer 2 (tag overlap) returns the insight when queried with the anchor's
+    tags.
+    """
+    sessions = tmp_vault / "claude-sessions"
+    insights = tmp_vault / "claude-insights"
+
+    anchor_path = sessions / "2026-04-16-proj-anchor.md"
+    anchor_path.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-16\n"
+        "session_id: anchor-session-id\n"
+        "project: proj\n"
+        "title: Anchor session\n"
+        "tags:\n"
+        "  - claude/session\n"
+        "  - claude/topic/retrieval\n"
+        "status: summarized\n"
+        "---\n"
+        "Anchor session body discussing retrieval.\n",
+        encoding="utf-8",
+    )
+
+    insight_path = insights / "2026-04-16-retrieval-insight.md"
+    insight_path.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "date: 2026-04-16\n"
+        "project: proj\n"
+        "title: Retrieval insight\n"
+        "tags:\n"
+        "  - claude/insight\n"
+        "  - claude/topic/retrieval\n"
+        "status: summarized\n"
+        "---\n"
+        "Insight about retrieval systems.\n",
+        encoding="utf-8",
+    )
+
+    db_path = str(tmp_vault / "test.db")
+    vault_index.ensure_index(
+        str(tmp_vault),
+        ["claude-sessions", "claude-insights"],
+        db_path=db_path,
+    )
+    return db_path, str(anchor_path)
+
+
+def test_search_vault_inserts_one_row_per_result(indexed_vault):
+    """Smoke test: one search returning N results must insert exactly N rows."""
     results = vault_index.search_vault(indexed_vault, "foo", project="proj", limit=10)
     assert len(results) >= 1, "Query should match at least one note"
 
@@ -54,4 +107,57 @@ def test_search_vault_uses_single_connection(indexed_vault, monkeypatch):
     assert call_count["n"] == 0, (
         f"log_access was called {call_count['n']} times — "
         "search_vault should use batch insert on its own connection instead."
+    )
+
+
+def test_query_related_notes_uses_batch_logging(
+    indexed_vault_with_related, monkeypatch
+):
+    """query_related_notes must go through the batch path, not log_access loop.
+
+    Asserts (a) access_log row count == returned result count,
+    (b) ``log_access`` is never called (monkeypatch, 0 calls),
+    (c) inserted rows have ``context_type == 'related'``.
+    """
+    db_path, _anchor_path = indexed_vault_with_related
+
+    call_count = {"n": 0}
+    original = vault_index.log_access
+
+    def counting(*args, **kwargs):
+        call_count["n"] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(vault_index, "log_access", counting)
+
+    results = vault_index.query_related_notes(
+        db_path,
+        project="proj",
+        session_ids=[],
+        session_tags=["claude/topic/retrieval"],
+        session_summary="",
+        limit=20,
+    )
+    assert len(results) >= 1, (
+        "Layer 2 (tag overlap) should return at least the retrieval insight"
+    )
+
+    assert call_count["n"] == 0, (
+        f"log_access was called {call_count['n']} times — "
+        "query_related_notes should use batch insert instead."
+    )
+
+    conn = sqlite3.connect(db_path)
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM access_log").fetchone()[0]
+        related_count = conn.execute(
+            "SELECT COUNT(*) FROM access_log WHERE context_type = 'related'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert total == len(results)
+    assert related_count == len(results), (
+        f"Expected all {len(results)} rows to have context_type='related', "
+        f"got {related_count}"
     )

--- a/tests/test_optional_deps.py
+++ b/tests/test_optional_deps.py
@@ -72,3 +72,38 @@ class TestConfigDefaults:
         loaded = obsidian_utils.load_config()
         assert loaded["optional_deps_prompted"] is False
         assert loaded["optional_deps_declined"] == []
+
+    def test_mutating_list_default_does_not_leak_across_loads(
+        self, tmp_path, monkeypatch
+    ):
+        """Mutating config['optional_deps_declined'] must not leak into _DEFAULTS.
+
+        Regression: dict(_DEFAULTS) is a shallow copy, so the same list
+        object was shared across every load_config() return value and the
+        _DEFAULTS module attribute. An in-place .append() in one caller
+        would silently surface in the next caller's "default".
+        """
+        cfg = {"vault_path": "/tmp/v"}
+        cfg_path = tmp_path / "obsidian-brain-config.json"
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+        monkeypatch.setattr(obsidian_utils, "_CONFIG_PATH", cfg_path)
+        monkeypatch.setattr(
+            obsidian_utils, "_get_session_id_fast", lambda: "leak-test-session",
+        )
+        obsidian_utils.cache_set("leak-test-session", "config", None)
+
+        first = obsidian_utils.load_config()
+        first["optional_deps_declined"].append("poisoned-entry")
+
+        # Bust the cache so the second call rebuilds from _DEFAULTS + disk.
+        obsidian_utils.cache_set("leak-test-session", "config", None)
+        second = obsidian_utils.load_config()
+
+        assert second["optional_deps_declined"] == [], (
+            "list default leaked across load_config() calls — "
+            f"got {second['optional_deps_declined']!r}, _DEFAULTS "
+            "is being shared (shallow copy regressed)"
+        )
+        assert obsidian_utils._DEFAULTS["optional_deps_declined"] == [], (
+            "mutation from load_config return value leaked into _DEFAULTS"
+        )

--- a/tests/test_optional_deps.py
+++ b/tests/test_optional_deps.py
@@ -1,6 +1,5 @@
 """Tests for check_optional_deps() and the Phase 2 optional-deps config fields."""
 
-import importlib
 import json
 
 import pytest

--- a/tests/test_optional_deps.py
+++ b/tests/test_optional_deps.py
@@ -33,6 +33,26 @@ class TestCheckOptionalDeps:
         result = obsidian_utils.check_optional_deps()
         assert result == {"numpy": False, "scipy": False}
 
+    def test_non_import_error_reports_false(self, monkeypatch):
+        # Compiled optional deps (numpy/scipy wheels) can raise OSError when
+        # their shared libraries are missing, ValueError on ABI mismatch, or
+        # RuntimeError for other binary incompat. These must be treated as
+        # "unavailable" rather than bubbling out of setup.
+        import importlib as _importlib
+
+        real_import_module = _importlib.import_module
+
+        def fake_import_module(name, *args, **kwargs):
+            if name == "numpy":
+                raise OSError("libopenblas.0.dylib not loaded")
+            if name == "scipy":
+                raise ValueError("numpy.dtype size changed, binary incompat")
+            return real_import_module(name, *args, **kwargs)
+
+        monkeypatch.setattr(_importlib, "import_module", fake_import_module)
+        result = obsidian_utils.check_optional_deps()
+        assert result == {"numpy": False, "scipy": False}
+
 
 class TestConfigDefaults:
     def test_optional_deps_fields_present_in_defaults(self):

--- a/tests/test_optional_deps.py
+++ b/tests/test_optional_deps.py
@@ -1,0 +1,55 @@
+"""Tests for check_optional_deps() and the Phase 2 optional-deps config fields."""
+
+import importlib
+import json
+
+import pytest
+
+import obsidian_utils
+
+
+class TestCheckOptionalDeps:
+    def test_reports_numpy_and_scipy_status(self):
+        result = obsidian_utils.check_optional_deps()
+        assert set(result.keys()) == {"numpy", "scipy"}
+        for v in result.values():
+            assert isinstance(v, bool)
+
+    def test_missing_package_reports_false(self, monkeypatch):
+        # Mock importlib.import_module at the source (obsidian_utils imports
+        # it lazily inside check_optional_deps). We patch the importlib
+        # module's import_module function to raise ImportError for the
+        # target packages.
+        import importlib as _importlib
+
+        real_import_module = _importlib.import_module
+
+        def fake_import_module(name, *args, **kwargs):
+            if name in {"numpy", "scipy"}:
+                raise ImportError(f"mocked ImportError for {name}")
+            return real_import_module(name, *args, **kwargs)
+
+        monkeypatch.setattr(_importlib, "import_module", fake_import_module)
+        result = obsidian_utils.check_optional_deps()
+        assert result == {"numpy": False, "scipy": False}
+
+
+class TestConfigDefaults:
+    def test_optional_deps_fields_present_in_defaults(self):
+        defaults = obsidian_utils._DEFAULTS
+        assert defaults.get("optional_deps_prompted") is False
+        assert defaults.get("optional_deps_declined") == []
+
+    def test_load_config_fills_defaults_when_missing(self, tmp_path, monkeypatch):
+        cfg = {"vault_path": "/tmp/v"}
+        cfg_path = tmp_path / "obsidian-brain-config.json"
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+        monkeypatch.setattr(obsidian_utils, "_CONFIG_PATH", cfg_path)
+        monkeypatch.setattr(
+            obsidian_utils, "_get_session_id_fast", lambda: "test-session-id",
+        )
+        obsidian_utils.cache_set("test-session-id", "config", None)
+
+        loaded = obsidian_utils.load_config()
+        assert loaded["optional_deps_prompted"] is False
+        assert loaded["optional_deps_declined"] == []

--- a/tests/test_surprise.py
+++ b/tests/test_surprise.py
@@ -44,6 +44,20 @@ class TestDetectSurprise:
         score = vault_index.detect_surprise(text, note_vec, centroid)
         assert 0.0 <= score <= 1.0
 
+    def test_expanded_contractions_registered(self):
+        """won't/isn't/wasn't/didn't/couldn't/shouldn't must all register."""
+        # Each phrase puts a distinct contraction within window of "retrieval"
+        for contraction in ("won\u2019t", "isn't", "wasn't", "didn't",
+                            "couldn't", "shouldn't", "wouldn't", "doesn't"):
+            text = f"{contraction} trust retrieval scoring here"
+            score = vault_index.detect_surprise(
+                text, {"retrieval": 1.0}, {"retrieval": 1.0},
+            )
+            assert score > 0, (
+                f"contraction {contraction!r} did not register as a "
+                "negation — _NEGATION_TERMS may be missing the bare form"
+            )
+
     def test_contractions_match_negation_terms(self):
         """Apostrophe'd negations ("don't"/"can't") must match the negation set.
 

--- a/tests/test_surprise.py
+++ b/tests/test_surprise.py
@@ -1,0 +1,45 @@
+"""Tests for surprise detection (Phase 2)."""
+
+import pytest
+
+import vault_index
+
+
+class TestDetectSurprise:
+    def test_negated_shared_term_scores_above_threshold(self):
+        text = "retrieval scoring is not reliable at 10k notes. activation does not help."
+        centroid = {"retrieval": 1.0, "scoring": 1.0, "activation": 1.0}
+        note_vec = {"retrieval": 1.0, "scoring": 1.0, "activation": 1.0}
+        score = vault_index.detect_surprise(text, note_vec, centroid)
+        assert score > 0.5
+
+    def test_agreement_text_scores_zero(self):
+        text = "retrieval scoring is reliable. activation is useful."
+        centroid = {"retrieval": 1.0, "scoring": 1.0, "activation": 1.0}
+        note_vec = {"retrieval": 1.0, "scoring": 1.0, "activation": 1.0}
+        score = vault_index.detect_surprise(text, note_vec, centroid)
+        assert score == 0.0
+
+    def test_no_shared_terms_returns_zero(self):
+        text = "retrieval scoring is not reliable"
+        centroid = {"pasta": 1.0, "garlic": 1.0}
+        note_vec = {"retrieval": 1.0, "scoring": 1.0}
+        score = vault_index.detect_surprise(text, note_vec, centroid)
+        assert score == 0.0
+
+    def test_negation_outside_window_does_not_count(self):
+        words = ["not"] + ["filler"] * 30 + ["retrieval"]
+        text = " ".join(words)
+        score = vault_index.detect_surprise(
+            text, {"retrieval": 1.0}, {"retrieval": 1.0},
+        )
+        assert score == 0.0
+
+    def test_score_is_clamped_to_unit_interval(self):
+        text = "retrieval never scoring never activation never importance never"
+        centroid = {
+            "retrieval": 1.0, "scoring": 1.0, "activation": 1.0, "importance": 1.0,
+        }
+        note_vec = dict(centroid)
+        score = vault_index.detect_surprise(text, note_vec, centroid)
+        assert 0.0 <= score <= 1.0

--- a/tests/test_surprise.py
+++ b/tests/test_surprise.py
@@ -43,3 +43,32 @@ class TestDetectSurprise:
         note_vec = dict(centroid)
         score = vault_index.detect_surprise(text, note_vec, centroid)
         assert 0.0 <= score <= 1.0
+
+    def test_contractions_match_negation_terms(self):
+        """Apostrophe'd negations ("don't"/"can't") must match the negation set.
+
+        Regression: _TOKEN_RE = [a-z0-9]+ strips apostrophes, so "don't"
+        tokenized to "don" and "t" — neither of which appeared in
+        _NEGATION_TERMS. Apostrophed negations in note text were silently
+        ignored by the surprise score. detect_surprise now normalizes
+        apostrophes (including smart quotes) out before tokenization.
+        """
+        # Straight apostrophe
+        text_straight = "don't trust retrieval scoring here"
+        score_straight = vault_index.detect_surprise(
+            text_straight, {"retrieval": 1.0}, {"retrieval": 1.0},
+        )
+        assert score_straight > 0, (
+            "straight-apostrophe negation 'don't' did not register — "
+            "apostrophe normalization missing"
+        )
+
+        # Smart quote (U+2019) — common from copy/pasted prose
+        text_smart = "can\u2019t trust retrieval scoring here"
+        score_smart = vault_index.detect_surprise(
+            text_smart, {"retrieval": 1.0}, {"retrieval": 1.0},
+        )
+        assert score_smart > 0, (
+            "smart-apostrophe negation 'can\u2019t' did not register — "
+            "smart-quote normalization missing"
+        )

--- a/tests/test_sync_path_containment.py
+++ b/tests/test_sync_path_containment.py
@@ -1,0 +1,63 @@
+"""Verifies _sync() does not delete rows from sibling folders with a shared prefix."""
+
+import sqlite3
+
+import pytest
+
+import vault_index
+
+
+def test_sync_does_not_delete_sibling_prefix_folder(tmp_vault):
+    """A file in 'claude-sessions-archive' must not be considered 'in claude-sessions'."""
+    sessions = tmp_vault / "claude-sessions"
+    archive = tmp_vault / "claude-sessions-archive"
+    archive.mkdir()
+
+    # Archived note present on disk, in a folder NOT scanned by this sync call.
+    archived_note = archive / "2026-04-01-old-proj-aaaa.md"
+    archived_note.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-01\n"
+        "project: old-proj\n"
+        "title: Archived\n"
+        "tags:\n  - claude/session\n"
+        "status: summarized\n"
+        "---\n"
+        "body\n",
+        encoding="utf-8",
+    )
+
+    db_path = str(tmp_vault / "test.db")
+
+    # First sync indexes BOTH folders (so the archived note is in the DB).
+    vault_index.ensure_index(
+        str(tmp_vault), ["claude-sessions", "claude-sessions-archive"],
+        db_path=db_path,
+    )
+
+    conn = sqlite3.connect(db_path)
+    before = conn.execute(
+        "SELECT COUNT(*) FROM notes WHERE path LIKE ?",
+        (f"%{archive}%",),
+    ).fetchone()[0]
+    conn.close()
+    assert before == 1, "Archived note should be indexed after the first sync"
+
+    # Second sync only asks for 'claude-sessions'. The bug is that startswith()
+    # considers the archive folder to live inside claude-sessions (shared prefix)
+    # and deletes its row.
+    vault_index.ensure_index(
+        str(tmp_vault), ["claude-sessions"], db_path=db_path,
+    )
+
+    conn = sqlite3.connect(db_path)
+    after = conn.execute(
+        "SELECT COUNT(*) FROM notes WHERE path LIKE ?",
+        (f"%{archive}%",),
+    ).fetchone()[0]
+    conn.close()
+    assert after == 1, (
+        "Archived note row must survive a partial-folder sync — "
+        "claude-sessions-archive is NOT inside claude-sessions."
+    )

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -96,3 +96,48 @@ class TestCosineSimilarity:
         v1 = {"a": 3.0, "b": 4.0}
         v2 = {"b": 4.0, "a": 3.0}
         assert vault_index._cosine_similarity(v1, v2) == pytest.approx(1.0)
+
+
+class TestUpdateTermDf:
+    def test_insert_increments_fresh_terms(self, tmp_vault):
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+        conn = vault_index._connect(db_path)
+        try:
+            vault_index._update_term_df(
+                conn, old_terms=set(), new_terms={"retrieval", "scoring"},
+            )
+            rows = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        finally:
+            conn.close()
+        assert rows == {"retrieval": 1, "scoring": 1}
+
+    def test_replace_adjusts_df(self, tmp_vault):
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+        conn = vault_index._connect(db_path)
+        try:
+            vault_index._update_term_df(
+                conn, old_terms=set(), new_terms={"alpha", "beta"},
+            )
+            vault_index._update_term_df(
+                conn, old_terms={"alpha", "beta"}, new_terms={"alpha", "gamma"},
+            )
+            rows = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        finally:
+            conn.close()
+        assert rows.get("alpha") == 1
+        assert rows.get("gamma") == 1
+        assert rows.get("beta", 0) == 0
+
+    def test_delete_purges_terms_when_df_hits_zero(self, tmp_vault):
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+        conn = vault_index._connect(db_path)
+        try:
+            vault_index._update_term_df(conn, old_terms=set(), new_terms={"solo"})
+            vault_index._update_term_df(conn, old_terms={"solo"}, new_terms=set())
+            rows = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        finally:
+            conn.close()
+        assert "solo" not in rows

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -70,3 +70,29 @@ class TestComputeTfidf:
             tokens, {"alpha": 1}, total_docs=1, top_k=5,
         )
         assert vec["alpha"] > 0
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors_score_one(self):
+        v = {"a": 2.0, "b": 1.0}
+        assert vault_index._cosine_similarity(v, dict(v)) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors_score_zero(self):
+        v1 = {"a": 1.0, "b": 1.0}
+        v2 = {"c": 1.0, "d": 1.0}
+        assert vault_index._cosine_similarity(v1, v2) == 0.0
+
+    def test_partial_overlap(self):
+        v1 = {"a": 1.0, "b": 1.0}
+        v2 = {"a": 1.0, "c": 1.0}
+        assert vault_index._cosine_similarity(v1, v2) == pytest.approx(0.5)
+
+    def test_empty_vector_returns_zero(self):
+        assert vault_index._cosine_similarity({}, {"a": 1.0}) == 0.0
+        assert vault_index._cosine_similarity({"a": 1.0}, {}) == 0.0
+        assert vault_index._cosine_similarity({}, {}) == 0.0
+
+    def test_order_independent(self):
+        v1 = {"a": 3.0, "b": 4.0}
+        v2 = {"b": 4.0, "a": 3.0}
+        assert vault_index._cosine_similarity(v1, v2) == pytest.approx(1.0)

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -1,0 +1,35 @@
+"""Tests for TF-IDF primitives: tokenization, vector math, cosine similarity."""
+
+import json
+import math
+
+import pytest
+
+import vault_index
+
+
+class TestTokenize:
+    def test_strips_punctuation_and_lowercases(self):
+        toks = vault_index._tokenize_for_tfidf("Hello, World! Python-3.9.")
+        assert toks == ["hello", "world", "python", "3", "9"]
+
+    def test_drops_stopwords(self):
+        toks = vault_index._tokenize_for_tfidf("the quick brown fox is here")
+        assert "the" not in toks
+        assert "is" not in toks
+        assert "here" not in toks
+        assert "quick" in toks
+        assert "brown" in toks
+
+    def test_drops_single_char_tokens(self):
+        toks = vault_index._tokenize_for_tfidf("a b c debugging")
+        assert toks == ["debugging"]
+
+    def test_empty_input(self):
+        assert vault_index._tokenize_for_tfidf("") == []
+        assert vault_index._tokenize_for_tfidf("the a an") == []
+
+    def test_is_deterministic_and_preserves_order(self):
+        text = "retrieval scoring retrieval activation scoring"
+        toks = vault_index._tokenize_for_tfidf(text)
+        assert toks == ["retrieval", "scoring", "retrieval", "activation", "scoring"]

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -2,6 +2,7 @@
 
 import json
 import math
+import sqlite3
 
 import pytest
 
@@ -141,9 +142,6 @@ class TestUpdateTermDf:
         finally:
             conn.close()
         assert "solo" not in rows
-
-
-import sqlite3
 
 
 class TestUpsertStoresTfidf:

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -33,3 +33,40 @@ class TestTokenize:
         text = "retrieval scoring retrieval activation scoring"
         toks = vault_index._tokenize_for_tfidf(text)
         assert toks == ["retrieval", "scoring", "retrieval", "activation", "scoring"]
+
+
+class TestComputeTfidf:
+    def test_sparse_vector_top_k(self):
+        """TF×IDF keeps only the top_k heaviest terms."""
+        tokens = ["retrieval"] * 5 + ["scoring"] * 3 + ["noise"] * 1
+        df = {"retrieval": 1, "scoring": 2, "noise": 50}
+        total_docs = 100
+        vec = vault_index._compute_tfidf_vector(tokens, df, total_docs, top_k=2)
+        assert set(vec.keys()) == {"retrieval", "scoring"}
+        # retrieval has the lowest df → highest IDF AND highest TF → should win
+        assert vec["retrieval"] > vec["scoring"] > 0
+
+    def test_rare_term_outranks_common_term_at_equal_tf(self):
+        tokens = ["obsidian", "python"]
+        df = {"obsidian": 1, "python": 80}
+        total_docs = 100
+        vec = vault_index._compute_tfidf_vector(tokens, df, total_docs, top_k=2)
+        assert vec["obsidian"] > vec["python"]
+
+    def test_empty_tokens_returns_empty_dict(self):
+        assert vault_index._compute_tfidf_vector([], {}, 10) == {}
+
+    def test_missing_df_treats_term_as_brand_new(self):
+        """A term absent from term_df should score as if df=0 (max IDF)."""
+        tokens = ["mystery"]
+        vec = vault_index._compute_tfidf_vector(tokens, {}, total_docs=100, top_k=5)
+        assert "mystery" in vec
+        assert vec["mystery"] > 0
+
+    def test_single_term_single_doc_corpus(self):
+        """Smoothing must keep IDF strictly positive even when df = total_docs."""
+        tokens = ["alpha"]
+        vec = vault_index._compute_tfidf_vector(
+            tokens, {"alpha": 1}, total_docs=1, top_k=5,
+        )
+        assert vec["alpha"] > 0

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -141,3 +141,136 @@ class TestUpdateTermDf:
         finally:
             conn.close()
         assert "solo" not in rows
+
+
+import sqlite3
+
+
+class TestUpsertStoresTfidf:
+    def test_first_insert_writes_tfidf_vector(self, tmp_vault):
+        """After ensure_index indexes a real note, its row carries a non-empty vector."""
+        (tmp_vault / "claude-sessions" / "2026-04-16-proj-alpha.md").write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-16\n"
+            "project: proj\n"
+            "title: Retrieval scoring research\n"
+            "tags:\n  - claude/session\n"
+            "status: summarized\n"
+            "---\n"
+            "Retrieval scoring with activation and importance signals.\n",
+            encoding="utf-8",
+        )
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+        conn = sqlite3.connect(db_path)
+        row = conn.execute("SELECT tfidf_vector FROM notes").fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0], "tfidf_vector should be non-empty JSON"
+        vec = json.loads(row[0])
+        assert isinstance(vec, dict) and len(vec) > 0
+        # Corpus-wide term 'retrieval' or 'scoring' should be present
+        assert any("retriev" in k or "scor" in k for k in vec)
+
+    def test_term_df_reflects_indexed_corpus(self, tmp_vault):
+        for slug, body in [("a", "alpha beta"), ("b", "alpha gamma")]:
+            (tmp_vault / "claude-sessions" / f"2026-04-16-proj-{slug}.md").write_text(
+                "---\n"
+                "type: claude-session\n"
+                "date: 2026-04-16\n"
+                "project: proj\n"
+                f"title: Doc {slug}\n"
+                "tags:\n  - claude/session\n"
+                "status: summarized\n"
+                "---\n"
+                f"{body}\n",
+                encoding="utf-8",
+            )
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+        conn = sqlite3.connect(db_path)
+        df = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        conn.close()
+        assert df.get("alpha") == 2
+        assert df.get("beta") == 1
+        assert df.get("gamma") == 1
+
+    def test_delete_removes_from_term_df(self, tmp_vault):
+        """Deleting a note decrements term_df and prunes zeros."""
+        note = tmp_vault / "claude-sessions" / "2026-04-16-proj-solo.md"
+        note.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-16\n"
+            "project: proj\n"
+            "title: Solo\n"
+            "tags:\n  - claude/session\n"
+            "status: summarized\n"
+            "---\n"
+            "uniquewordalpha uniquewordbeta\n",
+            encoding="utf-8",
+        )
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+        # Sanity: terms exist
+        conn = sqlite3.connect(db_path)
+        df = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        assert df.get("uniquewordalpha") == 1
+        conn.close()
+
+        # Remove the file and re-sync (triggers _delete_note)
+        note.unlink()
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        df_after = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        theme_rows = conn.execute(
+            "SELECT COUNT(*) FROM theme_members WHERE note_path = ?",
+            (str(note),),
+        ).fetchone()[0]
+        conn.close()
+        assert "uniquewordalpha" not in df_after
+        assert "uniquewordbeta" not in df_after
+        assert theme_rows == 0
+
+    def test_update_adjusts_term_df_symmetric_diff(self, tmp_vault):
+        """Changing a note's body decrements removed terms and increments added ones."""
+        note = tmp_vault / "claude-sessions" / "2026-04-16-proj-evo.md"
+        note.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-16\n"
+            "project: proj\n"
+            "title: Evolving\n"
+            "tags:\n  - claude/session\n"
+            "status: summarized\n"
+            "---\n"
+            "uniquetermone uniquetermtwo\n",
+            encoding="utf-8",
+        )
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        import time
+        time.sleep(0.01)  # ensure mtime changes on fast filesystems
+        note.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-16\n"
+            "project: proj\n"
+            "title: Evolving\n"
+            "tags:\n  - claude/session\n"
+            "status: summarized\n"
+            "---\n"
+            "uniquetermone uniquetermthree\n",
+            encoding="utf-8",
+        )
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        df = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        conn.close()
+        assert df.get("uniquetermone") == 1
+        assert df.get("uniquetermthree") == 1
+        assert df.get("uniquetermtwo", 0) == 0

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -252,8 +252,12 @@ class TestUpsertStoresTfidf:
         db_path = str(tmp_vault / "test.db")
         vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
 
-        import time
-        time.sleep(0.01)  # ensure mtime changes on fast filesystems
+        # Capture the current mtime so we can bump it deterministically.
+        # Several filesystems (e.g. HFS+, some network mounts) have 1s mtime
+        # resolution; time.sleep(0.01) can leave mtime unchanged and cause
+        # _sync() to skip the reindex, flaking the test.
+        import os
+        prev_mtime = note.stat().st_mtime
         note.write_text(
             "---\n"
             "type: claude-session\n"
@@ -266,6 +270,8 @@ class TestUpsertStoresTfidf:
             "uniquetermone uniquetermthree\n",
             encoding="utf-8",
         )
+        # Force mtime forward by 2 seconds regardless of filesystem resolution.
+        os.utime(note, (prev_mtime + 2, prev_mtime + 2))
         vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
 
         conn = sqlite3.connect(db_path)

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -278,3 +278,55 @@ class TestUpsertStoresTfidf:
         assert df.get("uniquetermone") == 1
         assert df.get("uniquetermthree") == 1
         assert df.get("uniquetermtwo", 0) == 0
+
+    def test_reindex_does_not_drift_term_df(self, tmp_vault):
+        """Reindexing the same note must not bump term_df for any term.
+
+        Regression test for the top-K asymmetry bug where common-but-low-IDF
+        terms (pushed out of the stored top-50 tfidf_vector) were
+        incremented on every reindex because _prior_terms_for read the
+        truncated vector instead of the full token set.
+        """
+        import os
+
+        note = tmp_vault / "claude-sessions" / "2026-04-16-proj-reidx.md"
+        # > 50 distinct tokens so the stored vector is meaningfully truncated.
+        body_tokens = " ".join(f"ctoken{i:03d}" for i in range(80))
+        note.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-16\n"
+            "project: proj\n"
+            "title: Reindex probe\n"
+            "tags:\n  - claude/session\n"
+            "status: summarized\n"
+            "---\n"
+            f"project retrieval activation {body_tokens}\n",
+            encoding="utf-8",
+        )
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        df_initial = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        conn.close()
+
+        # Reindex the same note 3× via index_note (the hot path) with mtime bumps.
+        for bump in range(1, 4):
+            st = os.stat(note)
+            os.utime(note, (st.st_mtime + bump * 5, st.st_mtime + bump * 5))
+            ok = vault_index.index_note(db_path, str(note))
+            assert ok, f"index_note returned False on reindex #{bump}"
+
+        conn = sqlite3.connect(db_path)
+        df_final = dict(conn.execute("SELECT term, df FROM term_df").fetchall())
+        conn.close()
+
+        assert df_final == df_initial, (
+            f"term_df drifted across reindexes; "
+            f"{len(set(df_final) ^ set(df_initial))} term(s) added/removed, "
+            f"{sum(1 for k in df_final if df_final[k] != df_initial.get(k))} changed"
+        )
+        # No term can exceed the total note count.
+        for term, df in df_final.items():
+            assert df <= 1, f"term {term!r} over-counted: df={df} > note_count=1"

--- a/tests/test_tfidf.py
+++ b/tests/test_tfidf.py
@@ -11,7 +11,7 @@ import vault_index
 class TestTokenize:
     def test_strips_punctuation_and_lowercases(self):
         toks = vault_index._tokenize_for_tfidf("Hello, World! Python-3.9.")
-        assert toks == ["hello", "world", "python", "3", "9"]
+        assert toks == ["hello", "world", "python"]
 
     def test_drops_stopwords(self):
         toks = vault_index._tokenize_for_tfidf("the quick brown fox is here")

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -679,3 +679,84 @@ class TestUpgradeWiresThemes:
         assert not status.startswith("Failed:"), (
             f"upgrade must succeed even when DB is missing, got: {status}"
         )
+
+    def test_upgrade_skips_theme_assignment_when_index_note_returns_false(
+        self, tmp_vault, mock_config
+    ):
+        """If index_note returns False (no exception), assign_to_theme must NOT run.
+
+        Regression: previously the pipeline used try/except/else, so a non-
+        raising False return from index_note would still fall through to
+        assign_to_theme on a stale or missing tfidf_vector.
+        """
+        import obsidian_utils
+        import vault_index
+
+        target_path = tmp_vault / "claude-sessions" / "2026-04-16-test-project-idxfail.md"
+        target_path.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-16\n"
+            "session_id: idxfail-session\n"
+            "project: test-project\n"
+            "duration_minutes: 5.0\n"
+            "tags:\n  - claude/session\n"
+            "status: auto-logged\n"
+            "---\n\n"
+            "# Session: test-project\n\n"
+            "## Summary\n"
+            "AI summary unavailable \u2014 raw extraction below.\n\n"
+            "## Conversation (raw)\n"
+            "**User:** retrieval?\n**Assistant:** scoring.\n",
+            encoding="utf-8",
+        )
+
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions"], db_path=db_path,
+        )
+
+        calls: dict[str, int] = {"index_note": 0, "assign_to_theme": 0}
+        original_index = vault_index.index_note
+        original_assign = vault_index.assign_to_theme
+        original_default = vault_index._default_db_path
+
+        def fake_index_note(_db, _path):
+            calls["index_note"] += 1
+            return False  # signal failure without raising
+
+        def fake_assign_to_theme(*args, **kwargs):
+            calls["assign_to_theme"] += 1
+            return original_assign(*args, **kwargs)
+
+        try:
+            vault_index._default_db_path = lambda: db_path
+            vault_index.index_note = fake_index_note
+            vault_index.assign_to_theme = fake_assign_to_theme
+
+            summary = (
+                "## Summary\nRetrieval scoring.\n\n"
+                "## Key Decisions\n- None noted.\n\n"
+                "## Changes Made\n- None noted.\n\n"
+                "## Errors Encountered\nNone.\n\n"
+                "## Open Questions / Next Steps\nNone.\n\n"
+                "IMPORTANCE: 5\n"
+            )
+            status = obsidian_utils.upgrade_note_with_summary(
+                str(target_path), summary,
+                str(tmp_vault), "claude-sessions", "test-project",
+                source="test",
+            )
+        finally:
+            vault_index._default_db_path = original_default
+            vault_index.index_note = original_index
+            vault_index.assign_to_theme = original_assign
+
+        assert not status.startswith("Failed:"), (
+            f"upgrade must succeed even when reindex fails, got: {status}"
+        )
+        assert calls["index_note"] == 1, "index_note should have been called exactly once"
+        assert calls["assign_to_theme"] == 0, (
+            "assign_to_theme ran despite index_note returning False — "
+            "reindex-failure gating regressed"
+        )

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -1,0 +1,81 @@
+"""Schema + incremental assignment tests for the Phase 2 theme engine."""
+
+import json
+import sqlite3
+
+import pytest
+
+import vault_index
+
+
+@pytest.fixture
+def db_path(tmp_vault):
+    p = str(tmp_vault / "test.db")
+    vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
+    return p
+
+
+class TestPhase2Schema:
+    def test_themes_table_exists(self, db_path):
+        conn = sqlite3.connect(db_path)
+        tables = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        conn.close()
+        assert "themes" in tables
+        assert "theme_members" in tables
+        assert "term_df" in tables
+
+    def test_themes_columns(self, db_path):
+        conn = sqlite3.connect(db_path)
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(themes)").fetchall()}
+        conn.close()
+        assert cols == {
+            "id", "name", "summary", "centroid", "note_count",
+            "activation", "created_date", "updated_date", "project",
+        }
+
+    def test_theme_members_columns(self, db_path):
+        conn = sqlite3.connect(db_path)
+        cols = {r[1] for r in conn.execute(
+            "PRAGMA table_info(theme_members)"
+        ).fetchall()}
+        conn.close()
+        assert cols == {
+            "theme_id", "note_path", "similarity", "surprise", "added_date",
+        }
+
+    def test_notes_has_tfidf_vector_column(self, db_path):
+        conn = sqlite3.connect(db_path)
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(notes)").fetchall()}
+        conn.close()
+        assert "tfidf_vector" in cols
+
+    def test_tfidf_vector_migration_on_existing_db(self, tmp_vault):
+        """A DB created without the new column must gain it via ensure_index()."""
+        db_path = str(tmp_vault / "legacy.db")
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE notes ("
+            "path TEXT PRIMARY KEY, type TEXT NOT NULL, date TEXT, "
+            "project TEXT, title TEXT, source_session TEXT, "
+            "source_note TEXT, tags TEXT, status TEXT, mtime REAL NOT NULL, "
+            "size INTEGER, body TEXT DEFAULT '', importance INTEGER DEFAULT 5)"
+        )
+        conn.commit()
+        conn.close()
+
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(notes)").fetchall()}
+        conn.close()
+        assert "tfidf_vector" in cols
+
+    def test_term_df_columns(self, db_path):
+        conn = sqlite3.connect(db_path)
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(term_df)").fetchall()}
+        conn.close()
+        assert cols == {"term", "df"}

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -316,3 +316,148 @@ class TestAssignToTheme:
         assert result is not None, "Cross-project theme should have been matched"
         assert result["theme_id"] == theme_id
         assert result["similarity"] > 0.3
+
+
+class TestUpgradeWiresThemes:
+    def test_upgrade_triggers_theme_assignment(self, tmp_vault, mock_config):
+        """After upgrade_note_with_summary(), the note must join a seeded matching theme."""
+        import obsidian_utils
+
+        # Seed an indexed note in the same project and build a theme around its vector
+        seed_path = _indexed_note(
+            tmp_vault, "seed", "retrieval scoring",
+            "retrieval scoring activation importance proximity bm25",
+            project="test-project",
+        )
+        target_path = tmp_vault / "claude-sessions" / "2026-04-16-test-project-newnote.md"
+        target_path.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-16\n"
+            "session_id: new-session\n"
+            "project: test-project\n"
+            "duration_minutes: 10.0\n"
+            "tags:\n  - claude/session\n"
+            "status: auto-logged\n"
+            "---\n\n"
+            "# Session: test-project (develop)\n\n"
+            "## Summary\n"
+            "AI summary unavailable \u2014 raw extraction below.\n\n"
+            "## Conversation (raw)\n"
+            "**User:** retrieval scoring?\n"
+            "**Assistant:** activation plus importance plus proximity plus bm25.\n",
+            encoding="utf-8",
+        )
+
+        import vault_index
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(
+            str(tmp_vault), ["claude-sessions"], db_path=db_path,
+        )
+
+        # Seed a theme centroid around the seed note's TF-IDF vector
+        conn = sqlite3.connect(db_path)
+        seed_vec = conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (seed_path,)
+        ).fetchone()[0]
+        assert seed_vec, "Seed note should have a TF-IDF vector after indexing"
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("Retrieval", "", seed_vec, 1,
+             "2026-04-16", "2026-04-16", "test-project"),
+        )
+        theme_id = conn.execute("SELECT id FROM themes").fetchone()[0]
+        conn.execute(
+            "INSERT INTO theme_members (theme_id, note_path, similarity, added_date) "
+            "VALUES (?, ?, 1.0, ?)",
+            (theme_id, seed_path, "2026-04-16"),
+        )
+        conn.commit()
+        conn.close()
+
+        # Point obsidian_utils at this test DB by monkey-patching _default_db_path.
+        original_default = vault_index._default_db_path
+        try:
+            vault_index._default_db_path = lambda: db_path
+            summary = (
+                "## Summary\n"
+                "Retrieval scoring activation importance.\n\n"
+                "## Key Decisions\n- None noted.\n\n"
+                "## Changes Made\n- None noted.\n\n"
+                "## Errors Encountered\nNone.\n\n"
+                "## Open Questions / Next Steps\nNone.\n\n"
+                "IMPORTANCE: 7\n"
+            )
+            status = obsidian_utils.upgrade_note_with_summary(
+                str(target_path), summary,
+                str(tmp_vault), "claude-sessions", "test-project",
+                source="test",
+            )
+        finally:
+            vault_index._default_db_path = original_default
+
+        assert not status.startswith("Failed:"), f"upgrade failed: {status}"
+
+        conn = sqlite3.connect(db_path)
+        members = {
+            r[0] for r in conn.execute(
+                "SELECT note_path FROM theme_members WHERE theme_id = ?",
+                (theme_id,),
+            ).fetchall()
+        }
+        conn.close()
+        assert str(target_path) in members, (
+            "upgrade_note_with_summary did not trigger theme assignment"
+        )
+
+    def test_upgrade_survives_missing_vault_index(self, tmp_vault, mock_config):
+        """If the DB file is missing, upgrade must still succeed (theme pipeline is best-effort)."""
+        import obsidian_utils
+        import vault_index
+
+        target_path = tmp_vault / "claude-sessions" / "2026-04-16-test-project-missing.md"
+        target_path.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-16\n"
+            "session_id: missing-db-session\n"
+            "project: test-project\n"
+            "duration_minutes: 5.0\n"
+            "tags:\n  - claude/session\n"
+            "status: auto-logged\n"
+            "---\n\n"
+            "# Session: test-project\n\n"
+            "## Summary\n"
+            "AI summary unavailable \u2014 raw extraction below.\n\n"
+            "## Conversation (raw)\n"
+            "**User:** hi\n**Assistant:** hello\n",
+            encoding="utf-8",
+        )
+
+        # Point the DB path at a file that doesn't exist.
+        nonexistent = str(tmp_vault / "nonexistent.db")
+        original_default = vault_index._default_db_path
+        try:
+            vault_index._default_db_path = lambda: nonexistent
+            summary = (
+                "## Summary\n"
+                "Short session.\n\n"
+                "## Key Decisions\n- None noted.\n\n"
+                "## Changes Made\n- None noted.\n\n"
+                "## Errors Encountered\nNone.\n\n"
+                "## Open Questions / Next Steps\nNone.\n\n"
+                "IMPORTANCE: 3\n"
+            )
+            status = obsidian_utils.upgrade_note_with_summary(
+                str(target_path), summary,
+                str(tmp_vault), "claude-sessions", "test-project",
+                source="test",
+            )
+        finally:
+            vault_index._default_db_path = original_default
+
+        assert not status.startswith("Failed:"), (
+            f"upgrade must succeed even when DB is missing, got: {status}"
+        )

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -317,6 +317,48 @@ class TestAssignToTheme:
         assert result["theme_id"] == theme_id
         assert result["similarity"] > 0.3
 
+    def test_global_recall_considers_scoped_themes(self, tmp_vault):
+        """project=None (global recall) must match scoped themes too.
+
+        Regression: `project = ? OR project IS NULL` with project=None
+        binds to `project = NULL` which is false in SQL, so only NULL-
+        project themes were ever candidates. Scoped themes were invisible
+        to global recall even when the note was semantically a perfect fit.
+        """
+        path = _indexed_note(tmp_vault, "global", "retrieval scoring",
+                             "retrieval scoring activation importance")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path,)
+        ).fetchone()[0])
+        # A project-scoped theme (NOT null) that matches the note perfectly.
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("Scoped Retrieval", "", json.dumps(vec), 1,
+             "2026-04-16", "2026-04-16", "proj"),
+        )
+        theme_id = conn.execute("SELECT id FROM themes").fetchone()[0]
+        conn.execute(
+            "INSERT INTO theme_members (theme_id, note_path, similarity, added_date) "
+            "VALUES (?, ?, 1.0, ?)",
+            (theme_id, "/some/other/path.md", "2026-04-16"),
+        )
+        conn.commit()
+        conn.close()
+
+        # project=None should still see the scoped theme.
+        result = vault_index.assign_to_theme(db_path, path, project=None)
+        assert result is not None, (
+            "Global recall (project=None) failed to match a scoped theme — "
+            "SQL filter treated None as NULL (match nothing) instead of wildcard"
+        )
+        assert result["theme_id"] == theme_id
+
 
 class TestUpgradeWiresThemes:
     def test_upgrade_triggers_theme_assignment(self, tmp_vault, mock_config):

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -283,6 +283,74 @@ class TestAssignToTheme:
             f"added_date overwritten to {row[2]!r} — should be preserved"
         )
 
+    def test_reassignment_does_not_double_count_or_drift_centroid(self, tmp_vault):
+        """Reassigning an already-member note must leave note_count and
+        centroid unchanged.
+
+        Regression: assign_to_theme always did +1 on note_count and folded
+        the note's vector back into the running-average centroid even when
+        the theme_members upsert was a no-op update. Calling assign twice
+        on the same note would bump count to 3 (from 1→2→3) and drift the
+        centroid toward the note's vector on every call.
+        """
+        path = _indexed_note(tmp_vault, "dupe", "retrieval scoring",
+                             "retrieval scoring activation importance")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path,)
+        ).fetchone()[0])
+        # Seed a theme with a DIFFERENT centroid than the note, so that if
+        # folding happens we can detect drift by comparing centroid values.
+        seed_centroid = {t: 0.5 for t in vec}  # same terms, uniform weights
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("Retrieval", "", json.dumps(seed_centroid), 3,
+             "2026-04-16", "2026-04-16", "proj"),
+        )
+        theme_id = conn.execute("SELECT id FROM themes").fetchone()[0]
+        conn.commit()
+        conn.close()
+
+        # First assignment: legitimately new member → count should go 3→4.
+        result1 = vault_index.assign_to_theme(db_path, path, project="proj")
+        assert result1 is not None
+
+        conn = sqlite3.connect(db_path)
+        count_after_1, centroid_after_1_json = conn.execute(
+            "SELECT note_count, centroid FROM themes WHERE id = ?", (theme_id,)
+        ).fetchone()
+        conn.close()
+        assert count_after_1 == 4, f"first assign should bump 3→4, got {count_after_1}"
+        centroid_after_1 = json.loads(centroid_after_1_json)
+
+        # Second assignment: same note, already a member → count+centroid must NOT change.
+        result2 = vault_index.assign_to_theme(db_path, path, project="proj")
+        assert result2 is not None
+
+        conn = sqlite3.connect(db_path)
+        count_after_2, centroid_after_2_json = conn.execute(
+            "SELECT note_count, centroid FROM themes WHERE id = ?", (theme_id,)
+        ).fetchone()
+        conn.close()
+        assert count_after_2 == 4, (
+            f"reassignment bumped note_count to {count_after_2} — "
+            "already-member path should skip count update"
+        )
+        centroid_after_2 = json.loads(centroid_after_2_json)
+        for term, v in centroid_after_1.items():
+            assert centroid_after_2.get(term) == pytest.approx(v, rel=1e-9), (
+                f"centroid drifted on reassignment (term={term!r}: "
+                f"{v} → {centroid_after_2.get(term)})"
+            )
+        assert set(centroid_after_2) == set(centroid_after_1), (
+            "centroid term set changed on reassignment"
+        )
+
     def test_cross_project_theme_candidate(self, tmp_vault):
         """A theme with project=NULL should be a valid candidate for any project."""
         path = _indexed_note(tmp_vault, "cross", "retrieval scoring",

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -79,3 +79,152 @@ class TestPhase2Schema:
         cols = {r[1] for r in conn.execute("PRAGMA table_info(term_df)").fetchall()}
         conn.close()
         assert cols == {"term", "df"}
+
+
+def _indexed_note(tmp_vault, slug, title, body, project="proj"):
+    """Write a note and return its path (caller re-indexes)."""
+    path = tmp_vault / "claude-sessions" / f"2026-04-16-{project}-{slug}.md"
+    path.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-16\n"
+        f"project: {project}\n"
+        f"title: {title}\n"
+        "tags:\n  - claude/session\n"
+        "status: summarized\n"
+        "---\n"
+        f"{body}\n",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+class TestAssignToTheme:
+    def test_first_note_leaves_no_theme(self, tmp_vault):
+        """With no existing themes, assignment is a no-op returning None."""
+        path = _indexed_note(tmp_vault, "a", "retrieval scoring",
+                             "retrieval scoring activation")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+        result = vault_index.assign_to_theme(db_path, path, project="proj")
+        assert result is None
+
+        conn = sqlite3.connect(db_path)
+        themes = conn.execute("SELECT COUNT(*) FROM themes").fetchone()[0]
+        members = conn.execute("SELECT COUNT(*) FROM theme_members").fetchone()[0]
+        conn.close()
+        assert themes == 0
+        assert members == 0
+
+    def test_similar_note_joins_existing_theme(self, tmp_vault):
+        path_a = _indexed_note(tmp_vault, "a", "retrieval scoring",
+                               "retrieval scoring activation importance")
+        path_b = _indexed_note(tmp_vault, "b", "activation importance",
+                               "retrieval scoring activation importance")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec_a = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path_a,)
+        ).fetchone()[0])
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("Retrieval", "", json.dumps(vec_a), 1,
+             "2026-04-16", "2026-04-16", "proj"),
+        )
+        theme_id = conn.execute("SELECT id FROM themes").fetchone()[0]
+        conn.execute(
+            "INSERT INTO theme_members (theme_id, note_path, similarity, added_date) "
+            "VALUES (?, ?, 1.0, ?)",
+            (theme_id, path_a, "2026-04-16"),
+        )
+        conn.commit()
+        conn.close()
+
+        result = vault_index.assign_to_theme(db_path, path_b, project="proj")
+        assert result is not None
+        assert result["theme_id"] == theme_id
+        assert result["similarity"] > 0.3
+
+        conn = sqlite3.connect(db_path)
+        members = conn.execute(
+            "SELECT note_path FROM theme_members WHERE theme_id = ?", (theme_id,)
+        ).fetchall()
+        note_count = conn.execute(
+            "SELECT note_count FROM themes WHERE id = ?", (theme_id,)
+        ).fetchone()[0]
+        conn.close()
+        assert {m[0] for m in members} == {path_a, path_b}
+        assert note_count == 2
+
+    def test_low_similarity_stays_unassigned(self, tmp_vault):
+        path_theme = _indexed_note(tmp_vault, "theme", "retrieval scoring",
+                                   "retrieval scoring activation")
+        path_stranger = _indexed_note(tmp_vault, "stranger", "garlic pasta",
+                                      "garlic pasta recipe italian dinner")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path_theme,)
+        ).fetchone()[0])
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("Retrieval", "", json.dumps(vec), 1,
+             "2026-04-16", "2026-04-16", "proj"),
+        )
+        conn.commit()
+        conn.close()
+
+        result = vault_index.assign_to_theme(db_path, path_stranger, project="proj")
+        assert result is None
+
+    def test_centroid_update_is_running_average(self, tmp_vault):
+        """After a second note joins, centroid term weight is the mean of the two vectors."""
+        path_a = _indexed_note(tmp_vault, "a", "retrieval", "retrieval retrieval")
+        path_b = _indexed_note(tmp_vault, "b", "retrieval scoring",
+                               "retrieval scoring")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec_a = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path_a,)
+        ).fetchone()[0])
+        vec_b = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path_b,)
+        ).fetchone()[0])
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("Retrieval", "", json.dumps(vec_a), 1,
+             "2026-04-16", "2026-04-16", "proj"),
+        )
+        theme_id = conn.execute("SELECT id FROM themes").fetchone()[0]
+        conn.execute(
+            "INSERT INTO theme_members (theme_id, note_path, similarity, added_date) "
+            "VALUES (?, ?, 1.0, ?)",
+            (theme_id, path_a, "2026-04-16"),
+        )
+        conn.commit()
+        conn.close()
+
+        vault_index.assign_to_theme(db_path, path_b, project="proj")
+
+        conn = sqlite3.connect(db_path)
+        centroid = json.loads(conn.execute(
+            "SELECT centroid FROM themes WHERE id = ?", (theme_id,)
+        ).fetchone()[0])
+        conn.close()
+
+        for term, a_val in vec_a.items():
+            b_val = vec_b.get(term, 0.0)
+            expected = (a_val + b_val) / 2
+            assert centroid.get(term) == pytest.approx(expected, rel=1e-6)

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -494,6 +494,63 @@ class TestDeleteNoteMaintainsThemeState:
         conn.close()
         assert members == {path_b}
 
+    def test_delete_last_member_cascades_theme_members(self, tmp_vault):
+        """Dropping a theme must also clear any stale theme_members rows.
+
+        Defense-in-depth: if an earlier invariant violation left two rows
+        under a theme that claimed count=1, the last-member branch must
+        not orphan the extra rows when it drops the themes row.
+        """
+        path = _indexed_note(tmp_vault, "invariant", "retrieval scoring",
+                             "retrieval scoring activation")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path,)
+        ).fetchone()[0])
+        # Seed a theme claiming note_count=1 but with TWO member rows
+        # (one for the note we'll delete, one stray). Simulates an
+        # earlier invariant violation the cascade must clean up.
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, 1, ?, ?, ?)",
+            ("Invariant", "", json.dumps(vec),
+             "2026-04-16", "2026-04-16", "proj"),
+        )
+        theme_id = conn.execute("SELECT id FROM themes").fetchone()[0]
+        conn.executemany(
+            "INSERT INTO theme_members (theme_id, note_path, similarity, added_date) "
+            "VALUES (?, ?, 1.0, ?)",
+            [
+                (theme_id, path, "2026-04-16"),
+                (theme_id, "/nonexistent/stray.md", "2026-04-16"),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        from vault_index import _delete_note, _connect
+        conn = _connect(db_path)
+        _delete_note(conn, path)
+        conn.commit()
+
+        # Both the theme AND any stray theme_members for it must be gone.
+        theme_row = conn.execute(
+            "SELECT id FROM themes WHERE id = ?", (theme_id,)
+        ).fetchone()
+        stray_members = conn.execute(
+            "SELECT note_path FROM theme_members WHERE theme_id = ?", (theme_id,)
+        ).fetchall()
+        conn.close()
+        assert theme_row is None
+        assert stray_members == [], (
+            f"stale theme_members rows left behind after theme drop: "
+            f"{[r[0] for r in stray_members]!r}"
+        )
+
     def test_delete_last_member_drops_theme(self, tmp_vault):
         """Deleting the sole member must drop the theme rather than leave count=0."""
         path = _indexed_note(tmp_vault, "solo", "retrieval scoring",

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -428,6 +428,114 @@ class TestAssignToTheme:
         assert result["theme_id"] == theme_id
 
 
+class TestDeleteNoteMaintainsThemeState:
+    """Deleting a note must keep themes.note_count + centroid consistent."""
+
+    def test_delete_decrements_count_and_unfolds_centroid(self, tmp_vault):
+        """Deleting one of N members must set count=N-1 and reverse the fold."""
+        path_a = _indexed_note(tmp_vault, "a", "retrieval scoring",
+                               "retrieval scoring activation importance")
+        path_b = _indexed_note(tmp_vault, "b", "more retrieval",
+                               "retrieval scoring activation importance proximity")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec_a = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path_a,)
+        ).fetchone()[0])
+        vec_b = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path_b,)
+        ).fetchone()[0])
+        # Hand-build the running-average centroid for a theme containing A+B.
+        all_terms = set(vec_a) | set(vec_b)
+        centroid = {t: (vec_a.get(t, 0.0) + vec_b.get(t, 0.0)) / 2 for t in all_terms}
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, 2, ?, ?, ?)",
+            ("Retrieval", "", json.dumps(centroid),
+             "2026-04-16", "2026-04-16", "proj"),
+        )
+        theme_id = conn.execute("SELECT id FROM themes").fetchone()[0]
+        conn.executemany(
+            "INSERT INTO theme_members (theme_id, note_path, similarity, added_date) "
+            "VALUES (?, ?, 1.0, ?)",
+            [(theme_id, path_a, "2026-04-16"),
+             (theme_id, path_b, "2026-04-16")],
+        )
+        conn.commit()
+        conn.close()
+
+        # Delete path_a via internal helper (same path as _sync's deletion branch).
+        from vault_index import _delete_note, _connect
+        conn = _connect(db_path)
+        _delete_note(conn, path_a)
+        conn.commit()
+
+        # note_count must drop to 1, centroid must equal vec_b (only remaining member).
+        row = conn.execute(
+            "SELECT note_count, centroid FROM themes WHERE id = ?", (theme_id,)
+        ).fetchone()
+        assert row is not None, "theme must still exist with 1 member"
+        assert row["note_count"] == 1, (
+            f"count did not decrement: expected 1, got {row['note_count']}"
+        )
+        remaining_centroid = json.loads(row["centroid"])
+        for term in vec_b:
+            assert remaining_centroid.get(term) == pytest.approx(vec_b[term], rel=1e-6), (
+                f"centroid term {term!r} did not unfold to vec_b value"
+            )
+
+        # Membership row for path_a gone; path_b intact.
+        members = {r[0] for r in conn.execute(
+            "SELECT note_path FROM theme_members WHERE theme_id = ?", (theme_id,)
+        ).fetchall()}
+        conn.close()
+        assert members == {path_b}
+
+    def test_delete_last_member_drops_theme(self, tmp_vault):
+        """Deleting the sole member must drop the theme rather than leave count=0."""
+        path = _indexed_note(tmp_vault, "solo", "retrieval scoring",
+                             "retrieval scoring activation")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path,)
+        ).fetchone()[0])
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, 1, ?, ?, ?)",
+            ("Solo", "", json.dumps(vec), "2026-04-16", "2026-04-16", "proj"),
+        )
+        theme_id = conn.execute("SELECT id FROM themes").fetchone()[0]
+        conn.execute(
+            "INSERT INTO theme_members (theme_id, note_path, similarity, added_date) "
+            "VALUES (?, ?, 1.0, ?)",
+            (theme_id, path, "2026-04-16"),
+        )
+        conn.commit()
+        conn.close()
+
+        from vault_index import _delete_note, _connect
+        conn = _connect(db_path)
+        _delete_note(conn, path)
+        conn.commit()
+
+        theme_row = conn.execute(
+            "SELECT id FROM themes WHERE id = ?", (theme_id,)
+        ).fetchone()
+        member_row = conn.execute(
+            "SELECT note_path FROM theme_members WHERE theme_id = ?", (theme_id,)
+        ).fetchone()
+        conn.close()
+        assert theme_row is None, "theme with 0 members must be dropped"
+        assert member_row is None
+
+
 class TestUpgradeWiresThemes:
     def test_upgrade_triggers_theme_assignment(self, tmp_vault, mock_config):
         """After upgrade_note_with_summary(), the note must join a seeded matching theme."""

--- a/tests/test_themes.py
+++ b/tests/test_themes.py
@@ -228,3 +228,91 @@ class TestAssignToTheme:
             b_val = vec_b.get(term, 0.0)
             expected = (a_val + b_val) / 2
             assert centroid.get(term) == pytest.approx(expected, rel=1e-6)
+
+    def test_reassignment_preserves_surprise_and_added_date(self, tmp_vault):
+        """Assigning a note twice must not reset surprise or added_date."""
+        path = _indexed_note(tmp_vault, "reassign", "retrieval scoring",
+                             "retrieval scoring activation importance")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path,)
+        ).fetchone()[0])
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("Retrieval", "", json.dumps(vec), 0,
+             "2026-04-16", "2026-04-16", "proj"),
+        )
+        conn.commit()
+        conn.close()
+
+        # First assignment: joins the theme, surprise defaults to 0.0.
+        result1 = vault_index.assign_to_theme(db_path, path, project="proj")
+        assert result1 is not None
+
+        # Simulate Batch F writing a surprise score and a custom added_date.
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "UPDATE theme_members SET surprise = 0.7, added_date = '2026-04-10' "
+            "WHERE note_path = ?", (path,),
+        )
+        conn.commit()
+        conn.close()
+
+        # Second assignment: similarity may update, surprise + added_date must NOT reset.
+        result2 = vault_index.assign_to_theme(db_path, path, project="proj")
+        assert result2 is not None
+
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "SELECT similarity, surprise, added_date FROM theme_members "
+            "WHERE note_path = ?", (path,),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        # similarity should reflect the fresh cosine
+        assert row[0] == pytest.approx(result2["similarity"], rel=1e-6)
+        assert row[1] == pytest.approx(0.7, rel=1e-6), (
+            f"surprise reset to {row[1]!r} — INSERT OR REPLACE bug regressed"
+        )
+        assert row[2] == "2026-04-10", (
+            f"added_date overwritten to {row[2]!r} — should be preserved"
+        )
+
+    def test_cross_project_theme_candidate(self, tmp_vault):
+        """A theme with project=NULL should be a valid candidate for any project."""
+        path = _indexed_note(tmp_vault, "cross", "retrieval scoring",
+                             "retrieval scoring activation importance")
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        vec = json.loads(conn.execute(
+            "SELECT tfidf_vector FROM notes WHERE path = ?", (path,)
+        ).fetchone()[0])
+        # Cross-project theme: project IS NULL
+        conn.execute(
+            "INSERT INTO themes (name, summary, centroid, note_count, "
+            "created_date, updated_date, project) "
+            "VALUES (?, ?, ?, ?, ?, ?, NULL)",
+            ("Global Retrieval", "", json.dumps(vec), 1,
+             "2026-04-16", "2026-04-16"),
+        )
+        theme_id = conn.execute("SELECT id FROM themes").fetchone()[0]
+        conn.execute(
+            "INSERT INTO theme_members (theme_id, note_path, similarity, added_date) "
+            "VALUES (?, ?, 1.0, ?)",
+            (theme_id, "/some/other/path.md", "2026-04-16"),
+        )
+        conn.commit()
+        conn.close()
+
+        # Call with a specific project — the NULL-project theme should still be a candidate.
+        result = vault_index.assign_to_theme(db_path, path, project="proj")
+        assert result is not None, "Cross-project theme should have been matched"
+        assert result["theme_id"] == theme_id
+        assert result["similarity"] > 0.3

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -80,7 +80,7 @@ def test_cli_dry_run_reports_issues(tmp_path):
 
     script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
     result = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
          "--project", "proj1", "--json"],
         capture_output=True,
         text=True,
@@ -132,7 +132,7 @@ def test_cli_apply_with_yes(tmp_path):
 
     script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
     result = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
          "--project", "proj1", "--apply", "--yes"],
         capture_output=True,
         text=True,

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -79,7 +79,7 @@ def test_end_to_end_scan_apply_verify(tmp_path):
 
     # --- 1. Dry-run → exit 1, file untouched ---
     r = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
          "--project", "proj1", "--json"],
         capture_output=True, text=True, env=env,
     )
@@ -92,7 +92,7 @@ def test_end_to_end_scan_apply_verify(tmp_path):
 
     # --- 2. Apply with --yes (non-interactive) ---
     r = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
          "--project", "proj1", "--apply", "--yes"],
         capture_output=True, text=True, env=env,
     )
@@ -118,7 +118,7 @@ def test_end_to_end_scan_apply_verify(tmp_path):
 
     # --- 4. Re-scan → exit 0 (clean) ---
     r = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "7",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
          "--project", "proj1", "--json"],
         capture_output=True, text=True, env=env,
     )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -113,7 +113,7 @@ def test_scan_flags_insight_stamped_to_wrong_session(doctor_vault, monkeypatch):
     )
 
     issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
     )
     assert len(issues) == 1
     iss = issues[0]
@@ -148,7 +148,7 @@ def test_scan_ignores_correct_insight(doctor_vault, monkeypatch):
         a_start + 1800,
     )
 
-    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=7, project="proj1")
+    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=60, project="proj1")
     assert issues == []
 
 
@@ -175,7 +175,7 @@ def test_scan_honors_days_window(doctor_vault, monkeypatch):
     )
 
     issues = check.scan(str(v), "claude-sessions", "claude-insights", days=7, project="proj1")
-    assert issues == []  # outside 7-day window
+    assert issues == []  # outside 7-day window — this test specifically validates that boundary
 
 
 def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch):
@@ -203,7 +203,7 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
         gap_mtime,
     )
 
-    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=7, project="proj1")
+    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=60, project="proj1")
     assert len(issues) == 1, f"expected exactly 1 unresolved issue, got {len(issues)}"
     iss = issues[0]
     assert iss.extra.get("unresolved") is True
@@ -256,7 +256,7 @@ def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monke
     original_body = original_text.split("---\n", 2)[-1]
 
     issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
     )
     assert len(issues) == 1, f"expected 1 issue, got {len(issues)}"
 
@@ -384,7 +384,7 @@ def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
     )
 
     issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
     )
     assert len(issues) == 1
     # Latest first_ts wins: sid-b (started at 14:00) beats sid-a (started at 10:00)
@@ -481,7 +481,7 @@ def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
     )
 
     issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
     )
     assert len(issues) == 1
 
@@ -499,7 +499,7 @@ def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
     # And a re-scan with the patched note should find nothing (proves the
     # self-reinforcing bug is not reintroduced)
     rescan_issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=7, project="proj1"
+        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
     )
     assert rescan_issues == [], f"re-scan should be clean, got: {rescan_issues}"
 

--- a/tests/test_vault_index.py
+++ b/tests/test_vault_index.py
@@ -182,6 +182,91 @@ class TestInsertAndSync:
 
         assert count == 0
 
+    def test_index_note_uses_begin_immediate(self, tmp_vault, monkeypatch):
+        """index_note must open a write transaction with BEGIN IMMEDIATE
+        so concurrent writers serialize cleanly instead of racing through
+        the tfidf read-modify-write. Verified via sqlite3 trace callback."""
+        note = tmp_vault / "claude-sessions" / "2026-04-10-proj-lock.md"
+        _write_note(
+            note,
+            {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+            body="# Session\n\nbody text.",
+        )
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        executed: list[str] = []
+        orig_connect = vault_index._connect
+
+        def recording_connect(p):
+            c = orig_connect(p)
+            c.set_trace_callback(lambda sql: executed.append(sql.strip().upper()))
+            return c
+
+        monkeypatch.setattr(vault_index, "_connect", recording_connect)
+        ok = vault_index.index_note(db_path, str(note))
+        assert ok is True
+        assert "BEGIN IMMEDIATE" in executed, (
+            f"index_note did not issue BEGIN IMMEDIATE — traced statements "
+            f"were {executed[:5]!r}... Concurrent hook runs will race the "
+            "tfidf upsert."
+        )
+
+    def test_sync_rolls_back_on_mid_loop_failure(self, tmp_vault, monkeypatch):
+        """If _upsert_note raises mid-_sync, the transaction must roll back
+        so the first note's partial insert is undone and the connection
+        doesn't carry a poisoned open transaction into its next use.
+
+        Tested at the _sync layer rather than through ensure_index because
+        ensure_index wraps _sync in a corrupt-DB auto-recovery path that
+        catches sqlite3.DatabaseError (which IntegrityError subclasses).
+        The transactional contract is on _sync itself.
+        """
+        # Seed two notes on disk that will both need indexing.
+        for slug in ("first", "second"):
+            _write_note(
+                tmp_vault / "claude-sessions" / f"2026-04-10-proj-{slug}.md",
+                {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+                body=f"# Session: {slug}\n\nbody.",
+            )
+        db_path = str(tmp_vault / "test.db")
+        # Bootstrap the schema without running a sync yet.
+        import sqlite3 as _sq
+        conn = vault_index._connect(db_path)
+        vault_index._init_schema(conn)
+        vault_index._ensure_access_log_indexes(conn)
+        if vault_index._needs_tfidf_vector_migration(conn):
+            vault_index._add_tfidf_vector_column(conn)
+        vault_index._ensure_theme_indexes(conn)
+        conn.commit()
+
+        call_count = {"n": 0}
+        real_upsert = vault_index._upsert_note
+
+        def flaky_upsert(c, path, *a, **kw):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise _sq.IntegrityError("simulated mid-loop failure")
+            return real_upsert(c, path, *a, **kw)
+
+        monkeypatch.setattr(vault_index, "_upsert_note", flaky_upsert)
+
+        with pytest.raises(_sq.IntegrityError):
+            vault_index._sync(conn, str(tmp_vault), ["claude-sessions"])
+
+        # The first note's partial upsert must have been rolled back.
+        notes_n = conn.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
+        assert notes_n == 0, (
+            f"partial notes rows persisted after rollback: got {notes_n} — "
+            "_sync did not roll back the open transaction on exception"
+        )
+        # The connection should not be stuck in an open transaction —
+        # a fresh BEGIN/COMMIT must work immediately after the rollback.
+        conn.execute("BEGIN")
+        conn.execute("CREATE TABLE canary_probe (x INT)")
+        conn.commit()
+        conn.close()
+
     def test_update_does_not_orphan_fts_rows(self, tmp_vault):
         """Repeated updates of the same note must not accumulate FTS rows.
 

--- a/tests/test_vault_index.py
+++ b/tests/test_vault_index.py
@@ -363,11 +363,21 @@ class TestRebuildIndex:
         conn = sqlite3.connect(db_path)
         conn.row_factory = sqlite3.Row
         rows = conn.execute("SELECT path FROM notes").fetchall()
+        # rebuild_index must leave the DB in the same index-coverage state as
+        # ensure_index — including access_log secondary indexes, which are
+        # needed for activation queries and access-log sanity checks.
+        index_names = {
+            r["name"] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            ).fetchall()
+        }
         conn.close()
 
         paths = [r["path"] for r in rows]
         assert len(paths) == 1
         assert "note2.md" in paths[0]
+        assert "idx_access_note" in index_names
+        assert "idx_access_time" in index_names
 
 
 class TestIndexNote:

--- a/tests/test_vault_index.py
+++ b/tests/test_vault_index.py
@@ -182,6 +182,64 @@ class TestInsertAndSync:
 
         assert count == 0
 
+    def test_update_does_not_orphan_fts_rows(self, tmp_vault):
+        """Repeated updates of the same note must not accumulate FTS rows.
+
+        Regression: _upsert_note previously did DELETE FROM notes + INSERT
+        but skipped the contentless-FTS5 special 'delete' command, leaving
+        the old notes_fts row behind on every rewrite. Over many updates
+        this bloats the FTS index (and historical tokens leak into
+        searches via any path that does not strictly JOIN notes_fts to
+        notes).
+        """
+        note = tmp_vault / "claude-sessions" / "2026-04-10-proj-fts.md"
+        _write_note(
+            note,
+            {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+            body="# Session: First\n\nalphaunique content.",
+        )
+        db_path = str(tmp_vault / "test.db")
+        vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        # Rewrite the note three times with fresh, non-overlapping body tokens,
+        # bumping mtime each time so _sync re-upserts.
+        for i, token in enumerate(("betaunique", "gammaunique", "deltaunique"), start=2):
+            prev_mtime = note.stat().st_mtime
+            _write_note(
+                note,
+                {"type": "claude-session", "date": "2026-04-10", "project": "proj"},
+                body=f"# Session: Rev{i}\n\n{token} content.",
+            )
+            os.utime(note, (prev_mtime + 2, prev_mtime + 2))
+            vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=db_path)
+
+        conn = sqlite3.connect(db_path)
+        # Exactly one notes row.
+        notes_count = conn.execute("SELECT COUNT(*) FROM notes").fetchone()[0]
+        # Exactly one FTS row (contentless FTS5 exposes rowid — orphan rows
+        # would count here even though they don't JOIN notes).
+        fts_count = conn.execute("SELECT COUNT(*) FROM notes_fts").fetchone()[0]
+        # Stale-token search must not match — the 'delete' command must have
+        # removed the old tokens from the FTS index.
+        stale_hits = conn.execute(
+            "SELECT COUNT(*) FROM notes_fts WHERE notes_fts MATCH 'alphaunique'"
+        ).fetchone()[0]
+        fresh_hits = conn.execute(
+            "SELECT COUNT(*) FROM notes_fts WHERE notes_fts MATCH 'deltaunique'"
+        ).fetchone()[0]
+        conn.close()
+
+        assert notes_count == 1
+        assert fts_count == 1, (
+            f"notes_fts has {fts_count} rows after 3 updates — "
+            "orphan FTS rows are accumulating (regression)"
+        )
+        assert stale_hits == 0, (
+            "FTS still matches a token from an earlier revision — "
+            "stale tokens are leaking (special 'delete' missing or wrong values)"
+        )
+        assert fresh_hits == 1
+
 
 # ---------------------------------------------------------------------------
 # Commit 2: rebuild_index + index_note


### PR DESCRIPTION
## Summary

Phase 2 of the Friston-inspired memory architecture adds TF-IDF vectorization, incremental theme clustering, and negation-based surprise detection to the vault index. Wires themes into the `/recall` summary upgrade pipeline as best-effort side effects.

### What's new

- **TF-IDF vectorization** — per-note sparse vectors (top-50 terms) with smoothed IDF `1 + ln((N+1)/(df+1))`, stored as JSON in `notes.tfidf_vector`
- **Incremental `term_df` table** — document-frequency counts maintained via symmetric-difference batching on every upsert/delete (caller-owned transaction)
- **Theme engine** — `themes` + `theme_members` tables, `assign_to_theme()` with `BEGIN IMMEDIATE`, running-average centroid, `INSERT ... ON CONFLICT DO UPDATE SET similarity` (preserves surprise + added_date on reassignment), already-member gate so reassignment doesn't double-count or drift the centroid
- **`_delete_note` maintains theme invariants** — unfolds the running-average centroid (`(centroid*count - note_vec)/(count-1)`), drops the theme when the last member leaves, cascades `theme_members` cleanup
- **Surprise scoring** — `detect_surprise()` uses an 8-token negation-proximity window over the top-10 shared TF-IDF terms; apostrophe normalization (straight + smart) so contractions `don't`/`can't`/`won't`/`isn't`/… all register
- **`/recall` wiring** — `upgrade_note_with_summary()` now runs `index_note` → `assign_to_theme` → surprise update (all best-effort, gated on `_reindex_ok = bool(index_note(...))`); every swallowed exception leaves a stderr breadcrumb
- **FTS5 orphan cleanup** — `_upsert_note` and `_delete_note` issue the contentless-FTS5 `INSERT INTO notes_fts(notes_fts, rowid, title, body, tags) VALUES('delete', ...)` special command before `DELETE FROM notes`, so the FTS index doesn't grow unbounded across note rewrites
- **Transaction discipline** — `index_note` and `_sync` both open `BEGIN IMMEDIATE` + commit/rollback so concurrent hooks serialize cleanly and mid-loop failures don't poison the connection
- **Optional deps** — `check_optional_deps()` with broad exception catch (numpy/scipy can raise `OSError`/`ValueError` on broken binaries), `optional_deps_prompted`/`optional_deps_declined` config fields (`deepcopy` of defaults to prevent shared-mutable-list leakage), `/obsidian-setup --deps` flag with idempotent 3-way prompt and atomic config writes (`tempfile.mkstemp + os.chmod(tmp, 0o600) + os.replace`)

### Phase 1 follow-ups included
- `_batch_log_access()` with per-row project attribution (executemany + single commit in `search_vault` and `query_related_notes`)
- `_is_under()` uses `Path.is_relative_to()` to fix sibling-prefix folder false matches in vault sync

## Review cycles

- **Copilot × 4 rounds** — 14 comments total, 13 fixed + 1 deferred to issue #42
- **pr-review-toolkit × 3 agents** (code-reviewer + silent-failure-hunter + pr-test-analyzer, parallel) — 5 findings, all addressed in `feeece2`
- **Dev-test pass on 403-note vault** — caught a real `term_df` drift bug that 522 pytest + 27 validator assertions all missed. Fixed in `cf12d66` with two new regression gates.

## Dev-test bug fix (`cf12d66`)

`_prior_terms_for()` read back the stored `tfidf_vector` keys, which are truncated to top-K=50. Callers pass `new_terms` as the full token set. Common-but-low-IDF terms (e.g. `project`) that sit outside the top-50 cutoff were incremented on every reindex without a matching decrement, causing `term_df.df` to drift past the total note count.

Rewritten as `_prior_tokens_for()`: re-tokenizes `title+tags+body` so old/new sets come from the same pipeline. Symmetric-diff invariant now holds across repeated `index_note` calls.

Regression gates:
- pytest `test_reindex_does_not_drift_term_df` (3× reindex, assert `term_df` unchanged)
- validator `test_reindex_invariance` (same property, real DB)

Existing drift on running vaults clears on `rebuild_index()`. Re-run of dev-test Steps 8–11 post-fix: **bash 10/0/4, validator 29/0**.

## Copilot round 4 fixes (`6bb6ce1`)

- **`rebuild_index()` missing access-log indexes** — was calling `_init_schema()` + `_ensure_theme_indexes()` but not `_ensure_access_log_indexes()`, so post-rebuild the DB was missing `idx_access_note` / `idx_access_time` until the next `ensure_index()`. `TestRebuildIndex` now asserts both indexes exist after rebuild.
- **`validate_phase2.py --help` crashed on missing hooks path** — module-level hook resolution ran before argparse. Guarded on `_HELP_REQUESTED` so `--help` prints usage even when the plugin cache is absent.

## Stats

- 33 commits, 10 files changed
- **523 tests passing** at 90%+ coverage (+1 reindex-invariance pytest)
- **29 numerical validator assertions** (+2 reindex-invariance + delete-unfold checks)
- New test modules: tfidf, themes, surprise, optional-deps, batch-access-logging, sync-path-containment; added tests to vault_index for FTS orphan, BEGIN IMMEDIATE trace, _sync rollback, rebuild-index access-log coverage

## Test plan

- [x] Full pytest suite (523 green)
- [x] `./scripts/commit-preflight.sh` on every commit (secrets, version-sync, tests, 90% coverage)
- [x] Copilot 4-iteration review (all threads resolved)
- [x] pr-review-toolkit 3-agent parallel review (all findings addressed)
- [x] `/dev-test install` into plugin cache
- [x] Fresh CC session 12-step procedure: 11/12 clean on first pass, caught `term_df` drift
- [x] Post-fix re-run Steps 8–11: all green; `max df=406 ≤ note_count=406`
- [x] `/obsidian-setup --deps` idempotency: install-yes + re-run early-exit branches exercised

## Phase 3 follow-ups (tracked in #42 and PR description)

1. **#42** Two-pass `tfidf_vector` recompute on bulk rebuild (order-dependent IDF on fresh ingestion)
2. Bulk `term_df` fetch in `_upsert_note` (currently reads entire `term_df` per note)
3. Theme candidate cap in `assign_to_theme` (linear scan today)
4. Surprise pipeline consolidation — return vecs from `assign_to_theme` instead of opening a third connection to recompute
5. Split `hooks/vault_index.py` (1600+ lines) into `tfidf.py` + `themes.py`
6. `/consolidate` skill — theme *creation* is missing. `assign_to_theme` only joins to existing themes; themes table stays empty until `/consolidate` ships (specced in Friston memory design §208)
7. Dev-test `--deps` skip/not-now branches untested when deps already installed — run in a clean env or mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)