### PR TITLE
feat: snapshot summary integration (Phase A + D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **snapshots**: First-class mid-session checkpoint support. Snapshots now carry `status: auto-logged` (or `summarized`) and `source_session_note` wikilink frontmatter, use seconds-resolution filenames (`-snapshot-HHMMSS`), and are AI-summarized lazily at `/recall` time alongside session notes via a dedicated snapshot prompt
+- **session-end**: Threshold bypass — writes the session note even when the transcript is below `min_turns`/`min_duration_minutes` if sibling snapshots exist, so every snapshot has a navigable parent anchor. Emits a `snapshots: [...]` list when siblings are present
+- **recall**: `_augment_session_input_with_snapshots()` prepends snapshot summary bodies to the session summarization input so the generated summary describes the full pre- and post-compact arc cohesively
+- **recall**: Nested `↳ HH:MM:SS` snapshot rows in the session history table; `LOAD_MANIFEST` surfaces `snapshot_count` and per-snapshot summaries at auto-load depth
+- **vault-index**: `log_access()` cascades snapshot accesses to the parent session via a single `executemany`, preventing hot snapshots from outranking their own parent under activation scoring
+- **obsidian_utils**: Public helper `fetch_snapshot_summaries(sessions_folder, session_id, date, project)` returning ordered snapshot dicts for presentation reuse across skills; `find_snapshots_for_session()` promoted to public API
+- **vault-stats**: `## Snapshots` section — trigger breakdown (compact/clear/auto), sessions-with-snapshots, max snapshots per session, orphan and broken-backlink counters, summarization fraction
+- **emerge**: `--include-snapshots` opt-in flag. `collect_vault_corpus()` gains `include_types` / `exclude_types` kwargs (default excludes `claude-snapshot` so mid-session "Key context" bullets don't dilute cross-session pattern synthesis); `run_corpus` cache key includes `include_snapshots` to prevent shape-mismatch returns
+- **check-items**: `collect_open_items()` filters to `type: claude-session` (legacy notes without a `type:` field preserved as sessions); snapshot bullets no longer produce false-positive open-item proposals
+- **vault-search**: Session hits annotate with `· 📸 N` marker and list snapshots as nested `↳ HH:MM:SS` rows; snapshot hits annotate with `→ [[parent-stem]]`; loading a snapshot pick opens the parent session at session-depth (body + all snapshot summaries)
+- **vault-ask**: Synthesis pool includes parent session body for snapshot hits and snapshot summaries for session hits, so answers reflect the full session arc rather than the post-compact tail; snapshot citations accompany parent-session wikilinks
+- **config**: `/vault-config` and `/obsidian-setup` warn when `snapshot_on_clear` or `snapshot_on_compact` is set to `false`
+
 - **vault-index**: Phase 2 theme engine — `themes`, `theme_members`, and `term_df` tables; `tfidf_vector` JSON column on `notes` (auto-migrated on first `ensure_index()` call)
 - **vault-index**: `_tokenize_for_tfidf()`, `_compute_tfidf_vector()` (smoothed IDF), `_cosine_similarity()` for sparse dict vectors, `_update_term_df()` for incremental IDF maintenance
 - **vault-index**: `assign_to_theme()` — incremental cosine-similarity clustering after note summarization; notes joining a theme update its centroid via running average under a BEGIN IMMEDIATE transaction so concurrent callers cannot clobber each other
@@ -17,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **config**: `check_optional_deps()` returns import-availability for numpy and scipy
 
 ### Changed
+- **pre-compact hook**: filename pattern extends from `-snapshot.md` to `-snapshot-HHMMSS.md` so multiple `/compact` events in one session no longer collide on write
+- **obsidian_session_log**: writes `snapshots: [...]` back-reference list when sibling snapshots exist for this `session_id` (bidirectional link surface)
 - **recall**: Replace sub-agent batch summarization (Wave 1-2-3) with parallel Haiku pipelines; sub-agents demoted to per-note fallback only
 - **vault-index**: `search_vault()` and `query_related_notes()` now batch their access-log writes via `executemany` on the existing connection (1 commit instead of N, Phase 1 Copilot review deferred item)
 

--- a/hooks/emerge_cli.py
+++ b/hooks/emerge_cli.py
@@ -18,10 +18,17 @@ from obsidian_utils import (
 )
 
 
-def run_corpus(days: int = 30) -> None:
+def run_corpus(days: int = 30, include_snapshots: bool = False) -> None:
     """Upgrade unsummarized notes and collect vault corpus for /emerge.
 
     Prints KEY=VALUE lines for SKILL.md to parse.  Exits non-zero on error.
+
+    Args:
+        days: lookback window in days.
+        include_snapshots: when True, snapshot notes are included in the
+            corpus (pass ``--include-snapshots`` from the skill).  Default is
+            False — snapshots are excluded because their transient "key context"
+            bullets dilute cross-session pattern synthesis.
     """
     c = load_config()
     if not c.get("vault_path"):
@@ -29,14 +36,18 @@ def run_corpus(days: int = 30) -> None:
         sys.exit(1)
 
     out = os.path.expanduser("~/.claude/obsidian-brain/emerge-corpus.json")
+    exclude_types: tuple[str, ...] = () if include_snapshots else ("claude-snapshot",)
 
-    # Cache check: reuse if < 15 min old and same window
+    # Cache check: reuse if < 15 min old, same window, and same include_snapshots setting
     if os.path.isfile(out) and (time.time() - os.path.getmtime(out)) < 900:
         try:
             with open(out) as f:
                 cached = json.load(f)
-            if cached.get("stats", {}).get("window_days") == days:
-                s = cached["stats"]
+            s = cached.get("stats", {})
+            if (
+                s.get("window_days") == days
+                and s.get("include_snapshots") == include_snapshots
+            ):
                 print("VAULT=" + c["vault_path"])
                 print("INS=" + c.get("insights_folder", "claude-insights"))
                 print("STATUS=CACHED:" + str(s["total_notes"]) + ":0:0")
@@ -50,25 +61,53 @@ def run_corpus(days: int = 30) -> None:
         c.get("insights_folder", "claude-insights"),
         days,
         out,
+        exclude_types=exclude_types,
     )
+
+    # Patch include_snapshots into stats so cache key round-trips correctly.
+    # We do this after upgrade_and_collect_corpus writes the file because
+    # that function doesn't know about include_snapshots at the stats level —
+    # the cleanest minimal change is a post-write patch here.
+    if os.path.isfile(out):
+        try:
+            with open(out) as f:
+                corpus = json.load(f)
+            corpus.setdefault("stats", {})["include_snapshots"] = include_snapshots
+            import tempfile
+            fd, tmp = tempfile.mkstemp(dir=os.path.dirname(out), suffix=".tmp")
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(corpus, f, indent=2)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, out)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"[obsidian-brain] stats patch failed: {exc}", file=sys.stderr)
+
     print("VAULT=" + c["vault_path"])
     print("INS=" + c.get("insights_folder", "claude-insights"))
     print("STATUS=" + status)
 
 
-def run_recollect(days: int = 30) -> None:
+def run_recollect(days: int = 30, include_snapshots: bool = False) -> None:
     """Re-collect corpus after fallback upgrades (no upgrade pass).
 
     Prints REFRESHED:<count> for SKILL.md to parse.
+
+    Args:
+        days: lookback window in days.
+        include_snapshots: when True, snapshot notes are included in the
+            corpus.  Must match the value used in the preceding run_corpus()
+            call so the corpus stays consistent.
     """
     import tempfile
 
     c = load_config()
+    exclude_types: tuple[str, ...] = () if include_snapshots else ("claude-snapshot",)
     corpus_json = collect_vault_corpus(
         c["vault_path"],
         c.get("sessions_folder", "claude-sessions"),
         c.get("insights_folder", "claude-insights"),
         days,
+        exclude_types=exclude_types,
     )
     out = os.path.expanduser("~/.claude/obsidian-brain/emerge-corpus.json")
     os.makedirs(os.path.dirname(out), exist_ok=True)

--- a/hooks/obsidian_context_snapshot.py
+++ b/hooks/obsidian_context_snapshot.py
@@ -36,6 +36,17 @@ from obsidian_utils import (  # noqa: E402
 # ---------------------------------------------------------------------------
 
 
+def _short_session_hash(session_id: str) -> str:
+    """Return the 4-hex-char short hash used in vault filenames.
+
+    Mirrors make_filename(): sha256(session_id)[:4]. Lifted here to avoid
+    circular dependency when computing the parent session note's filename
+    at snapshot-write time.
+    """
+    import hashlib
+    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:4] if session_id else "e3b0"
+
+
 def _build_snapshot_body(user_msgs: list[str], metadata: dict, trigger: str) -> str:
     """Build the snapshot note body from raw message data."""
     sections: list[str] = []
@@ -90,10 +101,13 @@ def _build_snapshot_note(
     """Construct full snapshot note with YAML frontmatter."""
     date_str = datetime.date.today().isoformat()
     project = metadata.get("project", "unknown")
+    project_slug = slugify(project)
+    sid4 = _short_session_hash(session_id)
+    parent_stem = f"{date_str}-{project_slug}-{sid4}"
 
     tags = [
         "claude/snapshot",
-        f"claude/project/{slugify(project)}",
+        f"claude/project/{project_slug}",
         "claude/auto",
     ]
 
@@ -106,6 +120,8 @@ def _build_snapshot_note(
         f"trigger: {trigger}",
         "tags:",
         *[f"  - {t}" for t in tags],
+        "status: auto-logged",
+        f'source_session_note: "[[{parent_stem}]]"',
         "---",
     ]
 
@@ -190,10 +206,12 @@ def _run() -> None:
     body = _build_snapshot_body(user_msgs, metadata, trigger)
     content = _build_snapshot_note(session_id, metadata, body, trigger)
 
-    # 6. Write to vault with -snapshot suffix
+    # 6. Write to vault with -snapshot-<HHMMSS> suffix (seconds-resolution avoids
+    # collisions between multiple /compact invocations in the same day).
     date_str = datetime.date.today().isoformat()
     project_slug = slugify(metadata.get("project", "session"))
-    filename = make_filename(date_str, project_slug, session_id, suffix="-snapshot")
+    hhmmss = datetime.datetime.now().strftime("%H%M%S")
+    filename = make_filename(date_str, project_slug, session_id, suffix=f"-snapshot-{hhmmss}")
 
     if write_vault_note(vault_path, sessions_folder, filename, content):
         print(f"[obsidian-brain] snapshot written: {filename}", file=sys.stderr)

--- a/hooks/obsidian_context_snapshot.py
+++ b/hooks/obsidian_context_snapshot.py
@@ -26,6 +26,7 @@ from obsidian_utils import (  # noqa: E402
     load_config,
     make_filename,
     read_transcript,
+    scrub_secrets,
     slugify,
     write_vault_note,
 )
@@ -34,17 +35,6 @@ from obsidian_utils import (  # noqa: E402
 # ---------------------------------------------------------------------------
 # Snapshot body construction
 # ---------------------------------------------------------------------------
-
-
-def _short_session_hash(session_id: str) -> str:
-    """Return the 4-hex-char short hash used in vault filenames.
-
-    Mirrors make_filename(): sha256(session_id)[:4]. Lifted here to avoid
-    circular dependency when computing the parent session note's filename
-    at snapshot-write time.
-    """
-    import hashlib
-    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:4] if session_id else "e3b0"
 
 
 def _build_snapshot_body(user_msgs: list[str], metadata: dict, trigger: str) -> str:
@@ -62,7 +52,7 @@ def _build_snapshot_body(user_msgs: list[str], metadata: dict, trigger: str) -> 
     )
     sections.append("Recent user messages:")
     for i, msg in enumerate(recent, 1):
-        snippet = msg[:300].replace("\n", " ")
+        snippet = scrub_secrets(msg[:300].replace("\n", " "))
         sections.append(f"{i}. {snippet}")
     sections.append("")
 
@@ -97,13 +87,23 @@ def _build_snapshot_note(
     metadata: dict,
     body: str,
     trigger: str,
+    date_str: str | None = None,
 ) -> str:
-    """Construct full snapshot note with YAML frontmatter."""
-    date_str = datetime.date.today().isoformat()
+    """Construct full snapshot note with YAML frontmatter.
+
+    ``date_str`` is optional; if omitted, today() is used. Callers that also
+    construct a filename should pass their pre-computed ``date_str`` so the
+    backlink stem and the actual filename can never skew across a midnight
+    clock tick inside a single _run() invocation.
+    """
+    if date_str is None:
+        date_str = datetime.date.today().isoformat()
     project = metadata.get("project", "unknown")
     project_slug = slugify(project)
-    sid4 = _short_session_hash(session_id)
-    parent_stem = f"{date_str}-{project_slug}-{sid4}"
+    # Derive the parent session note's filename stem via the same helper the
+    # session log uses, so the backlink can never drift from the real file.
+    parent_filename = make_filename(date_str, project_slug, session_id)
+    parent_stem = parent_filename[:-3] if parent_filename.endswith(".md") else parent_filename
 
     tags = [
         "claude/snapshot",
@@ -202,15 +202,20 @@ def _run() -> None:
     user_msgs = extract_user_messages(messages)
     metadata = extract_session_metadata(messages, cwd)
 
-    # 5. Build snapshot note
+    # 5. Build snapshot note.
+    # Compute date_str + hhmmss together so the frontmatter backlink stem
+    # (which embeds date_str) and the filename (which embeds both) share the
+    # same single source of truth — no midnight-rollover skew inside one run.
+    now = datetime.datetime.now()
+    date_str = now.date().isoformat()
+    hhmmss = now.strftime("%H%M%S")
+    project_slug = slugify(metadata.get("project", "session"))
+
     body = _build_snapshot_body(user_msgs, metadata, trigger)
-    content = _build_snapshot_note(session_id, metadata, body, trigger)
+    content = _build_snapshot_note(session_id, metadata, body, trigger, date_str=date_str)
 
     # 6. Write to vault with -snapshot-<HHMMSS> suffix (seconds-resolution avoids
     # collisions between multiple /compact invocations in the same day).
-    date_str = datetime.date.today().isoformat()
-    project_slug = slugify(metadata.get("project", "session"))
-    hhmmss = datetime.datetime.now().strftime("%H%M%S")
     filename = make_filename(date_str, project_slug, session_id, suffix=f"-snapshot-{hhmmss}")
 
     if write_vault_note(vault_path, sessions_folder, filename, content):

--- a/hooks/obsidian_context_snapshot.py
+++ b/hooks/obsidian_context_snapshot.py
@@ -21,6 +21,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from obsidian_utils import (  # noqa: E402
+    extract_assistant_messages,
     extract_session_metadata,
     extract_user_messages,
     load_config,
@@ -37,8 +38,22 @@ from obsidian_utils import (  # noqa: E402
 # ---------------------------------------------------------------------------
 
 
-def _build_snapshot_body(user_msgs: list[str], metadata: dict, trigger: str) -> str:
-    """Build the snapshot note body from raw message data."""
+def _build_snapshot_body(
+    user_msgs: list[str],
+    metadata: dict,
+    trigger: str,
+    assistant_msgs: list[str] | None = None,
+) -> str:
+    """Build the snapshot note body from raw message data.
+
+    Emits a trailing ``## Last messages (raw)`` section with alternating
+    ``**User:**`` / ``**Assistant:**`` lines so that the shared raw-fallback
+    parser in ``upgrade_unsummarized_note()`` can summarize a snapshot even
+    when its JSONL transcript is no longer available (e.g. the session has
+    been closed and the transcript garbage-collected).
+    """
+    if assistant_msgs is None:
+        assistant_msgs = []
     sections: list[str] = []
     project = metadata.get("project", "unknown")
 
@@ -78,6 +93,26 @@ def _build_snapshot_body(user_msgs: list[str], metadata: dict, trigger: str) -> 
     else:
         sections.append("No file modifications detected.")
     sections.append("")
+
+    # Raw-fallback section: interleave last N user + assistant messages so
+    # upgrade_unsummarized_note() can summarize from this file alone when
+    # the JSONL transcript is gone. Matches the section header consumed by
+    # the shared parser in obsidian_utils.py.
+    _RAW_TAIL = 6
+    recent_users = user_msgs[-_RAW_TAIL:] if len(user_msgs) > _RAW_TAIL else user_msgs
+    recent_asst = assistant_msgs[-_RAW_TAIL:] if len(assistant_msgs) > _RAW_TAIL else assistant_msgs
+    sections.append("## Last messages (raw)")
+    # Alternate as best we can — some sessions are user-heavy or assistant-heavy.
+    max_len = max(len(recent_users), len(recent_asst))
+    for i in range(max_len):
+        if i < len(recent_users):
+            clean = scrub_secrets(recent_users[i][:800].replace("\n", " "))
+            sections.append(f"**User:** {clean}")
+            sections.append("")
+        if i < len(recent_asst):
+            clean = scrub_secrets(recent_asst[i][:800].replace("\n", " "))
+            sections.append(f"**Assistant:** {clean}")
+            sections.append("")
 
     return "\n".join(sections)
 
@@ -200,6 +235,7 @@ def _run() -> None:
         return
 
     user_msgs = extract_user_messages(messages)
+    assistant_msgs = extract_assistant_messages(messages)
     metadata = extract_session_metadata(messages, cwd)
 
     # 5. Build snapshot note.
@@ -211,7 +247,8 @@ def _run() -> None:
     hhmmss = now.strftime("%H%M%S")
     project_slug = slugify(metadata.get("project", "session"))
 
-    body = _build_snapshot_body(user_msgs, metadata, trigger)
+    body = _build_snapshot_body(user_msgs, metadata, trigger,
+                                assistant_msgs=assistant_msgs)
     content = _build_snapshot_note(session_id, metadata, body, trigger, date_str=date_str)
 
     # 6. Write to vault with -snapshot-<HHMMSS> suffix (seconds-resolution avoids

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -8,6 +8,8 @@ slow subprocess calls like `claude -p` get killed when the process tree exits).
 Always exits 0.
 """
 
+from __future__ import annotations
+
 import datetime
 import json
 import os
@@ -179,16 +181,30 @@ def _run() -> None:
 
         # 4a. Discover sibling snapshots EARLY — their presence overrides
         # every threshold skip. Runs once; reused by both skip checks below.
-        date_str_for_glob = datetime.date.today().isoformat()
+        # Scan today AND yesterday so a session that spans midnight still
+        # finds snapshots written with the previous day's date prefix (Copilot
+        # PR #43 finding). The glob is keyed by date in find_snapshots_for_session;
+        # a single-day lookup would silently miss cross-midnight snapshots
+        # and both drop the threshold bypass and the back-reference list.
+        today = datetime.date.today()
+        candidate_dates = [
+            today.isoformat(),
+            (today - datetime.timedelta(days=1)).isoformat(),
+        ]
         sessions_dir = Path(vault_path) / sessions_folder
         # Use Path(cwd).name to handle trailing-slash cwd; then slugify to match
         # what extract_session_metadata() + make_filename() do canonically.
         early_project = slugify(Path(cwd).name) if cwd else ""
-        snapshots = (
-            find_snapshots_for_session(sessions_dir, session_id,
-                                       date_str_for_glob, early_project)
-            if early_project else []
-        )
+        snapshots: list[str] = []
+        if early_project:
+            seen: set[str] = set()
+            for d in candidate_dates:
+                for link in find_snapshots_for_session(
+                    sessions_dir, session_id, d, early_project
+                ):
+                    if link not in seen:
+                        seen.add(link)
+                        snapshots.append(link)
 
         # 5. Skip check (message count only)
         if should_skip_session(user_msgs, 0, min_messages=min_messages, min_duration=min_duration):
@@ -215,9 +231,13 @@ def _run() -> None:
         # preserves the early bypass when the canonical project diverges.
         canonical_project = metadata.get("project", "")
         if canonical_project and canonical_project != early_project:
-            canonical_hits = find_snapshots_for_session(
-                sessions_dir, session_id, date_str_for_glob, canonical_project
-            )
+            canonical_hits: list[str] = []
+            for d in candidate_dates:
+                canonical_hits.extend(
+                    find_snapshots_for_session(
+                        sessions_dir, session_id, d, canonical_project
+                    )
+                )
             # Merge, de-dupe, preserve chronological order (sorted wikilinks).
             snapshots = sorted(set(snapshots) | set(canonical_hits))
         metadata["snapshots"] = snapshots

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -12,6 +12,7 @@ import datetime
 import json
 import os
 import sys
+from pathlib import Path
 
 # ---------------------------------------------------------------------------
 # Import shared utilities
@@ -25,6 +26,7 @@ from obsidian_utils import (  # noqa: E402
     extract_session_metadata,
     extract_tool_uses,
     extract_user_messages,
+    find_snapshots_for_session,
     is_resumed_session,
     load_config,
     make_filename,
@@ -86,6 +88,12 @@ def _build_note(
     ]
     if resumed:
         fm_lines.append("resumed: true")
+    # Snapshot back-reference: append only if the caller discovered siblings.
+    snapshots = metadata.get("snapshots") or []
+    if snapshots:
+        fm_lines.append("snapshots:")
+        for s in snapshots:
+            fm_lines.append(f'  - "{s}"')
     fm_lines.extend([
         "tags:",
         *[f"  - {t}" for t in tags],
@@ -169,22 +177,63 @@ def _run() -> None:
         user_msgs = extract_user_messages(messages)
         assistant_msgs = extract_assistant_messages(messages)
 
-        # 5. Skip check
+        # 4a. Discover sibling snapshots EARLY — their presence overrides
+        # every threshold skip. Runs once; reused by both skip checks below.
+        date_str_for_glob = datetime.date.today().isoformat()
+        sessions_dir = Path(vault_path) / sessions_folder
+        # Use Path(cwd).name to handle trailing-slash cwd; then slugify to match
+        # what extract_session_metadata() + make_filename() do canonically.
+        early_project = slugify(Path(cwd).name) if cwd else ""
+        snapshots = (
+            find_snapshots_for_session(sessions_dir, session_id,
+                                       date_str_for_glob, early_project)
+            if early_project else []
+        )
+
+        # 5. Skip check (message count only)
         if should_skip_session(user_msgs, 0, min_messages=min_messages, min_duration=min_duration):
-            # Duration not yet known; check message count only (duration=0 bypasses duration check)
-            print(f"[obsidian-brain] too few user messages ({len(user_msgs)}), skipping", file=sys.stderr)
-            return
+            if not snapshots:
+                print(f"[obsidian-brain] too few user messages ({len(user_msgs)}), skipping",
+                      file=sys.stderr)
+                return
+            print(
+                f"[obsidian-brain] below message threshold but {len(snapshots)} snapshot(s) "
+                "exist — writing session note anyway as anchor",
+                file=sys.stderr,
+            )
 
         # 6. Extract metadata
         metadata = extract_session_metadata(messages, cwd)
         metadata["vault_path"] = vault_path
         metadata["sessions_folder"] = sessions_folder
 
-        # Re-check with actual duration
+        # 6a. Canonical snapshot discovery using the parsed metadata's project.
+        # Re-run because early_project (basename of cwd) may differ from
+        # metadata["project"] for non-standard repo layouts. Union the
+        # results — session_id already filters to this session's snapshots,
+        # so any hit from either glob is a real back-reference. This also
+        # preserves the early bypass when the canonical project diverges.
+        canonical_project = metadata.get("project", "")
+        if canonical_project and canonical_project != early_project:
+            canonical_hits = find_snapshots_for_session(
+                sessions_dir, session_id, date_str_for_glob, canonical_project
+            )
+            # Merge, de-dupe, preserve chronological order (sorted wikilinks).
+            snapshots = sorted(set(snapshots) | set(canonical_hits))
+        metadata["snapshots"] = snapshots
+
+        # Re-check with actual duration — BUT if snapshots exist, bypass
+        # thresholds so the session note always anchors the snapshots.
         if should_skip_session(user_msgs, metadata["duration_minutes"],
                                min_messages=min_messages, min_duration=min_duration):
-            print(f"[obsidian-brain] session below thresholds, skipping", file=sys.stderr)
-            return
+            if not snapshots:
+                print("[obsidian-brain] session below thresholds, skipping", file=sys.stderr)
+                return
+            print(
+                f"[obsidian-brain] below thresholds but {len(snapshots)} snapshot(s) exist — "
+                "writing session note anyway as anchor",
+                file=sys.stderr,
+            )
 
         # 7. Detect resumed session
         resumed = is_resumed_session(vault_path, sessions_folder, session_id)

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -677,12 +677,14 @@ def _augment_session_input_with_snapshots(
     if not blocks:
         return transcript
 
-    return (
-        "===== EARLIER IN THIS SESSION (from snapshots) =====\n\n"
-        + "\n\n".join(blocks)
-        + "\n\n===== CURRENT TAIL (post-compact transcript) =====\n\n"
-        + transcript
-    )
+    prefix = "===== EARLIER IN THIS SESSION (from snapshots) =====\n\n" + "\n\n".join(blocks)
+    if transcript:
+        return (
+            prefix
+            + "\n\n===== CURRENT TAIL (post-compact transcript) =====\n\n"
+            + transcript
+        )
+    return prefix
 
 
 def match_items_against_evidence(

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -563,6 +563,44 @@ def read_note_metadata(file_path: str) -> dict | None:
     return meta
 
 
+def find_snapshots_for_session(
+    sessions_folder_path: Path, session_id: str, date: str, project: str
+) -> list[str]:
+    """Return chronologically-sorted wikilinks of all snapshots whose
+    frontmatter session_id and project match the given session. Empty list
+    if none exist.
+
+    Matching rules:
+    - Filename pattern: <date>-<project-slug>-*-snapshot*.md (captures both
+      pre-spec `-snapshot.md` and post-spec `-snapshot-<HHMMSS>.md`).
+    - Requires frontmatter `session_id` AND `project` to match.
+    - Malformed snapshots are logged to stderr and skipped — one bad file
+      must not block back-reference writing.
+
+    Sorted lexicographically by filename stem; HHMMSS suffix makes this
+    chronological for post-spec snapshots. Pre-spec (no HHMMSS) sorts first.
+    """
+    if not sessions_folder_path.is_dir():
+        return []
+    slug = slugify(project)
+    wikilinks: list[str] = []
+    for p in sorted(sessions_folder_path.glob(f"{date}-{slug}-*-snapshot*.md")):
+        try:
+            meta = read_note_metadata(str(p))
+            if not meta:
+                continue
+            if meta.get("session_id") == session_id and (
+                meta.get("project", "").lower() == project.lower()
+                or slugify(meta.get("project", "")) == slug
+            ):
+                wikilinks.append(f"[[{p.stem}]]")
+        except Exception as exc:  # noqa: BLE001
+            print(f"[obsidian-brain] skipping malformed snapshot {p.name}: {exc}",
+                  file=sys.stderr)
+            continue
+    return wikilinks
+
+
 def match_items_against_evidence(
     evidence_text: str,
     open_items: list[tuple[str, int, str]],

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -601,6 +601,90 @@ def find_snapshots_for_session(
     return wikilinks
 
 
+_SECTION_RE_CACHE: dict[tuple[str, ...], re.Pattern] = {}
+
+
+def _extract_sections(body: str, section_headers: tuple[str, ...]) -> str:
+    """Return concatenated content of the named `## Foo` sections, or '' if none.
+
+    Header matching is literal — case-sensitive, full-line. Sections end at
+    the next `## ` heading or EOF. Empty string if no section matches.
+    """
+    key = tuple(section_headers)
+    if key not in _SECTION_RE_CACHE:
+        pattern = "|".join(re.escape(h) for h in section_headers)
+        _SECTION_RE_CACHE[key] = re.compile(
+            rf"^({pattern})\s*$\n(.*?)(?=^## |\Z)",
+            re.MULTILINE | re.DOTALL,
+        )
+    chunks = []
+    for m in _SECTION_RE_CACHE[key].finditer(body):
+        chunks.append(m.group(1) + "\n" + m.group(2).strip())
+    return "\n\n".join(chunks)
+
+
+def _extract_hhmmss_from_filename(filename: str) -> str:
+    """Return the HHMMSS suffix from a post-spec snapshot filename, or '??????'."""
+    m = re.search(r"-snapshot-(\d{6})\.md$", filename)
+    return m.group(1) if m else "??????"
+
+
+def _augment_session_input_with_snapshots(
+    transcript: str,
+    sessions_folder_path: Path,
+    session_id: str,
+    date: str,
+    project: str,
+) -> str:
+    """Prepend sibling snapshot bodies (preferring summaries) to session input.
+
+    Used by the session-note branch of upgrade_unsummarized_note to give
+    generate_summary a cohesive view of the whole arc, not just the
+    post-last-compact tail.
+
+    Returns the original transcript unchanged if no snapshots exist.
+    """
+    wikilinks = find_snapshots_for_session(sessions_folder_path, session_id, date, project)
+    if not wikilinks:
+        return transcript
+
+    blocks: list[str] = []
+    for link in wikilinks:
+        stem = link.strip("[]")
+        snap_path = sessions_folder_path / f"{stem}.md"
+        if not snap_path.exists():
+            continue
+        try:
+            body = snap_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        hh = _extract_hhmmss_from_filename(snap_path.name)
+        meta = read_note_metadata(str(snap_path)) or {}
+        trigger = meta.get("trigger", "compact")
+        summary_block = _extract_sections(
+            body, ("## Summary", "## Key context that may be lost (summary)")
+        )
+        if not summary_block.strip():
+            summary_block = _extract_sections(
+                body,
+                ("## What was happening", "## Key context that may be lost",
+                 "## Uncommitted work", "## Last messages (raw)"),
+            )
+        if not summary_block.strip():
+            continue
+        blocks.append(f"[snapshot {hh}, trigger={trigger}]\n{summary_block}")
+
+    if not blocks:
+        return transcript
+
+    return (
+        "===== EARLIER IN THIS SESSION (from snapshots) =====\n\n"
+        + "\n\n".join(blocks)
+        + "\n\n===== CURRENT TAIL (post-compact transcript) =====\n\n"
+        + transcript
+    )
+
+
 def match_items_against_evidence(
     evidence_text: str,
     open_items: list[tuple[str, int, str]],
@@ -1113,13 +1197,24 @@ def generate_summary(
     user_sample = "\n---\n".join(sampled_user)[:12000]
     assistant_sample = "\n---\n".join(sampled_asst)[:12000]
 
-    prompt = f"""You are a technical summarizer. You will be given the transcript of a Claude Code coding session. Your job is to produce a structured summary. Do NOT respond conversationally. Do NOT ask questions. Just output the summary.
+    preamble = metadata.get("snapshot_preamble", "")
+    cohesion_hint = ""
+    if preamble:
+        cohesion_hint = (
+            "\nSome earlier context may come from pre-compact snapshots — "
+            "synthesize the whole arc into a cohesive narrative rather than "
+            "three disjoint summaries.\n"
+        )
 
+    prompt = f"""You are a technical summarizer. You will be given the transcript of a Claude Code coding session. Your job is to produce a structured summary. Do NOT respond conversationally. Do NOT ask questions. Just output the summary.
+{cohesion_hint}
 SESSION METADATA:
 - Project: {metadata.get('project', 'unknown')}
 - Branch: {metadata.get('git_branch', 'unknown')}
 - Duration: {metadata.get('duration_minutes', 0)} minutes
 - Files touched: {', '.join(metadata.get('files_touched', [])[:15]) or 'none detected'}
+
+{preamble}
 
 TRANSCRIPT (user and assistant messages):
 {user_sample}
@@ -3270,6 +3365,21 @@ def upgrade_unsummarized_note(
             user_msgs, assistant_msgs, metadata, **gen_kwargs,
         )
     else:
+        # Session — augment with snapshot bodies for cohesion.
+        date_str = ""
+        for line in raw_lines[:20]:
+            if line.strip().startswith("date:"):
+                date_str = line.split(":", 1)[1].strip().strip('"').strip("'")
+                break
+        sessions_dir_path = Path(vault_path) / sessions_folder
+        preamble = _augment_session_input_with_snapshots(
+            "", sessions_dir_path, session_id, date_str, project,
+        )
+        if preamble:
+            # Stash the snapshot preamble into metadata so generate_summary can
+            # prepend it to its sampled transcript. New optional key; existing
+            # callers unaffected (absent key → no-op).
+            metadata["snapshot_preamble"] = preamble
         summary_text = generate_summary(
             user_msgs, assistant_msgs, metadata, **gen_kwargs,
         )

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -2142,12 +2142,25 @@ def collect_vault_corpus(
     sessions_folder: str,
     insights_folder: str,
     days: int = 7,
+    include_types: tuple[str, ...] | None = None,
+    exclude_types: tuple[str, ...] = ("claude-snapshot",),
 ) -> str:
     """Scan vault session and insight notes, date-filter, extract structured data.
 
     Returns JSON string with keys: date_range, note_count, notes[].
     Each note has: file, type, date, project, tags, summary, decisions,
     errors, open_items.
+
+    Type filtering:
+        exclude_types: note types to drop (default: ``("claude-snapshot",)``).
+            Pass ``exclude_types=()`` to include all types.
+        include_types: when not None, only notes whose type is in this tuple
+            are kept (applied after exclude_types).
+
+    By default, ``claude-snapshot`` notes are excluded because their
+    "Key context that may be lost" bullets are transient mid-session content
+    that dilutes cross-session pattern synthesis in /emerge.  Pass
+    ``exclude_types=()`` to opt in.
 
     Security: path containment via resolve() + is_relative_to().
     Note: scrub_secrets() is NOT called — content is already scrubbed at write time.
@@ -2239,6 +2252,11 @@ def collect_vault_corpus(
 
             note_type = meta.get("type", default_type)
 
+            if exclude_types and note_type in exclude_types:
+                continue
+            if include_types is not None and note_type not in include_types:
+                continue
+
             notes_out.append(
                 {
                     "file": md_file.name,
@@ -2267,13 +2285,16 @@ def upgrade_and_collect_corpus(
     insights_folder: str,
     days: int,
     output_path: str,
+    include_types: tuple[str, ...] | None = None,
+    exclude_types: tuple[str, ...] = ("claude-snapshot",),
 ) -> str:
     """Upgrade unsummarized notes then collect corpus in a single pass.
 
     1. Scan sessions folder for notes with ``status: auto-logged`` within
        the date window and attempt ``upgrade_unsummarized_note()`` on each.
     2. Call ``collect_vault_corpus()`` to build the full corpus (including
-       freshly upgraded notes).
+       freshly upgraded notes).  ``include_types`` / ``exclude_types`` are
+       forwarded verbatim — see ``collect_vault_corpus`` docstring for details.
     3. Atomically write corpus JSON to *output_path*.
     4. Return status line: ``OK:<total>:<upgraded>:<failed>`` or
        ``EMPTY:0:0:0``.
@@ -2336,7 +2357,9 @@ def upgrade_and_collect_corpus(
 
     # --- Phase 2: collect corpus (now includes freshly upgraded notes) ---
     corpus_json = collect_vault_corpus(
-        vault_path, sessions_folder, insights_folder, days
+        vault_path, sessions_folder, insights_folder, days,
+        include_types=include_types,
+        exclude_types=exclude_types,
     )
     corpus = json.loads(corpus_json)
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1013,6 +1013,72 @@ def parse_importance(summary_text: str) -> int:
     return 5
 
 
+SNAPSHOT_SUMMARY_PROMPT = """You are a technical summarizer. You will be given the tail of a Claude Code session, captured the moment before the user invoked /compact or /clear. Your job is to produce a SHORT pre-compact checkpoint summary. Do NOT respond conversationally. Do NOT ask questions.
+
+Context: the user is about to lose the in-context conversation. What they need from this summary later is: (1) what they were working on, (2) what progress they had just made, (3) what was in flight — unanswered questions, half-finished thoughts, assumptions not yet tested.
+
+Do NOT restate decisions that were already committed or finalized — those will be captured in the parent session's cohesive summary later. Focus on what's transient and in flight.
+
+TRANSCRIPT:
+{transcript}
+
+OUTPUT EXACTLY these two sections with no preamble, no commentary:
+
+## Summary
+2-4 sentences: what was happening, what progress mattered, why context was about to be compacted or cleared.
+
+## Key context that may be lost (summary)
+- 3-7 bullets: in-flight decisions, open questions, silent assumptions, hypotheses not yet verified.
+"""
+
+
+def generate_snapshot_summary(
+    user_msgs: list[str],
+    assistant_msgs: list[str],
+    metadata: dict,
+    model: str = "haiku",
+    timeout: int = 30,
+) -> str | None:
+    """Call ``claude -p --model <model>`` with the snapshot-specific prompt.
+
+    Returns None on failure. Reuses the retry/timeout pattern of
+    generate_summary but with a tighter scope (no open-item dedup, no
+    importance scoring — snapshots don't carry those structural fields).
+    """
+    sampled_user = user_msgs[-10:] if len(user_msgs) > 10 else user_msgs
+    sampled_asst = assistant_msgs[-10:] if len(assistant_msgs) > 10 else assistant_msgs
+    user_sample = "\n---\n".join(sampled_user)[:8000]
+    asst_sample = "\n---\n".join(sampled_asst)[:8000]
+    transcript = f"USER MESSAGES:\n{user_sample}\n\n---\n\nASSISTANT MESSAGES:\n{asst_sample}"
+
+    prompt = SNAPSHOT_SUMMARY_PROMPT.format(transcript=transcript)
+
+    attempts = (timeout, timeout * 2)
+    for i, attempt_timeout in enumerate(attempts):
+        try:
+            result = subprocess.run(
+                ["claude", "-p", "--model", model],
+                input=prompt, capture_output=True, text=True, timeout=attempt_timeout,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+            print(f"[obsidian-brain] claude -p (snapshot) failed (rc={result.returncode})",
+                  file=sys.stderr)
+            break
+        except FileNotFoundError:
+            print("[obsidian-brain] claude CLI not found", file=sys.stderr)
+            break
+        except subprocess.TimeoutExpired:
+            if i < len(attempts) - 1:
+                continue
+            print(f"[obsidian-brain] claude -p (snapshot) timed out at {attempt_timeout}s",
+                  file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[obsidian-brain] claude -p (snapshot) error: {exc}", file=sys.stderr)
+            break
+    return None
+
+
 def generate_summary(
     user_msgs: list[str],
     assistant_msgs: list[str],
@@ -3132,11 +3198,13 @@ def upgrade_unsummarized_note(
     else:
         # Fall back to raw note content for summarization
         source = "raw note (JSONL not found)"
-        # Extract user/assistant messages from raw note conversation section
+        # Extract user/assistant messages from raw note conversation section.
+        # Supports both session notes (## Conversation (raw)) and snapshot notes
+        # (## Last messages (raw)).
         in_conversation = False
         for line in raw_lines:
             stripped = line.strip()
-            if stripped == '## Conversation (raw)':
+            if stripped in ('## Conversation (raw)', '## Last messages (raw)'):
                 in_conversation = True
                 continue
             if in_conversation:
@@ -3153,7 +3221,7 @@ def upgrade_unsummarized_note(
         in_conversation = False
         for line in raw_lines:
             stripped = line.strip()
-            if stripped == '## Conversation (raw)':
+            if stripped in ('## Conversation (raw)', '## Last messages (raw)'):
                 in_conversation = True
                 continue
             if in_conversation:
@@ -3184,13 +3252,25 @@ def upgrade_unsummarized_note(
         metadata["files_touched"] = parsed.get("files_touched", [])
         metadata["errors"] = parsed.get("errors", [])
 
-    # Generate summary
+    # Route by note type — snapshots use a shorter, focused prompt.
+    note_type = ""
+    for line in raw_lines[:20]:
+        if line.strip().startswith("type:"):
+            note_type = line.split(":", 1)[1].strip()
+            break
+
     gen_kwargs: dict = {"model": summary_model}
     if summary_timeout is not None:
         gen_kwargs["timeout"] = summary_timeout
-    summary_text = generate_summary(
-        user_msgs, assistant_msgs, metadata, **gen_kwargs,
-    )
+
+    if note_type == "claude-snapshot":
+        summary_text = generate_snapshot_summary(
+            user_msgs, assistant_msgs, metadata, **gen_kwargs,
+        )
+    else:
+        summary_text = generate_summary(
+            user_msgs, assistant_msgs, metadata, **gen_kwargs,
+        )
 
     if not summary_text:
         return f"Failed: AI summarization returned empty for {os.path.basename(note_path)}"

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1821,6 +1821,7 @@ def build_context_brief(
 
     # History table (last 5 sessions)
     history_rows: list[str] = []
+    most_recent_snaps: list[dict] = []
     for i, (fname, fpath, meta) in enumerate(session_files[:5]):
         date = meta.get('date', '')
         title = meta.get('project', project)
@@ -1858,10 +1859,13 @@ def build_context_brief(
         sid = meta.get("session_id", "")
         note_date = meta.get("date", "")
         if sid and note_date:
-            for sn in fetch_snapshot_summaries(sessions_dir, sid, note_date, project):
+            _snaps = fetch_snapshot_summaries(sessions_dir, sid, note_date, project)
+            if i == 0:
+                most_recent_snaps = _snaps
+            for sn in _snaps:
                 hh = sn["hhmmss"]
                 hhmmss_pretty = (
-                    f"{hh[:2]}:{hh[2:4]}:{hh[4:]}" if hh and hh != "??????" else hh
+                    f"{hh[:2]}:{hh[2:4]}:{hh[4:]}" if hh and hh != "??????" else "--:--:--"
                 )
                 snap_title = sn["summary"][:80]
                 history_rows.append(
@@ -2071,22 +2075,16 @@ def build_context_brief(
     # Snapshot summaries for the most-recent session (if any) — included
     # at auto-load depth: summaries only, not raw transcripts.
     manifest_snapshot_lines: list[str] = []
-    if most_recent_path:
-        meta_mr = read_note_metadata(most_recent_path) or {}
-        mr_sid = meta_mr.get("session_id", "")
-        mr_date = meta_mr.get("date", "")
-        if mr_sid and mr_date:
-            snaps = fetch_snapshot_summaries(sessions_dir, mr_sid, mr_date, project)
-            if snaps:
-                manifest_snapshot_lines.append(f"snapshot_count: {len(snaps)}")
-                for sn in snaps:
-                    manifest_snapshot_lines.append(
-                        f"snapshot: [{sn['hhmmss']}] ({sn['trigger']}) {sn['summary']}"
-                    )
-                    if sn["key_context"]:
-                        for bullet in sn["key_context"].splitlines():
-                            if bullet.strip():
-                                manifest_snapshot_lines.append(f"  {bullet.strip()}")
+    if most_recent_snaps:
+        manifest_snapshot_lines.append(f"snapshot_count: {len(most_recent_snaps)}")
+        for sn in most_recent_snaps:
+            manifest_snapshot_lines.append(
+                f"snapshot: [{sn['hhmmss']}] ({sn['trigger']}) {sn['summary']}"
+            )
+            if sn["key_context"]:
+                for bullet in sn["key_context"].splitlines():
+                    if bullet.strip():
+                        manifest_snapshot_lines.append(f"  {bullet.strip()}")
 
     manifest_lines = [
         f"full_session_title: {most_recent_title or '(none)'}",

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -687,6 +687,64 @@ def _augment_session_input_with_snapshots(
     return prefix
 
 
+def fetch_snapshot_summaries(
+    sessions_folder_path: Path,
+    session_id: str,
+    date: str,
+    project: str,
+) -> list[dict]:
+    """Return chronologically-sorted summary dicts for a session's snapshots.
+
+    Each dict has: ``path``, ``hhmmss``, ``trigger``, ``summary`` (first
+    sentence of ``## Summary`` if upgraded; first bullet of
+    ``## What was happening`` as fallback; ``"(not yet summarized)"`` if
+    neither exists), ``key_context`` (``## Key context that may be lost
+    (summary)`` if upgraded; ``""`` otherwise).
+
+    Shared helper used by build_context_brief(), the vault-search skill,
+    and vault-ask so presentation stays consistent.
+    """
+    results: list[dict] = []
+    for link in find_snapshots_for_session(sessions_folder_path, session_id, date, project):
+        stem = link.strip("[]")
+        path = sessions_folder_path / f"{stem}.md"
+        if not path.exists():
+            continue
+        try:
+            body = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        meta = read_note_metadata(str(path)) or {}
+        hh = _extract_hhmmss_from_filename(path.name)
+        summary = ""
+        key_context = ""
+
+        summary_match = re.search(r"^## Summary\s*\n(.+?)(?=\n## |\Z)", body, re.MULTILINE | re.DOTALL)
+        if summary_match:
+            summary = summary_match.group(1).strip().split("\n", 1)[0].strip()
+        else:
+            wh_match = re.search(r"^## What was happening\s*\n(.+?)(?=\n## |\Z)",
+                                 body, re.MULTILINE | re.DOTALL)
+            if wh_match:
+                summary = wh_match.group(1).strip().split("\n", 1)[0].strip()
+
+        kc_match = re.search(
+            r"^## Key context that may be lost \(summary\)\s*\n(.+?)(?=\n## |\Z)",
+            body, re.MULTILINE | re.DOTALL,
+        )
+        if kc_match:
+            key_context = kc_match.group(1).strip()
+
+        results.append({
+            "path": str(path),
+            "hhmmss": hh,
+            "trigger": meta.get("trigger", "compact"),
+            "summary": summary or "(not yet summarized)",
+            "key_context": key_context,
+        })
+    return results
+
+
 def match_items_against_evidence(
     evidence_text: str,
     open_items: list[tuple[str, int, str]],
@@ -1681,6 +1739,9 @@ def build_context_brief(
             meta = read_note_metadata(str(f))
             if not meta:
                 continue
+            # Exclude snapshot-type notes from the top-level session table.
+            if meta.get('type') == 'claude-snapshot':
+                continue
             fm_project = meta.get('project', '')
             if fm_project.lower() != project.lower() and slugify(fm_project) != slugify(project):
                 continue
@@ -1792,6 +1853,20 @@ def build_context_brief(
         except OSError:
             pass
         history_rows.append(f"| {i+1} | {date} | {duration} | {title} | {branch} |")
+
+        # Append indented snapshot rows beneath this session.
+        sid = meta.get("session_id", "")
+        note_date = meta.get("date", "")
+        if sid and note_date:
+            for sn in fetch_snapshot_summaries(sessions_dir, sid, note_date, project):
+                hh = sn["hhmmss"]
+                hhmmss_pretty = (
+                    f"{hh[:2]}:{hh[2:4]}:{hh[4:]}" if hh and hh != "??????" else hh
+                )
+                snap_title = sn["summary"][:80]
+                history_rows.append(
+                    f"|   | ↳ {hhmmss_pretty} |  |   {snap_title} | — |"
+                )
 
     # --- 3. Load insights via vault index (layered ranking) ---
     insight_entries: list[tuple[str, str]] = []  # (title, key_point)
@@ -1992,6 +2067,27 @@ def build_context_brief(
             print(f"[obsidian-brain] open-item detection failed (non-fatal): {exc}", file=sys.stderr)
 
     # --- 6. Compose structured output ---
+
+    # Snapshot summaries for the most-recent session (if any) — included
+    # at auto-load depth: summaries only, not raw transcripts.
+    manifest_snapshot_lines: list[str] = []
+    if most_recent_path:
+        meta_mr = read_note_metadata(most_recent_path) or {}
+        mr_sid = meta_mr.get("session_id", "")
+        mr_date = meta_mr.get("date", "")
+        if mr_sid and mr_date:
+            snaps = fetch_snapshot_summaries(sessions_dir, mr_sid, mr_date, project)
+            if snaps:
+                manifest_snapshot_lines.append(f"snapshot_count: {len(snaps)}")
+                for sn in snaps:
+                    manifest_snapshot_lines.append(
+                        f"snapshot: [{sn['hhmmss']}] ({sn['trigger']}) {sn['summary']}"
+                    )
+                    if sn["key_context"]:
+                        for bullet in sn["key_context"].splitlines():
+                            if bullet.strip():
+                                manifest_snapshot_lines.append(f"  {bullet.strip()}")
+
     manifest_lines = [
         f"full_session_title: {most_recent_title or '(none)'}",
         f"full_session_date: {most_recent_date or '(none)'}",
@@ -2000,6 +2096,7 @@ def build_context_brief(
         f"summary_session_date: {second_date or '(none)'}",
         f"insight_count: {insight_count}",
     ]
+    manifest_lines.extend(manifest_snapshot_lines)
 
     # Use unique delimiters that cannot appear in user-authored markdown content
     output_parts = [

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1388,6 +1388,14 @@ def find_unsummarized_notes(
         if not status_match or status_match.group(1).strip() != 'auto-logged':
             continue
 
+        # Type filter — accept both sessions and snapshots. Legacy notes
+        # without a type field are kept (current permissive behavior).
+        type_match = re.search(r'^type:\s*(.+)$', frontmatter, re.MULTILINE)
+        if type_match:
+            type_val = type_match.group(1).strip().strip('"').strip("'")
+            if type_val not in ("claude-session", "claude-snapshot"):
+                continue
+
         # Must match project
         project_match = re.search(r'^project:\s*(.+)$', frontmatter, re.MULTILINE)
         if not project_match:
@@ -1435,6 +1443,27 @@ def find_unsummarized_notes(
 
         unsummarized.append(str(f))
 
+    # Ordering bias: within a session_id group, snapshots sort first so the
+    # per-note pipeline summarizes them before the parent session's cohesion
+    # step runs. Advisory only — Section 5's cohesion helper falls back to
+    # raw bodies for snapshots not yet upgraded.
+    def _bias_key(path_str):
+        name = os.path.basename(path_str)
+        try:
+            content = Path(path_str).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return ("", 1, name)
+        sid = ""
+        typ = ""
+        for line in content.splitlines()[:30]:
+            line = line.strip()
+            if line.startswith("session_id:"):
+                sid = line.split(":", 1)[1].strip().strip('"').strip("'")
+            elif line.startswith("type:"):
+                typ = line.split(":", 1)[1].strip()
+        return (sid, 0 if typ == "claude-snapshot" else 1, name)
+
+    unsummarized.sort(key=_bias_key)
     return json.dumps({"unsummarized": unsummarized, "auto_fixed": auto_fixed})
 
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1354,6 +1354,10 @@ def find_unsummarized_notes(
     filters by project, and checks for false positives (notes that already
     have a real ## Summary but stale status). Auto-fixes stale status inline.
 
+    Accepts notes of type ``claude-session`` and ``claude-snapshot``; rejects
+    other typed notes (e.g. ``claude-insight``). Legacy notes without a
+    ``type:`` field are accepted for backward compatibility.
+
     Returns JSON string: {"unsummarized": [paths], "auto_fixed": N}
     """
     sessions_dir = Path(vault_path) / sessions_folder

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1070,6 +1070,8 @@ def generate_snapshot_summary(
             break
         except subprocess.TimeoutExpired:
             if i < len(attempts) - 1:
+                print(f"[obsidian-brain] claude -p (snapshot) timed out at {attempt_timeout}s, retrying...",
+                      file=sys.stderr)
                 continue
             print(f"[obsidian-brain] claude -p (snapshot) timed out at {attempt_timeout}s",
                   file=sys.stderr)
@@ -3256,7 +3258,7 @@ def upgrade_unsummarized_note(
     note_type = ""
     for line in raw_lines[:20]:
         if line.strip().startswith("type:"):
-            note_type = line.split(":", 1)[1].strip()
+            note_type = line.split(":", 1)[1].strip().strip('"').strip("'")
             break
 
     gen_kwargs: dict = {"model": summary_model}

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -660,7 +660,10 @@ def _augment_session_input_with_snapshots(
             continue
         hh = _extract_hhmmss_from_filename(snap_path.name)
         meta = read_note_metadata(str(snap_path)) or {}
-        trigger = meta.get("trigger", "compact")
+        # Default missing `trigger:` to "auto" (consistent with _snapshot_stats
+        # and fetch_snapshot_summaries) so legacy/malformed notes don't get
+        # mislabeled as compact. Copilot PR #43 round 2 finding.
+        trigger = meta.get("trigger", "auto")
         summary_block = _extract_sections(
             body, ("## Summary", "## Key context that may be lost (summary)")
         )
@@ -738,7 +741,9 @@ def fetch_snapshot_summaries(
         results.append({
             "path": str(path),
             "hhmmss": hh,
-            "trigger": meta.get("trigger", "compact"),
+            # Default missing `trigger:` to "auto" so /recall doesn't mislabel
+            # legacy snapshots as compact. Copilot PR #43 round 2 finding.
+            "trigger": meta.get("trigger", "auto"),
             "summary": summary or "(not yet summarized)",
             "key_context": key_context,
         })
@@ -1687,7 +1692,11 @@ def find_unsummarized_notes(
             if line.startswith("session_id:"):
                 sid = line.split(":", 1)[1].strip().strip('"').strip("'")
             elif line.startswith("type:"):
-                typ = line.split(":", 1)[1].strip()
+                # Strip both quote styles so `type: "claude-snapshot"` and
+                # `type: 'claude-snapshot'` (both valid YAML) sort correctly
+                # under the snapshot-first bias. Copilot PR #43 round 2
+                # finding — sid-line already strips; type-line didn't.
+                typ = line.split(":", 1)[1].strip().strip('"').strip("'")
         return (sid, 0 if typ == "claude-snapshot" else 1, name)
 
     unsummarized.sort(key=_bias_key)

--- a/hooks/open_item_dedup.py
+++ b/hooks/open_item_dedup.py
@@ -64,6 +64,11 @@ def collect_open_items(
 ) -> list[tuple[str, int, str]]:
     """Collect unchecked open items from recent session notes for a project.
 
+    Filters to `type: claude-session` notes; notes without a `type:` field
+    are treated as sessions (legacy). Snapshot notes (`claude-snapshot`) are
+    excluded — their "Key context" bullets often look like action items and
+    would produce false-positive proposals.
+
     Returns [(file_path, line_number, item_text)] from the most recent
     max_sessions session notes matching the project. Single-pass per file,
     early termination, no stat() calls.
@@ -79,7 +84,7 @@ def collect_open_items(
     matched = 0
 
     for fname in all_files:
-        if not fname.endswith('.md') or fname.endswith('-snapshot.md'):
+        if not fname.endswith('.md'):
             continue
 
         fpath = os.path.join(sessions_dir, fname)
@@ -98,17 +103,23 @@ def collect_open_items(
             print(f"[obsidian-brain] encoding error in {fname}: {exc}", file=sys.stderr)
             continue
 
-        # Check frontmatter for project match (first 20 lines)
-        # Strip quotes to handle both `project: foo` and `project: "foo"`
+        # Check frontmatter for project match and type (first 20 lines).
+        # Strip quotes to handle both `project: foo` and `project: "foo"`.
+        # Notes without a `type:` field are treated as claude-session (legacy).
         project_match = False
+        is_session = True  # default for notes with no type field (legacy)
+        type_field_seen = False
         for line in lines[:20]:
             stripped = line.strip()
             if stripped.startswith('project:'):
                 val = stripped.split(':', 1)[1].strip().strip('"').strip("'")
                 if val == project:
                     project_match = True
-                    break
-        if not project_match:
+            elif stripped.startswith('type:'):
+                type_field_seen = True
+                tval = stripped.split(':', 1)[1].strip().strip('"').strip("'")
+                is_session = (tval == 'claude-session')
+        if not project_match or (type_field_seen and not is_session):
             continue
 
         matched += 1

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -641,7 +641,8 @@ def ensure_index(vault_path: str, folders: list[str], db_path: str | None = None
 
 
 # Per-process cache keyed by snapshot path → resolved parent path (or None).
-# Cleared when the process exits; intentionally not persisted.
+# Not invalidated on re-index — snapshot frontmatter changes take effect next
+# process lifetime. Cleared when the process exits; intentionally not persisted.
 _PARENT_CACHE: dict[str, str | None] = {}
 
 
@@ -657,6 +658,11 @@ def _parent_session_for_snapshot(note_path: str, db_path: str) -> str | None:
          and return it. If not, cache None and return None.
 
     Swallows all exceptions — logging is observability, not a blocker.
+
+    Cache entries are NOT invalidated when a snapshot is re-indexed; a
+    corrected ``source_session_note`` won't take effect until the next process
+    restart. This is a deliberate tradeoff — rename-after-first-access is rare
+    and invalidation complexity outweighs the benefit.
     """
     if note_path in _PARENT_CACHE:
         return _PARENT_CACHE[note_path]
@@ -667,7 +673,10 @@ def _parent_session_for_snapshot(note_path: str, db_path: str) -> str | None:
             row = conn.execute(
                 "SELECT type FROM notes WHERE path = ?", (note_path,),
             ).fetchone()
-            if not row or row[0] != "claude-snapshot":
+            if not row:
+                # Not indexed yet — don't cache; retry on next call.
+                return None
+            if row[0] != "claude-snapshot":
                 _PARENT_CACHE[note_path] = None
                 return None
         finally:

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -640,15 +640,81 @@ def ensure_index(vault_path: str, folders: list[str], db_path: str | None = None
     return db_path
 
 
-def log_access(db_path: str, note_path: str, context_type: str, project: str | None = None) -> None:
-    """Insert one access-log row. Logs a warning to stderr if the database is unavailable."""
+# Per-process cache keyed by snapshot path → resolved parent path (or None).
+# Cleared when the process exits; intentionally not persisted.
+_PARENT_CACHE: dict[str, str | None] = {}
+
+
+def _parent_session_for_snapshot(note_path: str, db_path: str) -> str | None:
+    """Return the absolute path of the parent session note for a snapshot,
+    or None if the input isn't a snapshot or the parent can't be resolved.
+
+    Strategy:
+      1. Check per-process cache.
+      2. Query notes table for the row; if type != 'claude-snapshot', return None.
+      3. Read the snapshot file's frontmatter source_session_note wikilink;
+         resolve to <sessions_folder>/<stem>.md. If the file exists, cache
+         and return it. If not, cache None and return None.
+
+    Swallows all exceptions — logging is observability, not a blocker.
+    """
+    if note_path in _PARENT_CACHE:
+        return _PARENT_CACHE[note_path]
+    resolved: str | None = None
     try:
         conn = sqlite3.connect(db_path, timeout=5.0)
         try:
-            conn.execute(
+            row = conn.execute(
+                "SELECT type FROM notes WHERE path = ?", (note_path,),
+            ).fetchone()
+            if not row or row[0] != "claude-snapshot":
+                _PARENT_CACHE[note_path] = None
+                return None
+        finally:
+            conn.close()
+
+        # Extract source_session_note from the snapshot's frontmatter.
+        with open(note_path, "r", encoding="utf-8", errors="replace") as fh:
+            head = fh.read(2048)
+        m = re.search(r'^source_session_note:\s*"?\[\[([^\]"]+)\]\]"?',
+                      head, re.MULTILINE)
+        if not m:
+            _PARENT_CACHE[note_path] = None
+            return None
+        parent_stem = m.group(1)
+        parent_path = os.path.join(os.path.dirname(note_path), f"{parent_stem}.md")
+        if os.path.isfile(parent_path):
+            resolved = parent_path
+    except Exception as exc:  # noqa: BLE001
+        print(f"[vault-index] parent-resolve failed for {note_path!r}: {exc}",
+              file=sys.stderr)
+        resolved = None
+
+    _PARENT_CACHE[note_path] = resolved
+    return resolved
+
+
+def log_access(db_path: str, note_path: str, context_type: str, project: str | None = None) -> None:
+    """Insert an access-log row for note_path, cascading to parent session
+    if note_path is a snapshot.
+
+    The cascade runs in the same connection under a single executemany, so
+    either both rows land or neither does. Broken snapshot backlinks are
+    tolerated — the parent is simply skipped, the snapshot is still logged.
+    """
+    paths = [note_path]
+    parent = _parent_session_for_snapshot(note_path, db_path)
+    if parent:
+        paths.append(parent)
+
+    try:
+        conn = sqlite3.connect(db_path, timeout=5.0)
+        try:
+            now = time.time()
+            conn.executemany(
                 "INSERT INTO access_log (note_path, timestamp, context_type, project) "
                 "VALUES (?, ?, ?, ?)",
-                (note_path, time.time(), context_type, project),
+                [(p, now, context_type, project) for p in paths],
             )
             conn.commit()
         finally:

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -681,23 +681,33 @@ def _parent_session_for_snapshot(note_path: str, db_path: str) -> str | None:
                 return None
         finally:
             conn.close()
+    except sqlite3.Error as exc:
+        # Transient DB errors (locked, busy, corrupt-for-one-tx) — don't poison
+        # the cache; next call retries.
+        print(f"[vault-index] parent-resolve DB error for {note_path!r}: {exc}",
+              file=sys.stderr)
+        return None
 
+    try:
         # Extract source_session_note from the snapshot's frontmatter.
         with open(note_path, "r", encoding="utf-8", errors="replace") as fh:
             head = fh.read(2048)
-        m = re.search(r'^source_session_note:\s*"?\[\[([^\]"]+)\]\]"?',
-                      head, re.MULTILINE)
-        if not m:
-            _PARENT_CACHE[note_path] = None
-            return None
-        parent_stem = m.group(1)
-        parent_path = os.path.join(os.path.dirname(note_path), f"{parent_stem}.md")
-        if os.path.isfile(parent_path):
-            resolved = parent_path
-    except Exception as exc:  # noqa: BLE001
-        print(f"[vault-index] parent-resolve failed for {note_path!r}: {exc}",
+    except OSError as exc:
+        # File gone / unreadable — permanent miss for this process lifetime.
+        print(f"[vault-index] parent-resolve read error for {note_path!r}: {exc}",
               file=sys.stderr)
-        resolved = None
+        _PARENT_CACHE[note_path] = None
+        return None
+
+    m = re.search(r'^source_session_note:\s*"?\[\[([^\]"]+)\]\]"?',
+                  head, re.MULTILINE)
+    if not m:
+        _PARENT_CACHE[note_path] = None
+        return None
+    parent_stem = m.group(1)
+    parent_path = os.path.join(os.path.dirname(note_path), f"{parent_stem}.md")
+    if os.path.isfile(parent_path):
+        resolved = parent_path
 
     _PARENT_CACHE[note_path] = resolved
     return resolved

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -699,7 +699,11 @@ def _parent_session_for_snapshot(note_path: str, db_path: str) -> str | None:
         _PARENT_CACHE[note_path] = None
         return None
 
-    m = re.search(r'^source_session_note:\s*"?\[\[([^\]"]+)\]\]"?',
+    # Accept double-quoted, single-quoted, AND unquoted wikilink values —
+    # YAML frontmatter allows all three and hand-edits may use any. Copilot
+    # PR #43 finding: stricter `"?...` regex silently failed on single-quoted
+    # values and poisoned the cache with None.
+    m = re.search(r"^source_session_note:\s*['\"]?\[\[([^\]'\"]+)\]\]['\"]?",
                   head, re.MULTILINE)
     if not m:
         _PARENT_CACHE[note_path] = None

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -140,8 +140,10 @@ def _snapshot_stats(conn: sqlite3.Connection) -> dict:
             read_errors += 1
             continue
         tm = re.search(r"^trigger:\s*(\w+)", head, re.MULTILINE)
-        trigger = tm.group(1) if tm else "compact"
-        # Fold unknown triggers into 'auto'
+        # Missing `trigger:` and unknown values both fold into 'auto' —
+        # previously defaulted to 'compact' which inflated that bucket with
+        # legacy/malformed snapshots (Copilot PR #43 finding).
+        trigger = tm.group(1) if tm else "auto"
         if trigger not in _KNOWN_TRIGGERS:
             trigger = "auto"
         by_trigger[trigger] += 1

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -99,10 +99,13 @@ def _snapshot_stats(conn: sqlite3.Connection) -> dict:
             "max_snapshots_per_session": 0,
             "orphaned_snapshots": 0,
             "broken_backlinks": 0,
+            "read_errors": 0,
             "summarized_fraction": 1.0,
         }
 
-    # Build session_id set from session note frontmatters
+    # Build session_id set from session note frontmatters.
+    # Unreadable sessions can cause false-positive orphan flags on their
+    # children, so log them loudly rather than dropping silently.
     session_ids: set[str] = set()
     for (sp,) in conn.execute(
         "SELECT path FROM notes WHERE type = 'claude-session'"
@@ -110,7 +113,9 @@ def _snapshot_stats(conn: sqlite3.Connection) -> dict:
         try:
             with open(sp, "r", encoding="utf-8", errors="replace") as fh:
                 head = fh.read(2048)
-        except OSError:
+        except OSError as exc:
+            print(f"[vault-stats] skipping unreadable session note {sp!r}: {exc}",
+                  file=sys.stderr)
             continue
         m = re.search(r"^session_id:\s*(.+)$", head, re.MULTILINE)
         if m:
@@ -122,11 +127,17 @@ def _snapshot_stats(conn: sqlite3.Connection) -> dict:
     by_trigger: dict[str, int] = {"compact": 0, "clear": 0, "auto": 0}
     summarized = 0
 
+    read_errors = 0
     for path, source_note, status in snap_rows:
         try:
             with open(path, "r", encoding="utf-8", errors="replace") as fh:
                 head = fh.read(2048)
-        except OSError:
+        except OSError as exc:
+            # An unreadable snapshot is an integrity failure, not a phantom row.
+            # Log it and count so `sum(by_trigger) + read_errors == total` holds.
+            print(f"[vault-stats] skipping unreadable snapshot {path!r}: {exc}",
+                  file=sys.stderr)
+            read_errors += 1
             continue
         tm = re.search(r"^trigger:\s*(\w+)", head, re.MULTILINE)
         trigger = tm.group(1) if tm else "compact"
@@ -160,6 +171,7 @@ def _snapshot_stats(conn: sqlite3.Connection) -> dict:
         "max_snapshots_per_session": max(per_session.values()) if per_session else 0,
         "orphaned_snapshots": orphaned,
         "broken_backlinks": broken_backlinks,
+        "read_errors": read_errors,
         "summarized_fraction": round(summarized / total, 3) if total else 1.0,
     }
 

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -129,6 +129,14 @@ def _snapshot_stats(conn: sqlite3.Connection) -> dict:
 
     read_errors = 0
     for path, source_note, status in snap_rows:
+        # Status comes from the indexed notes row, so it is usable even when
+        # the on-disk file is unreadable at stats-compute time. Count it up
+        # front so summarized_fraction stays truthful for operators whose
+        # vaults contain transient file-permission blips. Copilot PR #43
+        # round 2 finding.
+        if status == "summarized":
+            summarized += 1
+
         try:
             with open(path, "r", encoding="utf-8", errors="replace") as fh:
                 head = fh.read(2048)
@@ -162,9 +170,6 @@ def _snapshot_stats(conn: sqlite3.Connection) -> dict:
             ).fetchone()
             if not row:
                 broken_backlinks += 1
-
-        if status == "summarized":
-            summarized += 1
 
     return {
         "total_snapshots": total,

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 import datetime
 import json
 import os
+import re
 import sqlite3
 import sys
 import time
+from collections import Counter
 
 import vault_index
 
@@ -71,6 +73,95 @@ def _handle_error(label: str, exc: Exception) -> str:
     """Log error to stderr and return JSON error payload."""
     print(f"[vault-stats] {label}: {exc}", file=sys.stderr)
     return json.dumps({"error": f"{label}: {exc}"})
+
+
+_KNOWN_TRIGGERS = {"compact", "clear", "auto"}
+
+
+def _snapshot_stats(conn: sqlite3.Connection) -> dict:
+    """Compute snapshot trigger breakdown + integrity counters.
+
+    Returns zero-state when no snapshots exist.  Orphan detection reads
+    session frontmatter directly because session_id isn't indexed as a
+    column; broken-backlink detection uses the already-indexed source_note.
+    Unknown trigger values are counted under 'auto' rather than growing
+    the by_trigger dict with unexpected keys.
+    """
+    snap_rows = conn.execute(
+        "SELECT path, source_note, status FROM notes WHERE type = 'claude-snapshot'"
+    ).fetchall()
+    total = len(snap_rows)
+    if total == 0:
+        return {
+            "total_snapshots": 0,
+            "by_trigger": {"compact": 0, "clear": 0, "auto": 0},
+            "sessions_with_snapshots": 0,
+            "max_snapshots_per_session": 0,
+            "orphaned_snapshots": 0,
+            "broken_backlinks": 0,
+            "summarized_fraction": 1.0,
+        }
+
+    # Build session_id set from session note frontmatters
+    session_ids: set[str] = set()
+    for (sp,) in conn.execute(
+        "SELECT path FROM notes WHERE type = 'claude-session'"
+    ).fetchall():
+        try:
+            with open(sp, "r", encoding="utf-8", errors="replace") as fh:
+                head = fh.read(2048)
+        except OSError:
+            continue
+        m = re.search(r"^session_id:\s*(.+)$", head, re.MULTILINE)
+        if m:
+            session_ids.add(m.group(1).strip().strip('"').strip("'"))
+
+    per_session: Counter = Counter()
+    orphaned = 0
+    broken_backlinks = 0
+    by_trigger: dict[str, int] = {"compact": 0, "clear": 0, "auto": 0}
+    summarized = 0
+
+    for path, source_note, status in snap_rows:
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as fh:
+                head = fh.read(2048)
+        except OSError:
+            continue
+        tm = re.search(r"^trigger:\s*(\w+)", head, re.MULTILINE)
+        trigger = tm.group(1) if tm else "compact"
+        # Fold unknown triggers into 'auto'
+        if trigger not in _KNOWN_TRIGGERS:
+            trigger = "auto"
+        by_trigger[trigger] += 1
+
+        sid_m = re.search(r"^session_id:\s*(.+)$", head, re.MULTILINE)
+        sid = sid_m.group(1).strip().strip('"').strip("'") if sid_m else ""
+        if sid:
+            per_session[sid] += 1
+            if sid not in session_ids:
+                orphaned += 1
+
+        if source_note:
+            row = conn.execute(
+                "SELECT 1 FROM notes WHERE type = 'claude-session' AND path LIKE ? LIMIT 1",
+                (f"%/{source_note}.md",),
+            ).fetchone()
+            if not row:
+                broken_backlinks += 1
+
+        if status == "summarized":
+            summarized += 1
+
+    return {
+        "total_snapshots": total,
+        "by_trigger": by_trigger,
+        "sessions_with_snapshots": len(per_session),
+        "max_snapshots_per_session": max(per_session.values()) if per_session else 0,
+        "orphaned_snapshots": orphaned,
+        "broken_backlinks": broken_backlinks,
+        "summarized_fraction": round(summarized / total, 3) if total else 1.0,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -191,6 +282,7 @@ def _compute_stats_inner(conn: sqlite3.Connection, db_path: str, project: str) -
         "access_by_context": access_by_context,
         "top_accessed": top_accessed,
         "importance_distribution": dist,
+        "snapshots": _snapshot_stats(conn),
     }
 
     # --- project ---

--- a/scripts/dev-test/DEV-TEST-SNAPSHOTS.md
+++ b/scripts/dev-test/DEV-TEST-SNAPSHOTS.md
@@ -1,0 +1,202 @@
+# Dev-Test: Snapshot Summary Integration (PR #43, Phase A + D)
+
+This is the **live Claude Code smoke test** for the snapshot-summary
+integration. It complements the automated script
+`scripts/dev-test/test-snapshots-manual.sh` which covers the parts that can be
+validated without an actual `/compact` or `/recall` firing.
+
+## Prerequisites
+
+1. `feature/snapshot-summary-integration` branch checked out locally.
+2. `./scripts/dev-test/dev-test install` executed successfully — the
+   plugin cache now contains the branch's hooks and skills.
+3. A **new Claude Code session started** in this repo so the installed
+   SKILL.md content is loaded.
+4. Your Obsidian vault is configured and has at least one recent session
+   note for this project.
+
+If you haven't run the automated checks yet:
+
+```bash
+bash scripts/dev-test/test-snapshots-manual.sh
+```
+
+All automated checks should pass before starting the live flow below.
+
+---
+
+## Live smoke checklist
+
+Walk through the following in a **fresh CC session**. Check each box
+only after visually confirming the described behavior. Record any
+deviation in the notes section at the bottom.
+
+### Phase 1 — Baseline sanity
+
+- [ ] **/recall works with no regression.** Run `/recall` in this repo
+      and confirm the session history table renders and open items load
+      as before. No snapshot-related crashes or empty sections where
+      there used to be content.
+
+### Phase 2 — Snapshot write on `/compact`
+
+- [ ] **First /compact writes a timestamped snapshot.** Chat for 2-3
+      turns (enough to make the transcript non-trivial), then run
+      `/compact`. Inspect the vault:
+      ```bash
+      ls -lt "<vault>/claude-sessions/$(date +%Y-%m-%d)"*snapshot* | head -3
+      ```
+      Confirm a new file exists matching `*-snapshot-HHMMSS.md` where
+      HHMMSS is the current wall-clock time.
+
+- [ ] **Frontmatter is correct.** Open the new snapshot note. Verify:
+      - `type: claude-snapshot`
+      - `session_id:` matches the session you're in (non-empty)
+      - `trigger: compact`
+      - `status: auto-logged` (not yet summarized)
+      - `source_session_note: "[[<date>-<project>-<hash>]]"` (the
+        parent session note's stem, in wikilink form)
+      - `tags:` contains `claude/snapshot`
+
+- [ ] **Second /compact does not overwrite.** Continue chatting for
+      another 2-3 turns, then run `/compact` again. Confirm a **second**
+      `-snapshot-HHMMSS.md` file now exists with a distinct HHMMSS
+      suffix and the first file is untouched.
+
+### Phase 3 — SessionEnd back-reference
+
+- [ ] **Close the session (Ctrl-D).** The SessionEnd hook fires.
+
+- [ ] **Session note includes a `snapshots:` list.** Find the
+      just-written session note for this session:
+      ```bash
+      grep -l "session_id: <your-session-id>" "<vault>/claude-sessions"/*.md
+      ```
+      Open it and confirm the frontmatter contains:
+      ```yaml
+      snapshots:
+        - "[[<date>-<project>-<sid>-snapshot-HHMMSS>]]"
+        - "[[<date>-<project>-<sid>-snapshot-HHMMSS>]]"
+      ```
+      One entry per `/compact` you triggered.
+
+- [ ] **Threshold bypass works.** If you had a very short session (below
+      `min_turns` / `min_duration_minutes`), the session note should
+      still exist because snapshots were present. Open
+      `~/.claude/obsidian-brain.log` — there should be no "skipped —
+      below threshold" line for this session.
+
+### Phase 4 — `/recall` folds snapshots in
+
+- [ ] **Start a fresh CC session and run `/recall`.**
+
+- [ ] **Unsummarized snapshots get upgraded.** The recall output should
+      include a line like `Upgraded N session note(s) with AI summaries`
+      where N includes at least the two snapshot notes you just created.
+
+- [ ] **Session history table shows nested snapshot rows.** The parent
+      session row appears at the top, and **underneath it** you should
+      see indented rows prefixed with `↳ HH:MM:SS` (one per snapshot).
+
+- [ ] **LOAD_MANIFEST mentions snapshots.** The "Loaded into this
+      conversation:" block should include `snapshot_count: 2` (or
+      however many `/compact`s you did) and a brief summary bullet per
+      snapshot.
+
+- [ ] **Session summary covers the pre- and post-compact arc.** The
+      session's `## Summary` section should read as a single coherent
+      arc — it should NOT be noticeably truncated to just the tail.
+
+### Phase 5 — `/vault-search` markers
+
+- [ ] **Run `/vault-search snapshot`** (or any keyword that matches your
+      test session).
+
+- [ ] **Session hits show `· 📸 N`.** For the session you just
+      compacted, the type label in its result line should include the
+      `· 📸 2` (or however many snapshots) suffix.
+
+- [ ] **Nested snapshot rows appear under the session hit.** Below the
+      snippet, indented `↳` rows list each snapshot with HH:MM:SS +
+      trigger.
+
+- [ ] **Snapshot-only hits show `→ [[parent]]`.** If any individual
+      snapshot note is ranked as its own result, its metadata row ends
+      with `→ [[<parent-stem>]]`.
+
+- [ ] **Picking a snapshot result loads session-depth.** Select the
+      snapshot number. CC should read the parent session body AND the
+      snapshot summaries, not just the snapshot fragment.
+
+### Phase 6 — `/vault-stats`
+
+- [ ] **Run `/vault-stats`.**
+
+- [ ] **A `## Snapshots` section renders** containing:
+      - `Total: N (compact: X, clear: Y, auto: Z)`
+      - `Sessions with snapshots: M (max K per session)`
+      - `Summarization: P%`
+      - `Integrity: 0 orphan(s), 0 broken backlink(s)` on a clean vault
+
+- [ ] **No `⚠ N snapshot file(s) unreadable` line.** If this appears on
+      a healthy install, something is wrong — check stderr in the log
+      for paths.
+
+### Phase 7 — `/emerge` flag
+
+- [ ] **Run `/emerge 7d`.** The resulting pattern report should NOT
+      reference any snapshot notes in its Sources section — snapshots
+      are excluded by default.
+
+- [ ] **Run `/emerge 7d --include-snapshots`.** This time the Sources
+      section may include snapshot notes (whether it actually does
+      depends on your corpus, but the command must not crash and the
+      cache must rebuild — look for `Using cached corpus` to be ABSENT
+      the first time you flip the flag).
+
+### Phase 8 — `/vault-config` warnings
+
+- [ ] **Run `/vault-config`.** Rows 7 (`snapshot_on_compact`) and 8
+      (`snapshot_on_clear`) should appear.
+
+- [ ] **Toggle `snapshot_on_clear` to false.** The menu should display
+      an in-row `⚠ Disables pre-clear/compact checkpoint` warning, and
+      a confirmation prompt should fire before the write.
+
+- [ ] **Toggle it back to true** to leave the config clean.
+
+### Phase 9 — Teardown
+
+- [ ] **`./scripts/dev-test/dev-test restore`** to put the original
+      plugin cache back.
+
+- [ ] **Delete the test snapshot + session notes from the vault** if
+      they are polluting your real vault (up to you — they are valid
+      notes, just not ones you want in search results).
+
+---
+
+## Notes
+
+_Record any observed deviations, unexpected output, or ideas for
+follow-up tests below. When all boxes are ticked and notes are empty,
+this section is your signal that the PR is dev-test-clean._
+
+- …
+
+## If something fails
+
+1. **Check the log:** `tail -50 ~/.claude/obsidian-brain.log` — hook
+   errors surface here.
+2. **Re-run the automated script:** `bash scripts/dev-test/test-snapshots-manual.sh`
+   — it catches code-level drift that live flows mask.
+3. **File-level inspection:** the fixtures left behind by `/compact` are
+   regular markdown. `cat` them and compare against the Phase 2
+   frontmatter expectations.
+4. **DB introspection:**
+   ```bash
+   sqlite3 ~/.claude/obsidian-brain-vault.db \
+     "SELECT path, type, source_note, status FROM notes
+      WHERE type = 'claude-snapshot' ORDER BY path DESC LIMIT 5;"
+   ```
+   confirms the indexed snapshot rows match the disk files.

--- a/scripts/dev-test/test-snapshots-manual.sh
+++ b/scripts/dev-test/test-snapshots-manual.sh
@@ -1,0 +1,421 @@
+#!/usr/bin/env bash
+# Manual smoke test for Snapshot Summary Integration (PR #43, Phase A + D)
+# Run AFTER: /dev-test install + start a new Claude Code session
+# Usage: bash scripts/dev-test/test-snapshots-manual.sh
+#
+# Validates what can be checked without live /compact or /recall:
+#   - Plugin cache contains expected code and skill markers
+#   - Python helpers (_snapshot_stats, fetch_snapshot_summaries,
+#     find_snapshots_for_session, collect_vault_corpus default,
+#     collect_open_items type filter, log_access cascade) behave correctly
+#   - DB schema untouched (no new tables/columns required by this PR)
+#
+# For the live-session parts (/compact creates a snapshot, /recall nested
+# rendering, /vault-search markers, /vault-stats Snapshots section),
+# see ./DEV-TEST-SNAPSHOTS.md.
+
+set -euo pipefail
+
+DB="$HOME/.claude/obsidian-brain-vault.db"
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  ✅ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  ⏭️  $1"; SKIP=$((SKIP + 1)); }
+
+# Locate the currently-installed plugin cache (the `dev-test install` target)
+CACHE_DIR=$(find ~/.claude/plugins/cache -type d -path "*/obsidian-brain/*" \
+    -not -path "*.bak*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null || true)
+if [ -z "$CACHE_DIR" ] || [ ! -d "$CACHE_DIR" ]; then
+    echo "❌ Could not locate obsidian-brain plugin cache."
+    echo "   Run /dev-test install first."
+    exit 1
+fi
+
+HOOK_DIR=$(find "$CACHE_DIR" -maxdepth 2 -type d -name hooks | sort -V | tail -1)
+SKILL_ROOT=$(find "$CACHE_DIR" -maxdepth 2 -type d -name skills | sort -V | tail -1)
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "Snapshot Summary Integration — Automated Validation"
+echo "═══════════════════════════════════════════════════════════════"
+echo "Plugin cache: $CACHE_DIR"
+echo "Hooks dir:    $HOOK_DIR"
+echo "Skills dir:   $SKILL_ROOT"
+echo ""
+
+# ─── Test 1: Installed code surface ──────────────────────────────────
+echo "Test 1: Installed code surface"
+
+if grep -q "def fetch_snapshot_summaries" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "fetch_snapshot_summaries() present in obsidian_utils.py"
+else
+    fail "fetch_snapshot_summaries() missing — did /dev-test install pick up this branch?"
+fi
+
+if grep -q "def find_snapshots_for_session" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "find_snapshots_for_session() present (public name — no underscore)"
+else
+    fail "find_snapshots_for_session() missing"
+fi
+
+if grep -q "SNAPSHOT_SUMMARY_PROMPT" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "SNAPSHOT_SUMMARY_PROMPT constant present"
+else
+    fail "SNAPSHOT_SUMMARY_PROMPT constant missing"
+fi
+
+if grep -q "_augment_session_input_with_snapshots" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_augment_session_input_with_snapshots() present"
+else
+    fail "_augment_session_input_with_snapshots() missing"
+fi
+
+if grep -q "def _snapshot_stats" "$HOOK_DIR/vault_stats.py"; then
+    pass "_snapshot_stats() present in vault_stats.py"
+else
+    fail "_snapshot_stats() missing"
+fi
+
+if grep -q "_parent_session_for_snapshot" "$HOOK_DIR/vault_index.py"; then
+    pass "log_access cascade helper present"
+else
+    fail "log_access cascade helper missing"
+fi
+
+if grep -q "exclude_types.*claude-snapshot" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "collect_vault_corpus excludes claude-snapshot by default"
+else
+    fail "collect_vault_corpus default exclusion missing"
+fi
+
+echo ""
+
+# ─── Test 2: Skill markers ──────────────────────────────────────────
+echo "Test 2: Skill markers"
+
+RECALL_SKILL="$SKILL_ROOT/recall/SKILL.md"
+if [ -f "$RECALL_SKILL" ] && grep -q "snapshot_count" "$RECALL_SKILL"; then
+    pass "/recall SKILL.md mentions snapshot_count (LOAD_MANIFEST key)"
+else
+    fail "/recall SKILL.md missing snapshot_count references"
+fi
+
+SEARCH_SKILL="$SKILL_ROOT/vault-search/SKILL.md"
+if [ -f "$SEARCH_SKILL" ] && grep -q "📸" "$SEARCH_SKILL"; then
+    pass "/vault-search SKILL.md has snapshot marker documentation"
+else
+    fail "/vault-search SKILL.md missing snapshot marker"
+fi
+
+ASK_SKILL="$SKILL_ROOT/vault-ask/SKILL.md"
+if [ -f "$ASK_SKILL" ] && grep -q "source_session_note\|snapshot" "$ASK_SKILL"; then
+    pass "/vault-ask SKILL.md mentions snapshot citation handling"
+else
+    fail "/vault-ask SKILL.md missing snapshot citation guidance"
+fi
+
+STATS_SKILL="$SKILL_ROOT/vault-stats/SKILL.md"
+if [ -f "$STATS_SKILL" ] && grep -q "## Snapshots" "$STATS_SKILL"; then
+    pass "/vault-stats SKILL.md has Snapshots rendering section"
+else
+    fail "/vault-stats SKILL.md missing Snapshots section"
+fi
+
+EMERGE_SKILL="$SKILL_ROOT/emerge/SKILL.md"
+if [ -f "$EMERGE_SKILL" ] && grep -q "include-snapshots" "$EMERGE_SKILL"; then
+    pass "/emerge SKILL.md documents --include-snapshots"
+else
+    fail "/emerge SKILL.md missing --include-snapshots flag"
+fi
+
+CHECKITEMS_SKILL="$SKILL_ROOT/check-items/SKILL.md"
+if [ -f "$CHECKITEMS_SKILL" ] && grep -q "claude-session\|Scope:" "$CHECKITEMS_SKILL"; then
+    pass "/check-items SKILL.md scope note present"
+else
+    fail "/check-items SKILL.md missing scope note"
+fi
+
+VAULTCFG_SKILL="$SKILL_ROOT/vault-config/SKILL.md"
+if [ -f "$VAULTCFG_SKILL" ] && grep -q "snapshot_on_compact\|snapshot_on_clear" "$VAULTCFG_SKILL"; then
+    pass "/vault-config SKILL.md exposes snapshot toggles"
+else
+    fail "/vault-config SKILL.md missing snapshot toggle rows"
+fi
+
+echo ""
+
+# ─── Test 3: Python behavior — fixture vault ─────────────────────────
+echo "Test 3: Python behavior against a fresh fixture vault"
+
+# Build a throwaway vault in /tmp, exercise the helpers, clean up.
+FIXTURE=$(mktemp -d -t ob-snapshot-test.XXXXXX)
+trap "rm -rf '$FIXTURE'" EXIT
+
+mkdir -p "$FIXTURE/v/claude-sessions" "$FIXTURE/v/claude-insights"
+
+# Session note
+cat > "$FIXTURE/v/claude-sessions/2026-04-18-demo-abcd.md" <<'EOF'
+---
+type: claude-session
+date: 2026-04-18
+session_id: s-abcd-1111
+project: demo
+status: summarized
+---
+
+# Demo Session
+
+## Summary
+A short session summary body.
+EOF
+
+# Snapshot backed by the session
+cat > "$FIXTURE/v/claude-sessions/2026-04-18-demo-abcd-snapshot-140000.md" <<'EOF'
+---
+type: claude-snapshot
+date: 2026-04-18
+session_id: s-abcd-1111
+project: demo
+trigger: compact
+status: summarized
+source_session_note: "[[2026-04-18-demo-abcd]]"
+---
+
+# Snapshot
+
+## Summary
+Pre-compact snapshot body.
+EOF
+
+# Orphan snapshot (no matching session)
+cat > "$FIXTURE/v/claude-sessions/2026-04-18-demo-zzzz-snapshot-180000.md" <<'EOF'
+---
+type: claude-snapshot
+date: 2026-04-18
+session_id: missing-parent
+project: demo
+trigger: compact
+status: auto-logged
+source_session_note: "[[does-not-exist]]"
+---
+
+# Orphan
+EOF
+
+FIXTURE_DB="$FIXTURE/fixture.db"
+
+# --- 3a: find_snapshots_for_session picks up the snapshot by id ---
+RESULT=$(python3 - <<PY 2>&1 || true
+import sys, os
+sys.path.insert(0, "$HOOK_DIR")
+from pathlib import Path
+from obsidian_utils import find_snapshots_for_session
+snaps = find_snapshots_for_session(
+    Path("$FIXTURE/v/claude-sessions"),
+    "s-abcd-1111",
+    "2026-04-18",
+    "demo",
+)
+print(len(snaps))
+PY
+)
+if [ "$RESULT" = "1" ]; then
+    pass "find_snapshots_for_session returns 1 snapshot for session s-abcd-1111"
+else
+    fail "find_snapshots_for_session returned '$RESULT' (expected 1)"
+fi
+
+# --- 3b: fetch_snapshot_summaries returns enriched dicts ---
+RESULT=$(python3 - <<PY 2>&1 || true
+import sys, os, json
+sys.path.insert(0, "$HOOK_DIR")
+from pathlib import Path
+from obsidian_utils import fetch_snapshot_summaries
+snaps = fetch_snapshot_summaries(
+    Path("$FIXTURE/v/claude-sessions"),
+    "s-abcd-1111",
+    "2026-04-18",
+    "demo",
+)
+print(json.dumps([{
+    "hhmmss": s["hhmmss"],
+    "trigger": s["trigger"],
+    "has_summary": bool(s.get("summary")),
+} for s in snaps]))
+PY
+)
+if echo "$RESULT" | grep -q '"hhmmss": "140000"' && echo "$RESULT" | grep -q '"trigger": "compact"'; then
+    pass "fetch_snapshot_summaries returns HHMMSS+trigger correctly"
+else
+    fail "fetch_snapshot_summaries result unexpected: $RESULT"
+fi
+
+# --- 3c: collect_vault_corpus default excludes snapshots ---
+RESULT=$(python3 - <<PY 2>&1 || true
+import sys, os, json
+sys.path.insert(0, "$HOOK_DIR")
+from obsidian_utils import collect_vault_corpus
+raw = collect_vault_corpus("$FIXTURE/v", "claude-sessions", "claude-insights", days=30)
+types = sorted({n["type"] for n in json.loads(raw)["notes"]})
+print(",".join(types))
+PY
+)
+if [ "$RESULT" = "claude-session" ]; then
+    pass "collect_vault_corpus default excludes claude-snapshot"
+else
+    fail "collect_vault_corpus emitted types '$RESULT' (expected 'claude-session')"
+fi
+
+# --- 3d: exclude_types=() opts back in ---
+RESULT=$(python3 - <<PY 2>&1 || true
+import sys, os, json
+sys.path.insert(0, "$HOOK_DIR")
+from obsidian_utils import collect_vault_corpus
+raw = collect_vault_corpus("$FIXTURE/v", "claude-sessions", "claude-insights",
+                           days=30, exclude_types=())
+types = sorted({n["type"] for n in json.loads(raw)["notes"]})
+print(",".join(types))
+PY
+)
+if echo "$RESULT" | grep -q "claude-snapshot" && echo "$RESULT" | grep -q "claude-session"; then
+    pass "collect_vault_corpus with exclude_types=() includes snapshots"
+else
+    fail "collect_vault_corpus opt-in returned '$RESULT'"
+fi
+
+# --- 3e: collect_open_items filters to claude-session ---
+cat > "$FIXTURE/v/claude-sessions/2026-04-18-demo-open.md" <<'EOF'
+---
+type: claude-session
+date: 2026-04-18
+session_id: s-open
+project: demo
+---
+
+# Session
+
+## Open Questions / Next Steps
+- [ ] Session open item that should appear
+EOF
+cat > "$FIXTURE/v/claude-sessions/2026-04-18-demo-open-snapshot-150000.md" <<'EOF'
+---
+type: claude-snapshot
+date: 2026-04-18
+session_id: s-open
+project: demo
+trigger: compact
+status: auto-logged
+---
+
+# Snap
+
+## Open Questions / Next Steps
+- [ ] Snapshot bullet that MUST be ignored
+EOF
+RESULT=$(python3 - <<PY 2>&1 || true
+import sys, os
+sys.path.insert(0, "$HOOK_DIR")
+from open_item_dedup import collect_open_items
+items = collect_open_items("$FIXTURE/v", "claude-sessions", "demo")
+texts = [t for _, _, t in items]
+has_session = any("should appear" in t for t in texts)
+has_snap = any("MUST be ignored" in t for t in texts)
+print(f"session={has_session} snap={has_snap}")
+PY
+)
+if [ "$RESULT" = "session=True snap=False" ]; then
+    pass "collect_open_items keeps session items, skips snapshot items"
+else
+    fail "collect_open_items filter wrong: $RESULT"
+fi
+
+# --- 3f: log_access cascade — snapshot access writes 2 rows ---
+RESULT=$(python3 - <<PY 2>&1 || true
+import sqlite3, sys, os
+sys.path.insert(0, "$HOOK_DIR")
+from vault_index import ensure_index, log_access, _PARENT_CACHE
+
+db = ensure_index("$FIXTURE/v", ["claude-sessions", "claude-insights"],
+                  db_path="$FIXTURE_DB")
+_PARENT_CACHE.clear()
+snap_path = "$FIXTURE/v/claude-sessions/2026-04-18-demo-abcd-snapshot-140000.md"
+log_access(db, snap_path, "search", "demo")
+
+conn = sqlite3.connect(db)
+rows = conn.execute("SELECT note_path FROM access_log").fetchall()
+conn.close()
+paths = sorted({r[0] for r in rows})
+print(f"count={len(paths)} session_present={any(p.endswith('2026-04-18-demo-abcd.md') for p in paths)}")
+PY
+)
+if echo "$RESULT" | grep -q "count=2" && echo "$RESULT" | grep -q "session_present=True"; then
+    pass "log_access cascade: snapshot access writes both self + parent rows"
+else
+    fail "log_access cascade wrong: $RESULT"
+fi
+
+# --- 3g: _snapshot_stats computes the 8-field dict ---
+RESULT=$(python3 - <<PY 2>&1 || true
+import sys, os, json
+sys.path.insert(0, "$HOOK_DIR")
+from vault_index import ensure_index
+from vault_stats import compute_stats
+
+db = ensure_index("$FIXTURE/v", ["claude-sessions", "claude-insights"],
+                  db_path="$FIXTURE_DB")
+payload = json.loads(compute_stats(db, "demo"))
+snap = payload["vault_wide"].get("snapshots", {})
+keys = sorted(snap.keys())
+print(",".join(keys))
+print(f"orphaned={snap.get('orphaned_snapshots')} broken={snap.get('broken_backlinks')} read_errors={snap.get('read_errors')}")
+PY
+)
+EXPECTED_KEYS="broken_backlinks,by_trigger,max_snapshots_per_session,orphaned_snapshots,read_errors,sessions_with_snapshots,summarized_fraction,total_snapshots"
+if echo "$RESULT" | head -1 | grep -qx "$EXPECTED_KEYS"; then
+    pass "_snapshot_stats emits all 8 expected fields"
+else
+    fail "_snapshot_stats field set mismatch: $(echo "$RESULT" | head -1)"
+fi
+if echo "$RESULT" | tail -1 | grep -q "orphaned=1" && echo "$RESULT" | tail -1 | grep -q "read_errors=0"; then
+    pass "_snapshot_stats counts orphan correctly, no spurious read_errors"
+else
+    fail "_snapshot_stats counters wrong: $(echo "$RESULT" | tail -1)"
+fi
+
+echo ""
+
+# ─── Test 4: Schema unchanged ───────────────────────────────────────
+echo "Test 4: Vault DB schema untouched by this PR"
+
+if [ -f "$DB" ]; then
+    # No new tables/columns required — confirm none accidentally introduced
+    if sqlite3 "$DB" "PRAGMA table_info(notes)" 2>/dev/null | grep -q "snapshot_"; then
+        fail "notes table gained an unexpected snapshot_ column"
+    else
+        pass "notes table shape preserved (no snapshot_* columns)"
+    fi
+else
+    skip "Live vault DB not yet created — skip schema-drift check"
+fi
+
+echo ""
+
+# ─── Summary ────────────────────────────────────────────────────────
+echo "═══════════════════════════════════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "❌ One or more checks failed. Inspect the log above, fix, and re-run."
+    exit 1
+fi
+
+cat <<'NEXT'
+
+✅ Automated checks passed. Next: run the live Claude Code smoke flow in
+   ./DEV-TEST-SNAPSHOTS.md (the parts that require an
+   actual /compact, /recall, /vault-search, /vault-stats, and /emerge).
+NEXT

--- a/skills/check-items/SKILL.md
+++ b/skills/check-items/SKILL.md
@@ -13,6 +13,11 @@ Scans all session notes across all projects for unchecked `- [ ]` items in `## O
 
 ## Procedure
 
+**Scope:** Only `claude-session` notes are scanned for open items. Snapshot
+notes (`claude-snapshot`) are excluded — their "Key context" bullets often
+look like action items and would produce false-positive proposals. This
+filter is enforced by `collect_open_items` in `hooks/open_item_dedup.py`.
+
 Follow these steps exactly. Do not skip steps or reorder them.
 
 ### Step 1 — Load config

--- a/skills/emerge/SKILL.md
+++ b/skills/emerge/SKILL.md
@@ -22,14 +22,20 @@ TaskCreate: subject="Present results", activeForm="Presenting results"
 Track task IDs. Set task #1 to `in_progress`.
 
 ### Step 1 — Parse args + upgrade + collect corpus
-Parse DAYS: no arg=30, `Nd`/`N days`=N, `this week`=days since Monday.
+
+**Optional flags:**
+- `--include-snapshots` — include `claude-snapshot` notes in the corpus.
+  By default snapshots are excluded; their transient "Key context" bullets
+  dilute cross-session pattern synthesis.
+
+Parse args: strip `--include-snapshots` first (set `INCLUDE_SNAPSHOTS=1` or `0`), then parse remaining arg as DAYS: no arg=30, `Nd`/`N days`=N, `this week`=days since Monday.
 
 ```bash
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
 import sys, os, glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from emerge_cli import run_corpus; run_corpus(int(sys.argv[1]) if len(sys.argv) > 1 else 30)
-' "$DAYS"
+from emerge_cli import run_corpus; run_corpus(int(sys.argv[1]) if len(sys.argv) > 1 else 30, include_snapshots=(sys.argv[2] == "1") if len(sys.argv) > 2 else False)
+' "$DAYS" "$INCLUDE_SNAPSHOTS"
 ```
 
 If STATUS starts with `CACHED:`, report "Using cached corpus (< 15 min old, same window)" and skip to Step 2.
@@ -42,8 +48,8 @@ Spawn parallel sub-agents for failed notes using /recall Path C Wave 2-3 pattern
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
 import sys, os, glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from emerge_cli import run_recollect; run_recollect(int(sys.argv[1]) if len(sys.argv) > 1 else 30)
-' "$DAYS"
+from emerge_cli import run_recollect; run_recollect(int(sys.argv[1]) if len(sys.argv) > 1 else 30, include_snapshots=(sys.argv[2] == "1") if len(sys.argv) > 2 else False)
+' "$DAYS" "$INCLUDE_SNAPSHOTS"
 ```
 
 ### Step 2 — Pattern synthesis

--- a/skills/obsidian-setup/SKILL.md
+++ b/skills/obsidian-setup/SKILL.md
@@ -497,6 +497,13 @@ After writing the config file, restrict permissions so only the current user can
 chmod 600 ~/.claude/obsidian-brain-config.json
 ```
 
+After writing the config, inspect the final `snapshot_on_clear` and `snapshot_on_compact` values. If either is `False` (for instance, when migrating from an older config), warn the user:
+
+> ⚠ `snapshot_on_clear` is False — /clear will not preserve pre-clear context.
+> Recommended: True. (This is on by default; only change if you have a specific reason.)
+
+Both flags ship `true` by default, so the warning only fires when a prior config, manual edit, or migration set them `false`. Ask the user whether to flip them back to `true` via `/vault-config` before continuing.
+
 ### Step 8 — Verify vault access
 
 Run:

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -203,7 +203,7 @@ If the command fails (non-zero exit code), print the error and stop — do not f
 **Parse the output.** Split on section labels:
 
 1. Extract `<<<OB_CONTEXT_BRIEF>>>` — everything between this delimiter and `<<<OB_LOAD_MANIFEST>>>`. This is the brief to display.
-2. Extract `<<<OB_LOAD_MANIFEST>>>` — parse `full_session_title`, `full_session_date`, `full_session_path`, `summary_session_title`, `summary_session_date`, `insight_count`.
+2. Extract `<<<OB_LOAD_MANIFEST>>>` — parse `full_session_title`, `full_session_date`, `full_session_path`, `summary_session_title`, `summary_session_date`, `insight_count`, `snapshot_count` (optional), and all `snapshot:` lines (there may be zero or more, each followed by optional 2-space-indented `key_context` bullets).
 3. Extract `<<<OB_MOST_RECENT_SESSION_PATH>>>` — the full path for checkoff edits.
 4. Extract `<<<OB_OPEN_ITEM_CANDIDATES>>>` — either `NO_CANDIDATES`, `NO_ITEMS`, or a JSON array.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -215,6 +215,8 @@ Update task #3 to `completed`. Update task #4 to `in_progress`.
 
 Then output the `CONTEXT_BRIEF` section. For the session history table, paraphrase each session's Title column into a concise one-line summary (under ~80 characters) that captures the key accomplishment. Keep all other columns (date, duration, branch) verbatim.
 
+Snapshots appear in the brief as nested indented rows beneath their parent session (rows starting with `↳ HH:MM:SS`). Render them verbatim — do not paraphrase snapshot titles (they're already one-line summaries). Display the `snapshot:` lines from LOAD_MANIFEST as bullet points under the most-recent session in the "Loaded into this conversation" output.
+
 If unsummarized notes were upgraded in Step 2, also mention:
 
 > _Upgraded N session note(s) with AI summaries._

--- a/skills/vault-ask/SKILL.md
+++ b/skills/vault-ask/SKILL.md
@@ -160,10 +160,25 @@ Read the top 5–10 files from `RANKED_FILES`. Apply the following size-based st
 - **Files over ~100 lines:** Use the `/context-shield` skill (parallel, one sub-agent per file). Each sub-agent reads the file in isolation and returns a distilled summary relevant to the question.
 
 For each file, extract:
-- Note type (session, insight, decision, error-fix)
+- Note type (session, insight, decision, error-fix, snapshot)
 - Date
 - Key content relevant to the question — decisions made, patterns observed, errors and fixes
 - Exact filename (without path) for use as a wikilink citation
+
+**Snapshot-aware reading.** If a ranked file has `type: claude-snapshot`, also resolve its parent session via the `source_session_note` frontmatter wikilink and include the parent session body in the synthesis pool — the snapshot alone only captures a mid-session fragment. If a ranked file has `type: claude-session` and has associated snapshots, fetch those snapshot summaries via the shared helper and include them alongside the session body:
+
+```bash
+python3 -c '
+import sys, os, json, glob
+sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from pathlib import Path
+from obsidian_utils import fetch_snapshot_summaries
+snaps = fetch_snapshot_summaries(Path(sys.argv[1]), sys.argv[2], sys.argv[3], sys.argv[4])
+print(json.dumps([{"hhmmss": s["hhmmss"], "trigger": s["trigger"], "summary": s["summary"]} for s in snaps]))
+' "$SESSIONS_DIR" "$SESSION_ID" "$DATE" "$PROJECT"
+```
+
+The goal is that an answer synthesized from a session hit reflects the full session arc (pre-compact + post-compact), not only the tail transcript.
 
 Store all extracted content as `NOTE_SUMMARIES`.
 
@@ -187,6 +202,9 @@ Using `NOTE_SUMMARIES`, synthesize a comprehensive answer to the user's question
    - [[note-filename-1]] — <what this note contributed to the answer>
    - [[note-filename-2]] — <what this note contributed to the answer>
    ```
+
+5. **Cite snapshot parents.** When a snapshot note contributes to the answer, cite BOTH the snapshot and its parent session so the user can navigate up:
+   > "Mid-session you sketched the API shape ([[2026-04-18-demo-aa-snapshot-140000]]; parent: [[2026-04-18-demo-aa]])."
 
 If the notes contain contradictory information (e.g. a decision was changed later), surface that explicitly:
 > "You initially chose X ([[older-note]]), but later switched to Y ([[newer-note]])."

--- a/skills/vault-config/SKILL.md
+++ b/skills/vault-config/SKILL.md
@@ -48,11 +48,19 @@ Obsidian Brain Configuration
 4. log_raw_messages       <value>      <- controls raw conversation logging
 5. min_turns              <value>      <- minimum turns to log a session
 6. min_duration_minutes   <value>      <- minimum duration to log
+7. snapshot_on_compact    <value>      <- checkpoint note on /compact
+8. snapshot_on_clear      <value>      <- checkpoint note on /clear
 
 Enter a number to change, or 'done' to exit.
 ```
 
-For any key not present in the config, show its default value: `log_raw_messages` defaults to `true`, `min_turns` defaults to `3`, `min_duration_minutes` defaults to `2`.
+For any key not present in the config, show its default value: `log_raw_messages` defaults to `true`, `min_turns` defaults to `3`, `min_duration_minutes` defaults to `2`, `snapshot_on_compact` defaults to `true`, `snapshot_on_clear` defaults to `true`.
+
+When rendering rows 7 or 8, if the value is `False`, append this warning inline on the same row:
+
+> ⚠ Disables pre-clear/compact checkpoint. Recommended: True.
+
+The warning only fires when the value is explicitly `False` — don't show it for the default `true`.
 
 ### Step 3 — Handle user selection
 
@@ -63,7 +71,11 @@ Wait for user input.
 
 ### Step 4 — Change setting
 
-- **Boolean settings** (`log_raw_messages`): Toggle the value (true→false, false→true). No prompt needed.
+- **Boolean settings** (`log_raw_messages`, `snapshot_on_compact`, `snapshot_on_clear`): Toggle the value (true→false, false→true). If the user is about to set `snapshot_on_compact` or `snapshot_on_clear` to `False`, warn first:
+
+  > ⚠ Disabling this removes the pre-compact/clear checkpoint safety net. You will lose in-flight context on accidental `/clear`. Proceed? (y/N)
+
+  Only toggle after explicit confirmation.
 - **String settings** (`vault_path`, `sessions_folder`, `insights_folder`): Show current value, ask for new value.
 - **Number settings** (`min_turns`, `min_duration_minutes`): Show current value, ask for new value. Validate it's a positive integer.
 

--- a/skills/vault-search/SKILL.md
+++ b/skills/vault-search/SKILL.md
@@ -120,8 +120,10 @@ If zero results and query has multiple words, retry by grepping each word separa
 For each matched file (up to 20 files), use Read to read the first 40 lines. Extract from frontmatter:
 
 - **date** — the `date:` field
-- **type** — the `type:` field (e.g. `claude-session`, `claude-insight`, `claude-decision`, `claude-error-fix`)
+- **type** — the `type:` field (e.g. `claude-session`, `claude-insight`, `claude-decision`, `claude-error-fix`, `claude-snapshot`)
 - **project** — the `project:` field
+- **session_id** — the `session_id:` field (used below to attach snapshots to session hits)
+- **source_session_note** — the `source_session_note:` wikilink on snapshots (the parent session stem, enclosed in `[[...]]`)
 - **title** — the first `# ` heading, or the filename without extension
 
 Also extract a **snippet**: the first 200 characters of content after the frontmatter closing `---`.
@@ -129,6 +131,25 @@ Also extract a **snippet**: the first 200 characters of content after the frontm
 If there are more than 20 matched files, sort by filename (which contains the date in YYYY-MM-DD format) descending and take only the 20 most recent.
 
 **Performance note:** If there are 10 or fewer matches, read all files in parallel. If there are 11-20, read in two parallel batches.
+
+### Step 5b — Augment session hits with snapshot data
+
+For each result whose `type` is `claude-session`, query its snapshots once via the shared Python helper `fetch_snapshot_summaries()`:
+
+```bash
+python3 -c '
+import sys, os, json, glob
+sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
+from pathlib import Path
+from obsidian_utils import fetch_snapshot_summaries
+snaps = fetch_snapshot_summaries(Path(sys.argv[1]), sys.argv[2], sys.argv[3], sys.argv[4])
+print(json.dumps([{"hhmmss": s["hhmmss"], "trigger": s["trigger"]} for s in snaps]))
+' "$SESSIONS_DIR" "$SESSION_ID" "$DATE" "$PROJECT"
+```
+
+If the returned JSON array is non-empty, remember the snapshot count `N` and each snapshot's `hhmmss` + `trigger` for that result. If batching many sessions, run these queries in parallel (same pattern as Step 5's metadata reads).
+
+For results whose `type` is `claude-snapshot`, remember the `source_session_note` wikilink stem (strip `[[...]]`) as the parent pointer.
 
 ### Step 6 — Sort and present results
 
@@ -149,9 +170,18 @@ Use these icons for type labels:
 - `claude-insight` → insight
 - `claude-decision` → decision
 - `claude-error-fix` → error-fix
+- `claude-snapshot` → snapshot
 - anything else → note
 
 Truncate snippets at 200 characters, ending with `...` if truncated.
+
+**Snapshot markers on session hits:** If Step 5b found `N >= 1` snapshots for a session result, append `· 📸 N` to the type-label block — e.g. `(session · 📸 2, 2026-04-18)`. Under the snippet, list each snapshot as a nested bullet:
+
+```
+   ↳ 📸 <hhmmss> (<trigger>)
+```
+
+**Parent pointer on snapshot hits:** For a `claude-snapshot` result, append `→ [[<parent-stem>]]` after the date — e.g. `(snapshot, 2026-04-18 → [[2026-04-18-demo-aa]])`. Only include the marker when `source_session_note` is set.
 
 After the list, tell the user:
 
@@ -160,6 +190,8 @@ After the list, tell the user:
 ### Step 7 — Handle user selection
 
 If the user picks a number, read the full content of that file using the Read tool and present it in the conversation.
+
+**Session-depth loading applies to snapshot picks too.** If the user picks a snapshot result, load the parent session body AND all its snapshot summaries (re-use `fetch_snapshot_summaries()`), not just the snapshot file alone — so the answer reflects the full session arc, not the mid-session fragment. Resolve the parent via the `source_session_note` stem captured in Step 5.
 
 If the user provides a new query, go back to Step 2.
 

--- a/skills/vault-stats/SKILL.md
+++ b/skills/vault-stats/SKILL.md
@@ -158,6 +158,12 @@ Summarization: {summarized_fraction formatted as integer %}
 Integrity: {orphaned_snapshots} orphan(s), {broken_backlinks} broken backlink(s)
 ```
 
+If `read_errors > 0`, append on a new line before the auto-fix suggestion:
+
+```
+⚠ {read_errors} snapshot file(s) unreadable — check stderr for paths.
+```
+
 If `orphaned_snapshots > 0` or `broken_backlinks > 0`, append on a new line:
 
 ```

--- a/skills/vault-stats/SKILL.md
+++ b/skills/vault-stats/SKILL.md
@@ -144,6 +144,28 @@ If `access_log_entries == 0`, append after the tables:
 
 > Access tracking is active. Run `/vault-search` and `/recall` to start building history.
 
+### Snapshots section
+
+If the JSON payload has a `vault_wide.snapshots` object with
+`total_snapshots > 0`, render a `## Snapshots` section after the
+Importance Distribution table:
+
+```
+## Snapshots
+Total: {total_snapshots} (compact: {by_trigger.compact}, clear: {by_trigger.clear}, auto: {by_trigger.auto})
+Sessions with snapshots: {sessions_with_snapshots} (max {max_snapshots_per_session} per session)
+Summarization: {summarized_fraction formatted as integer %}
+Integrity: {orphaned_snapshots} orphan(s), {broken_backlinks} broken backlink(s)
+```
+
+If `orphaned_snapshots > 0` or `broken_backlinks > 0`, append on a new line:
+
+```
+Run `/vault-doctor` to auto-fix.
+```
+
+If `total_snapshots == 0`, omit the section entirely.
+
 ### Step 4 — Save vault note
 
 Generate filename:

--- a/templates/snapshot.md
+++ b/templates/snapshot.md
@@ -8,6 +8,8 @@ tags:
   - claude/snapshot
   - claude/project/{{project}}
   - claude/auto
+status: auto-logged
+source_session_note: "[[{{parent_stem}}]]"
 ---
 
 # Context Snapshot -- {{trigger_label}}
@@ -20,3 +22,6 @@ tags:
 
 ## Uncommitted work
 {{uncommitted_work}}
+
+## Last messages (raw)
+{{last_messages}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,12 @@ _HOOKS_DIR = os.path.join(os.path.dirname(__file__), "..", "hooks")
 if _HOOKS_DIR not in sys.path:
     sys.path.insert(0, os.path.abspath(_HOOKS_DIR))
 
+# Add repo root to sys.path so tests can use the `hooks.<module>` package form
+# (in addition to the bare `obsidian_utils` form used by older tests).
+_REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, os.path.abspath(_REPO_ROOT))
+
 
 @pytest.fixture
 def tmp_vault(tmp_path):

--- a/tests/test_check_items_snapshot_filter.py
+++ b/tests/test_check_items_snapshot_filter.py
@@ -1,0 +1,34 @@
+from hooks.open_item_dedup import collect_open_items
+
+
+def test_collect_open_items_ignores_snapshots(tmp_path):
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    (sess / "2026-04-18-demo-aa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nproject: demo\n---\n\n"
+        "# S\n\n## Open Questions / Next Steps\n- [ ] Session open item\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-demo-aa-snapshot-140000.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nproject: demo\n---\n\n"
+        "# Snap\n\n## Open Questions / Next Steps\n- [ ] Snapshot item — should be ignored\n",
+        encoding="utf-8",
+    )
+    items = collect_open_items(str(tmp_path), "claude-sessions", "demo")
+    texts = [t for _, _, t in items]
+    assert any("Session open item" in t for t in texts)
+    assert not any("should be ignored" in t for t in texts)
+
+
+def test_collect_open_items_treats_no_type_field_as_session(tmp_path):
+    """Legacy notes without a type frontmatter field default to claude-session."""
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    (sess / "2026-04-18-legacy-aa.md").write_text(
+        "---\ndate: 2026-04-18\nproject: demo\n---\n\n"
+        "# Legacy\n\n## Open Questions / Next Steps\n- [ ] Legacy open item\n",
+        encoding="utf-8",
+    )
+    items = collect_open_items(str(tmp_path), "claude-sessions", "demo")
+    texts = [t for _, _, t in items]
+    assert any("Legacy open item" in t for t in texts)

--- a/tests/test_emerge_snapshot_filter.py
+++ b/tests/test_emerge_snapshot_filter.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+
+from hooks.obsidian_utils import collect_vault_corpus
+
+
+def _setup(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    ins = vault / "claude-insights"
+    sess.mkdir(parents=True); ins.mkdir()
+    (sess / "2026-04-18-demo-aa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+        "tags: [claude/session]\n---\n\n# S\n\n## Summary\nSession body.\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-demo-aa-snapshot-140000.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+        "tags: [claude/snapshot]\n---\n\n# Snap\n\n## Summary\nSnapshot body.\n",
+        encoding="utf-8",
+    )
+    return vault
+
+
+def test_collect_vault_corpus_excludes_snapshots_by_default(tmp_path):
+    vault = _setup(tmp_path)
+    raw = collect_vault_corpus(str(vault), "claude-sessions", "claude-insights", days=30)
+    notes = json.loads(raw)["notes"]
+    types = {n["type"] for n in notes}
+    assert "claude-snapshot" not in types
+    assert "claude-session" in types
+
+
+def test_collect_vault_corpus_include_snapshots_flag(tmp_path):
+    vault = _setup(tmp_path)
+    raw = collect_vault_corpus(
+        str(vault), "claude-sessions", "claude-insights", days=30,
+        exclude_types=(),
+    )
+    types = {n["type"] for n in json.loads(raw)["notes"]}
+    assert "claude-snapshot" in types

--- a/tests/test_open_item_dedup.py
+++ b/tests/test_open_item_dedup.py
@@ -302,10 +302,11 @@ def test_batch_cascade_checkoff_empty(tmp_vault):
 
 def test_collect_open_items_skips_snapshot_files(tmp_vault):
     sessions_dir = tmp_vault / "claude-sessions"
-    # A snapshot file should be skipped even if it contains matching content
-    snapshot_note = sessions_dir / "2026-04-10-proj-snapshot.md"
+    # Snapshot notes (type: claude-snapshot) are excluded via frontmatter type
+    # filter, regardless of filename suffix.
+    snapshot_note = sessions_dir / "2026-04-10-proj-snapshot-140000.md"
     snapshot_note.write_text(
-        "---\ntype: claude-session\nproject: myproject\n---\n\n"
+        "---\ntype: claude-snapshot\nproject: myproject\n---\n\n"
         "## Open Questions / Next Steps\n- [ ] Snapshot item\n",
         encoding="utf-8",
     )

--- a/tests/test_snapshot_access_cascade.py
+++ b/tests/test_snapshot_access_cascade.py
@@ -89,6 +89,34 @@ def test_log_access_with_broken_snapshot_backlink_is_tolerant(tmp_path):
     assert {r[0] for r in rows} == {str(snap)}
 
 
+def test_log_access_transient_db_error_does_not_poison_cache(tmp_path):
+    """A DB-open failure during parent resolution must not cache None permanently.
+
+    Regression guard for a silent failure where `_parent_session_for_snapshot`
+    caught all exceptions and cached None on any sqlite3 error — e.g. a
+    transient 'database is locked' during high concurrency would disable the
+    parent cascade for that snapshot for the process lifetime.
+    """
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    parent_path, snap_path = _seed(vault, sess)
+    db_path = vault_index.ensure_index(
+        str(vault), ["claude-sessions"], db_path=str(tmp_path / "test.db")
+    )
+    vault_index._PARENT_CACHE.clear()
+
+    # Simulate transient DB error by pointing at a nonexistent DB file.
+    bad_db = str(tmp_path / "does-not-exist.db")
+    result = vault_index._parent_session_for_snapshot(str(snap_path), bad_db)
+    assert result is None
+    # Critical: cache must NOT contain a poisoned None for snap_path.
+    assert str(snap_path) not in vault_index._PARENT_CACHE
+
+    # Next call with the real DB must resolve the parent.
+    result2 = vault_index._parent_session_for_snapshot(str(snap_path), db_path)
+    assert result2 == str(parent_path)
+
+
 def test_log_access_on_unindexed_snapshot_does_not_poison_cache(tmp_path):
     vault = tmp_path / "v"
     sess = vault / "claude-sessions"

--- a/tests/test_snapshot_access_cascade.py
+++ b/tests/test_snapshot_access_cascade.py
@@ -1,0 +1,89 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hooks import vault_index
+
+
+def _seed(vault, sess):
+    (sess).mkdir(parents=True, exist_ok=True)
+    parent_path = sess / "2026-04-18-demo-aaaa.md"
+    parent_path.write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+        "status: summarized\n---\n\n# Session\n",
+        encoding="utf-8",
+    )
+    snap_path = sess / "2026-04-18-demo-aaaa-snapshot-140000.md"
+    snap_path.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+        "status: summarized\n"
+        'source_session_note: "[[2026-04-18-demo-aaaa]]"\n'
+        "---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    return parent_path, snap_path
+
+
+def test_log_access_on_snapshot_inserts_two_rows(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    parent_path, snap_path = _seed(vault, sess)
+    db_path = vault_index.ensure_index(
+        str(vault), ["claude-sessions"], db_path=str(tmp_path / "test.db")
+    )
+    # Clear cache so this test's snap_path is not stale from a previous run
+    vault_index._PARENT_CACHE.clear()
+
+    vault_index.log_access(db_path, str(snap_path), "search", "demo")
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT note_path FROM access_log").fetchall()
+    conn.close()
+    paths = {r[0] for r in rows}
+    assert str(snap_path) in paths
+    assert str(parent_path) in paths
+
+
+def test_log_access_on_session_inserts_single_row(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    parent_path, _ = _seed(vault, sess)
+    db_path = vault_index.ensure_index(
+        str(vault), ["claude-sessions"], db_path=str(tmp_path / "test.db")
+    )
+    vault_index._PARENT_CACHE.clear()
+
+    vault_index.log_access(db_path, str(parent_path), "recall", "demo")
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT note_path FROM access_log").fetchall()
+    conn.close()
+    assert len(rows) == 1
+    assert rows[0][0] == str(parent_path)
+
+
+def test_log_access_with_broken_snapshot_backlink_is_tolerant(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    snap = sess / "2026-04-18-demo-cccc-snapshot-090000.md"
+    snap.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: no-such\n"
+        'project: demo\nstatus: auto-logged\nsource_session_note: "[[does-not-exist]]"\n'
+        "---\n\n# Orphan snap\n",
+        encoding="utf-8",
+    )
+    db_path = vault_index.ensure_index(
+        str(vault), ["claude-sessions"], db_path=str(tmp_path / "test.db")
+    )
+    vault_index._PARENT_CACHE.clear()
+
+    # Must not raise
+    vault_index.log_access(db_path, str(snap), "search", "demo")
+
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT note_path FROM access_log").fetchall()
+    conn.close()
+    # Only the snapshot is logged; parent cannot be resolved
+    assert {r[0] for r in rows} == {str(snap)}

--- a/tests/test_snapshot_access_cascade.py
+++ b/tests/test_snapshot_access_cascade.py
@@ -87,3 +87,30 @@ def test_log_access_with_broken_snapshot_backlink_is_tolerant(tmp_path):
     conn.close()
     # Only the snapshot is logged; parent cannot be resolved
     assert {r[0] for r in rows} == {str(snap)}
+
+
+def test_log_access_on_unindexed_snapshot_does_not_poison_cache(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    parent_path, snap_path = _seed(vault, sess)
+    # Build DB but seed it with a DIFFERENT vault so snap_path is NOT indexed.
+    db_path = str(tmp_path / "test.db")
+    vault_index.ensure_index(str(tmp_path / "other-vault"), ["claude-sessions"], db_path=db_path)
+    vault_index._PARENT_CACHE.clear()
+
+    # First call: snap_path not in DB, cache should NOT record None.
+    vault_index.log_access(db_path, str(snap_path), "search", "demo")
+    assert str(snap_path) not in vault_index._PARENT_CACHE
+
+    # Re-index with the real vault — now snap_path is present.
+    vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=db_path)
+
+    # Second call: cache should now resolve the parent.
+    vault_index.log_access(db_path, str(snap_path), "search", "demo")
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute("SELECT note_path FROM access_log").fetchall()
+    conn.close()
+    paths = [r[0] for r in rows]
+    # Snapshot logged twice; parent logged once (only after indexing).
+    assert paths.count(str(snap_path)) == 2
+    assert paths.count(str(parent_path)) == 1

--- a/tests/test_snapshot_access_cascade.py
+++ b/tests/test_snapshot_access_cascade.py
@@ -89,6 +89,68 @@ def test_log_access_with_broken_snapshot_backlink_is_tolerant(tmp_path):
     assert {r[0] for r in rows} == {str(snap)}
 
 
+def test_parent_session_resolved_with_single_quoted_wikilink(tmp_path):
+    """Regression for Copilot PR #43 finding: `source_session_note` regex
+    must accept single-quoted and unquoted wikilinks, not just double-quoted.
+    YAML allows all three and hand-edits may use any.
+    """
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    parent = sess / "2026-04-18-demo-eeee.md"
+    parent.write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: sq\n"
+        "project: demo\nstatus: summarized\n---\n\n# Session\n",
+        encoding="utf-8",
+    )
+    # Single-quoted wikilink — previously NOT matched by the regex
+    snap = sess / "2026-04-18-demo-eeee-snapshot-120000.md"
+    snap.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: sq\n"
+        "project: demo\nstatus: summarized\n"
+        "source_session_note: '[[2026-04-18-demo-eeee]]'\n"
+        "---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    db_path = vault_index.ensure_index(
+        str(vault), ["claude-sessions"], db_path=str(tmp_path / "single.db")
+    )
+    vault_index._PARENT_CACHE.clear()
+
+    result = vault_index._parent_session_for_snapshot(str(snap), db_path)
+    assert result == str(parent), (
+        f"single-quoted wikilink should resolve to parent; got {result!r}"
+    )
+
+
+def test_parent_session_resolved_with_unquoted_wikilink(tmp_path):
+    """Unquoted wikilink form is also valid YAML; must resolve."""
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    parent = sess / "2026-04-18-demo-ffff.md"
+    parent.write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: uq\n"
+        "project: demo\nstatus: summarized\n---\n\n# Session\n",
+        encoding="utf-8",
+    )
+    snap = sess / "2026-04-18-demo-ffff-snapshot-120000.md"
+    snap.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: uq\n"
+        "project: demo\nstatus: summarized\n"
+        "source_session_note: [[2026-04-18-demo-ffff]]\n"
+        "---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    db_path = vault_index.ensure_index(
+        str(vault), ["claude-sessions"], db_path=str(tmp_path / "unquoted.db")
+    )
+    vault_index._PARENT_CACHE.clear()
+
+    result = vault_index._parent_session_for_snapshot(str(snap), db_path)
+    assert result == str(parent)
+
+
 def test_log_access_transient_db_error_does_not_poison_cache(tmp_path):
     """A DB-open failure during parent resolution must not cache None permanently.
 

--- a/tests/test_snapshot_recall.py
+++ b/tests/test_snapshot_recall.py
@@ -62,6 +62,28 @@ def test_build_context_brief_emits_snapshot_count_in_load_manifest(tmp_path):
     assert "snapshot: [150000]" in out
 
 
+def test_fetch_snapshot_summaries_missing_trigger_defaults_to_auto(tmp_path):
+    """Regression for Copilot PR #43 round 2 finding: snapshots without a
+    `trigger:` frontmatter field must default to 'auto', not 'compact'.
+    Mislabeling in the /recall UI would misattribute legacy snapshots.
+    """
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    # Snapshot without a `trigger:` field
+    (sess / "2026-04-18-demo-ccc-snapshot-120000.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s3\n"
+        "project: demo\nstatus: summarized\n"
+        'source_session_note: "[[2026-04-18-demo-ccc]]"\n'
+        "---\n\n# T\n\n## Summary\nno trigger set\n",
+        encoding="utf-8",
+    )
+    items = fetch_snapshot_summaries(sess, "s3", "2026-04-18", "demo")
+    assert len(items) == 1
+    assert items[0]["trigger"] == "auto", (
+        f"missing trigger should default to 'auto', got {items[0]['trigger']!r}"
+    )
+
+
 def test_build_context_brief_no_snapshot_artifacts_when_session_has_none(tmp_path):
     vault = tmp_path / "v"
     sess = vault / "claude-sessions"

--- a/tests/test_snapshot_recall.py
+++ b/tests/test_snapshot_recall.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from hooks.obsidian_utils import build_context_brief, fetch_snapshot_summaries
+
+
+def _fixture(path, type_, sid, date, project="demo", extras="", body="body"):
+    path.write_text(
+        f"---\ntype: {type_}\ndate: {date}\nsession_id: {sid}\n"
+        f"project: {project}\nstatus: summarized\n{extras}---\n\n"
+        f"# Title\n\n## Summary\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_build_context_brief_filters_snapshots_from_top_level(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    ins = vault / "claude-insights"
+    sess.mkdir(parents=True); ins.mkdir()
+    _fixture(sess / "2026-04-18-demo-aaaa.md", "claude-session", "s1", "2026-04-18",
+             extras="duration_minutes: 30\ngit_branch: develop\n", body="Session A ran through checklist.")
+    _fixture(sess / "2026-04-18-demo-aaaa-snapshot-140000.md", "claude-snapshot", "s1",
+             "2026-04-18", body="Pre-compact checkpoint.")
+    out = build_context_brief(str(vault), "claude-sessions", "claude-insights", "demo")
+    # Table row count: top-level line 1 (session A) — snapshot should not appear
+    # as a top-level numbered row.
+    assert "| 1 | 2026-04-18" in out
+    assert "| 2 | 2026-04-18" not in out  # only 1 session => 1 row
+    # Nested indented row present below the session
+    assert "↳ 14:00:00" in out or "↳ 140000" in out
+
+
+def test_fetch_snapshot_summaries_returns_ordered_items(tmp_path):
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    _fixture(sess / "2026-04-18-demo-bbbb-snapshot-150000.md", "claude-snapshot",
+             "s2", "2026-04-18", body="Later checkpoint.")
+    _fixture(sess / "2026-04-18-demo-bbbb-snapshot-100000.md", "claude-snapshot",
+             "s2", "2026-04-18", body="Earlier checkpoint.")
+    items = fetch_snapshot_summaries(sess, "s2", "2026-04-18", "demo")
+    assert len(items) == 2
+    assert items[0]["hhmmss"] == "100000"
+    assert items[1]["hhmmss"] == "150000"
+    assert "Earlier" in items[0]["summary"]

--- a/tests/test_snapshot_recall.py
+++ b/tests/test_snapshot_recall.py
@@ -42,3 +42,33 @@ def test_fetch_snapshot_summaries_returns_ordered_items(tmp_path):
     assert items[0]["hhmmss"] == "100000"
     assert items[1]["hhmmss"] == "150000"
     assert "Earlier" in items[0]["summary"]
+
+
+def test_build_context_brief_emits_snapshot_count_in_load_manifest(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    ins = vault / "claude-insights"
+    sess.mkdir(parents=True); ins.mkdir()
+    _fixture(sess / "2026-04-18-demo-cccc.md", "claude-session", "s3", "2026-04-18",
+             extras="duration_minutes: 45\ngit_branch: develop\n", body="Main session.")
+    _fixture(sess / "2026-04-18-demo-cccc-snapshot-120000.md", "claude-snapshot",
+             "s3", "2026-04-18", body="Checkpoint one.")
+    _fixture(sess / "2026-04-18-demo-cccc-snapshot-150000.md", "claude-snapshot",
+             "s3", "2026-04-18", body="Checkpoint two.")
+    out = build_context_brief(str(vault), "claude-sessions", "claude-insights", "demo")
+    assert "<<<OB_LOAD_MANIFEST>>>" in out
+    assert "snapshot_count: 2" in out
+    assert "snapshot: [120000]" in out
+    assert "snapshot: [150000]" in out
+
+
+def test_build_context_brief_no_snapshot_artifacts_when_session_has_none(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    ins = vault / "claude-insights"
+    sess.mkdir(parents=True); ins.mkdir()
+    _fixture(sess / "2026-04-18-demo-dddd.md", "claude-session", "s4", "2026-04-18",
+             extras="duration_minutes: 20\ngit_branch: develop\n", body="Standalone session.")
+    out = build_context_brief(str(vault), "claude-sessions", "claude-insights", "demo")
+    assert "snapshot_count" not in out
+    assert "↳" not in out

--- a/tests/test_snapshot_summarization.py
+++ b/tests/test_snapshot_summarization.py
@@ -1,7 +1,8 @@
 import json
 from pathlib import Path
+from unittest.mock import patch
 
-from hooks.obsidian_utils import find_unsummarized_notes
+from hooks.obsidian_utils import find_unsummarized_notes, upgrade_unsummarized_note
 
 
 def _fixture(sess_dir: Path, name: str, type_: str, status: str, session_id: str, body: str = ""):
@@ -83,3 +84,40 @@ def test_find_unsummarized_keeps_legacy_notes_without_type_field(tmp_path):
     result = json.loads(find_unsummarized_notes(str(vault), "claude-sessions", "demo"))
     names = [Path(p).name for p in result["unsummarized"]]
     assert "2026-04-18-demo-eeee-legacy.md" in names
+
+
+def test_snapshot_routes_through_snapshot_prompt(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    snap_path = sess / "2026-04-18-demo-dddd-snapshot-140000.md"
+    snap_path.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s4\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n"
+        "# Context Snapshot: demo\n\n## What was happening\nWorking on X.\n\n"
+        "## Last messages (raw)\n**User:** hi\n**Assistant:** hello\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def fake_snapshot_summary(*args, **kwargs):
+        calls.append(("snapshot", args, kwargs))
+        return (
+            "## Summary\nIn-flight work on X interrupted by /compact.\n\n"
+            "## Key context that may be lost (summary)\n- Open decision: approach A vs B\n"
+        )
+
+    def fake_session_summary(*args, **kwargs):
+        calls.append(("session", args, kwargs))
+        return "## Summary\nshould-not-be-used\n"
+
+    with patch("hooks.obsidian_utils.generate_snapshot_summary", fake_snapshot_summary), \
+         patch("hooks.obsidian_utils.generate_summary", fake_session_summary):
+        result = upgrade_unsummarized_note(str(snap_path), str(vault), "claude-sessions", "demo")
+
+    assert not result.startswith("Failed"), result
+    types_called = [c[0] for c in calls]
+    assert types_called == ["snapshot"]
+    # File now contains the snapshot-shaped summary
+    assert "## Key context that may be lost (summary)" in snap_path.read_text(encoding="utf-8")

--- a/tests/test_snapshot_summarization.py
+++ b/tests/test_snapshot_summarization.py
@@ -13,6 +13,15 @@ def _fixture(sess_dir: Path, name: str, type_: str, status: str, session_id: str
     )
 
 
+def _fixture_no_type(sess_dir: Path, name: str, status: str, session_id: str):
+    p = sess_dir / name
+    p.write_text(
+        f"---\ndate: 2026-04-18\nsession_id: {session_id}\n"
+        f"project: demo\nstatus: {status}\n---\n\n# {name}\n",
+        encoding="utf-8",
+    )
+
+
 def test_find_unsummarized_picks_up_snapshots(tmp_path):
     vault = tmp_path / "v"
     sess = vault / "claude-sessions"
@@ -50,3 +59,27 @@ def test_find_unsummarized_orders_snapshots_before_parent(tmp_path):
     # Snapshots before parent within the same session_id group
     assert names.index("2026-04-18-demo-cccc-snapshot-090000.md") < names.index("2026-04-18-demo-cccc.md")
     assert names.index("2026-04-18-demo-cccc-snapshot-120000.md") < names.index("2026-04-18-demo-cccc.md")
+
+
+def test_find_unsummarized_rejects_non_session_non_snapshot_types(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    _fixture(sess, "2026-04-18-demo-dddd.md", "claude-session", "auto-logged", "s4")
+    _fixture(sess, "2026-04-18-demo-dddd-insight.md", "claude-insight", "auto-logged", "s4")
+
+    result = json.loads(find_unsummarized_notes(str(vault), "claude-sessions", "demo"))
+    names = [Path(p).name for p in result["unsummarized"]]
+    assert "2026-04-18-demo-dddd.md" in names
+    assert "2026-04-18-demo-dddd-insight.md" not in names
+
+
+def test_find_unsummarized_keeps_legacy_notes_without_type_field(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    _fixture_no_type(sess, "2026-04-18-demo-eeee-legacy.md", "auto-logged", "s5")
+
+    result = json.loads(find_unsummarized_notes(str(vault), "claude-sessions", "demo"))
+    names = [Path(p).name for p in result["unsummarized"]]
+    assert "2026-04-18-demo-eeee-legacy.md" in names

--- a/tests/test_snapshot_summarization.py
+++ b/tests/test_snapshot_summarization.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-from hooks.obsidian_utils import find_unsummarized_notes, upgrade_unsummarized_note
+from hooks.obsidian_utils import find_unsummarized_notes, upgrade_unsummarized_note, _augment_session_input_with_snapshots
 
 
 def _fixture(sess_dir: Path, name: str, type_: str, status: str, session_id: str, body: str = ""):
@@ -157,3 +157,57 @@ def test_session_routes_through_session_prompt(tmp_path):
     assert not result.startswith("Failed"), result
     types_called = [c[0] for c in calls]
     assert types_called == ["session"]
+
+
+def test_augment_prepends_upgraded_snapshot_summaries(tmp_path):
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    snap = sess / "2026-04-18-demo-eeee-snapshot-143000.md"
+    snap.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s5\n"
+        "project: demo\ntrigger: compact\nstatus: summarized\n---\n\n"
+        "# Context Snapshot: demo\n\n"
+        "## Summary\nMid-session decision on approach B.\n\n"
+        "## Key context that may be lost (summary)\n- Open question about scalability.\n\n"
+        "## Last messages (raw)\n**User:** earlier stuff\n",
+        encoding="utf-8",
+    )
+    result = _augment_session_input_with_snapshots(
+        transcript="current tail messages",
+        sessions_folder_path=sess,
+        session_id="s5",
+        date="2026-04-18",
+        project="demo",
+    )
+    assert "===== EARLIER IN THIS SESSION" in result
+    assert "Mid-session decision on approach B." in result
+    assert "current tail messages" in result
+    # Summary section preferred over raw body
+    assert "earlier stuff" not in result
+    # Trigger annotation present
+    assert "trigger=compact" in result
+
+
+def test_augment_returns_transcript_unchanged_when_no_snapshots(tmp_path):
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    result = _augment_session_input_with_snapshots(
+        "original", sess, "no-matches", "2026-04-18", "demo",
+    )
+    assert result == "original"
+
+
+def test_augment_falls_back_to_raw_when_snapshot_not_yet_upgraded(tmp_path):
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    snap = sess / "2026-04-18-demo-ffff-snapshot-090000.md"
+    snap.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s6\n"
+        "project: demo\ntrigger: clear\nstatus: auto-logged\n---\n\n"
+        "# Context Snapshot: demo\n\n## What was happening\nRaw work in progress.\n",
+        encoding="utf-8",
+    )
+    result = _augment_session_input_with_snapshots(
+        "tail", sess, "s6", "2026-04-18", "demo",
+    )
+    assert "Raw work in progress." in result

--- a/tests/test_snapshot_summarization.py
+++ b/tests/test_snapshot_summarization.py
@@ -211,3 +211,22 @@ def test_augment_falls_back_to_raw_when_snapshot_not_yet_upgraded(tmp_path):
         "tail", sess, "s6", "2026-04-18", "demo",
     )
     assert "Raw work in progress." in result
+
+
+def test_augment_omits_current_tail_banner_when_transcript_empty(tmp_path):
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    snap = sess / "2026-04-18-demo-gggg-snapshot-110000.md"
+    snap.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s7\n"
+        "project: demo\ntrigger: compact\nstatus: summarized\n---\n\n"
+        "## Summary\nSome mid-session work.\n",
+        encoding="utf-8",
+    )
+    result = _augment_session_input_with_snapshots(
+        "", sess, "s7", "2026-04-18", "demo",
+    )
+    assert "===== EARLIER IN THIS SESSION" in result
+    assert "Some mid-session work." in result
+    # No dangling tail banner when transcript is empty (preamble mode)
+    assert "CURRENT TAIL" not in result

--- a/tests/test_snapshot_summarization.py
+++ b/tests/test_snapshot_summarization.py
@@ -121,3 +121,39 @@ def test_snapshot_routes_through_snapshot_prompt(tmp_path):
     assert types_called == ["snapshot"]
     # File now contains the snapshot-shaped summary
     assert "## Key context that may be lost (summary)" in snap_path.read_text(encoding="utf-8")
+
+
+def test_session_routes_through_session_prompt(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    sess_path = sess / "2026-04-18-demo-eeee.md"
+    sess_path.write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s5\n"
+        "project: demo\nstatus: auto-logged\n---\n\n"
+        "# Session\n\n## Conversation (raw)\n"
+        "**User:** hi\n**Assistant:** hello\n",
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def fake_snapshot_summary(*args, **kwargs):
+        calls.append(("snapshot", args, kwargs))
+        return "## Summary\nshould-not-be-used\n"
+
+    def fake_session_summary(*args, **kwargs):
+        calls.append(("session", args, kwargs))
+        return (
+            "## Summary\nSession work.\n\n## Key Decisions\n- None noted.\n\n"
+            "## Changes Made\n- None noted.\n\n## Errors Encountered\n- None.\n\n"
+            "## Open Questions / Next Steps\n- [ ] None.\n\n## Importance\n5\n"
+        )
+
+    with patch("hooks.obsidian_utils.generate_snapshot_summary", fake_snapshot_summary), \
+         patch("hooks.obsidian_utils.generate_summary", fake_session_summary):
+        result = upgrade_unsummarized_note(str(sess_path), str(vault), "claude-sessions", "demo")
+
+    assert not result.startswith("Failed"), result
+    types_called = [c[0] for c in calls]
+    assert types_called == ["session"]

--- a/tests/test_snapshot_summarization.py
+++ b/tests/test_snapshot_summarization.py
@@ -86,6 +86,71 @@ def test_find_unsummarized_keeps_legacy_notes_without_type_field(tmp_path):
     assert "2026-04-18-demo-eeee-legacy.md" in names
 
 
+def test_augment_defaults_missing_trigger_to_auto(tmp_path):
+    """Regression for Copilot PR #43 round 2 finding: a snapshot without a
+    `trigger:` frontmatter field emits `trigger=auto` in the augmented
+    input, not `trigger=compact` — so the session summarizer isn't fed a
+    misleading label.
+    """
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    # No trigger field; summary is real so the block lands
+    (sess / "2026-04-18-demo-zz-snapshot-140000.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: sz\n"
+        "project: demo\nstatus: summarized\n"
+        'source_session_note: "[[2026-04-18-demo-zz]]"\n'
+        "---\n\n# T\n\n## Summary\nreal summary body\n",
+        encoding="utf-8",
+    )
+    out = _augment_session_input_with_snapshots(
+        "transcript tail",
+        sessions_folder_path=sess,
+        session_id="sz",
+        date="2026-04-18",
+        project="demo",
+    )
+    assert "[snapshot 14:00:00, trigger=auto]" in out or \
+           "[snapshot 140000, trigger=auto]" in out
+    assert "trigger=compact" not in out
+
+
+def test_find_unsummarized_orders_snapshot_before_parent_with_quoted_type(tmp_path):
+    """Regression for Copilot PR #43 round 2 finding: `_bias_key` reads the
+    `type:` frontmatter value without stripping quotes. A snapshot that uses
+    valid YAML quoting (`type: "claude-snapshot"`) previously sorted AFTER
+    its parent because the raw quoted string != 'claude-snapshot'.
+    """
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    parent = sess / "2026-04-18-demo-qqqq.md"
+    parent.write_text(
+        '---\ntype: "claude-session"\ndate: 2026-04-18\nsession_id: sq\n'
+        'project: demo\nstatus: auto-logged\n---\n\n# Parent\n',
+        encoding="utf-8",
+    )
+    # Double-quoted and single-quoted snapshot type declarations
+    snap_double = sess / "2026-04-18-demo-qqqq-snapshot-100000.md"
+    snap_double.write_text(
+        '---\ntype: "claude-snapshot"\ndate: 2026-04-18\nsession_id: sq\n'
+        'project: demo\nstatus: auto-logged\n---\n\n# Snap DQ\n',
+        encoding="utf-8",
+    )
+    snap_single = sess / "2026-04-18-demo-qqqq-snapshot-110000.md"
+    snap_single.write_text(
+        "---\ntype: 'claude-snapshot'\ndate: 2026-04-18\nsession_id: sq\n"
+        "project: demo\nstatus: auto-logged\n---\n\n# Snap SQ\n",
+        encoding="utf-8",
+    )
+
+    result = json.loads(find_unsummarized_notes(str(vault), "claude-sessions", "demo"))
+    names = [Path(p).name for p in result["unsummarized"]]
+    # Both snapshots must sort before the parent (quote-stripping lets the
+    # type check see 'claude-snapshot' rather than '"claude-snapshot"').
+    assert names.index(snap_double.name) < names.index(parent.name)
+    assert names.index(snap_single.name) < names.index(parent.name)
+
+
 def test_snapshot_routes_through_snapshot_prompt(tmp_path):
     vault = tmp_path / "v"
     sess = vault / "claude-sessions"

--- a/tests/test_snapshot_summarization.py
+++ b/tests/test_snapshot_summarization.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+from hooks.obsidian_utils import find_unsummarized_notes
+
+
+def _fixture(sess_dir: Path, name: str, type_: str, status: str, session_id: str, body: str = ""):
+    p = sess_dir / name
+    p.write_text(
+        f"---\ntype: {type_}\ndate: 2026-04-18\nsession_id: {session_id}\n"
+        f"project: demo\nstatus: {status}\n---\n\n# {name}\n\n{body}",
+        encoding="utf-8",
+    )
+
+
+def test_find_unsummarized_picks_up_snapshots(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    _fixture(sess, "2026-04-18-demo-aaaa-snapshot-140000.md", "claude-snapshot", "auto-logged", "s1")
+    _fixture(sess, "2026-04-18-demo-aaaa.md", "claude-session", "auto-logged", "s1")
+
+    result = json.loads(find_unsummarized_notes(str(vault), "claude-sessions", "demo"))
+    paths = result["unsummarized"]
+    names = [Path(p).name for p in paths]
+    assert any("snapshot-140000" in n for n in names)
+    assert any(n == "2026-04-18-demo-aaaa.md" for n in names)
+
+
+def test_find_unsummarized_skips_summarized_snapshots(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    _fixture(sess, "2026-04-18-demo-bbbb-snapshot-100000.md", "claude-snapshot", "summarized", "s2")
+
+    result = json.loads(find_unsummarized_notes(str(vault), "claude-sessions", "demo"))
+    assert result["unsummarized"] == []
+
+
+def test_find_unsummarized_orders_snapshots_before_parent(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    _fixture(sess, "2026-04-18-demo-cccc.md", "claude-session", "auto-logged", "s3")
+    _fixture(sess, "2026-04-18-demo-cccc-snapshot-120000.md", "claude-snapshot", "auto-logged", "s3")
+    _fixture(sess, "2026-04-18-demo-cccc-snapshot-090000.md", "claude-snapshot", "auto-logged", "s3")
+
+    result = json.loads(find_unsummarized_notes(str(vault), "claude-sessions", "demo"))
+    names = [Path(p).name for p in result["unsummarized"]]
+    # Snapshots before parent within the same session_id group
+    assert names.index("2026-04-18-demo-cccc-snapshot-090000.md") < names.index("2026-04-18-demo-cccc.md")
+    assert names.index("2026-04-18-demo-cccc-snapshot-120000.md") < names.index("2026-04-18-demo-cccc.md")

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -275,3 +275,96 @@ def test_early_skip_bypass_is_independently_exercised(tmp_path, monkeypatch):
         f"step 5 early-bypass did not fire; found: "
         f"{[p.name for p in sessions.glob('*.md')]}"
     )
+
+
+def test_session_log_finds_yesterday_snapshot_across_midnight(tmp_path, monkeypatch):
+    """Regression for Copilot PR #43 finding: SessionEnd must scan today AND
+    yesterday's date prefix so day-spanning sessions don't lose their
+    pre-midnight snapshots' back-references.
+    """
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+
+    today = datetime.date.today()
+    yesterday = today - datetime.timedelta(days=1)
+
+    # Seed a snapshot dated yesterday for this session
+    yesterday_snap = sessions / f"{yesterday.isoformat()}-demo-abcd-snapshot-235030.md"
+    yesterday_snap.write_text(
+        f"---\ntype: claude-snapshot\ndate: {yesterday.isoformat()}\n"
+        "session_id: s1\nproject: demo\ntrigger: compact\n"
+        "status: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(sesslog, "load_config", lambda: {
+        "vault_path": str(vault),
+        "sessions_folder": "claude-sessions",
+        "min_messages": 99,  # force bypass-or-skip path
+        "min_duration_minutes": 0,
+        "auto_log_enabled": True,
+    })
+    monkeypatch.setattr(sesslog, "read_transcript", lambda path: [
+        {"type": "user", "message": {"content": "cross midnight"}},
+    ])
+    monkeypatch.setattr(sesslog, "extract_user_messages", lambda msgs: ["cross midnight"])
+    monkeypatch.setattr(sesslog, "extract_assistant_messages", lambda msgs: [])
+    monkeypatch.setattr(sesslog, "extract_tool_uses", lambda msgs: [])
+    monkeypatch.setattr(sesslog, "extract_session_metadata", lambda msgs, cwd: {
+        "project": "demo", "git_branch": "develop", "duration_minutes": 0,
+        "project_path": str(tmp_path), "files_touched": [], "errors": [],
+    })
+
+    demo_cwd = tmp_path / "demo"
+    demo_cwd.mkdir()
+    projects_dir = tmp_path / ".claude" / "projects" / "demo"
+    projects_dir.mkdir(parents=True)
+    transcript = projects_dir / "sess.jsonl"
+    transcript.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    stdin_json = json.dumps({
+        "session_id": "s1",
+        "cwd": str(demo_cwd),
+        "transcript_path": str(transcript),
+    })
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin_json))
+
+    sesslog._run()
+
+    # Session note should land (threshold bypass fired because yesterday's
+    # snapshot was discovered via the candidate-dates loop) AND its
+    # snapshots: list must include yesterday's wikilink.
+    session_notes = [p for p in sessions.glob("*.md") if "-snapshot-" not in p.name]
+    assert len(session_notes) == 1, (
+        f"expected anchor session note across midnight; got: "
+        f"{[p.name for p in sessions.glob('*.md')]}"
+    )
+    content = session_notes[0].read_text(encoding="utf-8")
+    assert "snapshots:" in content
+    assert yesterday_snap.stem in content, (
+        f"yesterday's snapshot not back-referenced in session note:\n{content}"
+    )
+
+
+def test_snapshot_body_emits_last_messages_raw_section():
+    """Regression for Copilot PR #43 finding: snapshot bodies must include a
+    `## Last messages (raw)` section so `upgrade_unsummarized_note()`'s
+    raw-fallback parser can summarize a snapshot without the JSONL transcript.
+    """
+    metadata = {"project": "demo", "git_branch": "develop", "duration_minutes": 5}
+    body = snap._build_snapshot_body(
+        user_msgs=["hello there", "does this work?"],
+        metadata=metadata,
+        trigger="compact",
+        assistant_msgs=["yes, hi", "it sure does"],
+    )
+    # Exact section header the shared fallback parser looks for
+    assert "## Last messages (raw)" in body
+    # Must contain alternating User/Assistant lines in that section
+    raw_tail = body.split("## Last messages (raw)", 1)[1]
+    assert "**User:** hello there" in raw_tail
+    assert "**Assistant:** yes, hi" in raw_tail
+    assert "**User:** does this work?" in raw_tail
+    assert "**Assistant:** it sure does" in raw_tail

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -97,3 +97,181 @@ def test_run_writes_file_with_hhmmss_suffix(tmp_path, monkeypatch):
         r"2026-04-18-demo-[a-f0-9]{4}-snapshot-143027\.md$",
         written[0].name,
     )
+
+
+from hooks.obsidian_utils import find_snapshots_for_session
+from hooks.obsidian_session_log import _build_note
+
+
+def _write_snapshot_fixture(sessions_dir, date, project, sid4, hhmmss, session_id):
+    path = sessions_dir / f"{date}-{project}-{sid4}-snapshot-{hhmmss}.md"
+    path.write_text(
+        f"---\ntype: claude-snapshot\ndate: {date}\nsession_id: {session_id}\n"
+        f"project: {project}\ntrigger: compact\nstatus: auto-logged\n---\n\n"
+        "# Context Snapshot: demo (develop)\n\n## What was happening\nx\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_find_snapshots_returns_chronological_wikilinks(tmp_path):
+    sess = tmp_path / "claude-sessions"
+    sess.mkdir()
+    _write_snapshot_fixture(sess, "2026-04-18", "demo", "abcd", "155140", "sess-1")
+    _write_snapshot_fixture(sess, "2026-04-18", "demo", "abcd", "143027", "sess-1")
+    # Different session
+    _write_snapshot_fixture(sess, "2026-04-18", "demo", "abcd", "120000", "sess-2")
+
+    result = find_snapshots_for_session(sess, "sess-1", "2026-04-18", "demo")
+    assert result == [
+        "[[2026-04-18-demo-abcd-snapshot-143027]]",
+        "[[2026-04-18-demo-abcd-snapshot-155140]]",
+    ]
+
+
+def test_build_note_includes_snapshots_list_when_nonempty():
+    metadata = {"project": "demo", "git_branch": "develop", "duration_minutes": 42,
+                "project_path": "/x", "sessions_folder": "claude-sessions"}
+    metadata["snapshots"] = [
+        "[[2026-04-18-demo-abcd-snapshot-143027]]",
+        "[[2026-04-18-demo-abcd-snapshot-155140]]",
+    ]
+    note = _build_note("sess-1", metadata, body="content\n")
+    assert "\nsnapshots:\n" in note
+    assert '  - "[[2026-04-18-demo-abcd-snapshot-143027]]"' in note
+
+
+def test_build_note_omits_snapshots_list_when_empty():
+    metadata = {"project": "demo", "git_branch": "develop", "duration_minutes": 2,
+                "project_path": "/x", "sessions_folder": "claude-sessions"}
+    note = _build_note("sess-1", metadata, body="content\n")
+    assert "snapshots:" not in note  # field fully omitted — tidiness
+
+
+import hooks.obsidian_session_log as sesslog
+
+
+def test_session_log_writes_anchor_when_snapshots_exist_despite_low_messages(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    # Pre-create a snapshot for session s1
+    (sessions / "2026-04-18-demo-abcd-snapshot-143027.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+
+    # Config with very high min_messages to force the early skip path
+    monkeypatch.setattr(sesslog, "load_config", lambda: {
+        "vault_path": str(vault),
+        "sessions_folder": "claude-sessions",
+        "min_messages": 99,  # force early-skip path
+        "min_duration_minutes": 0,
+        "auto_log_enabled": True,
+    })
+
+    # Stub transcript parsing to return exactly 1 user message
+    monkeypatch.setattr(sesslog, "read_transcript", lambda path: [
+        {"type": "user", "message": {"content": "hello"}},
+    ])
+    monkeypatch.setattr(sesslog, "extract_user_messages", lambda msgs: ["hello"])
+    monkeypatch.setattr(sesslog, "extract_assistant_messages", lambda msgs: [])
+    monkeypatch.setattr(sesslog, "extract_tool_uses", lambda msgs: [])
+    monkeypatch.setattr(sesslog, "extract_session_metadata", lambda msgs, cwd: {
+        "project": "demo", "git_branch": "develop", "duration_minutes": 0,
+        "project_path": str(tmp_path), "files_touched": [], "errors": [],
+    })
+    # Use a cwd whose basename is "demo" so the early glob finds the snapshot.
+    demo_cwd = tmp_path / "demo"
+    demo_cwd.mkdir()
+
+    # Fake transcript path inside ~/.claude/projects
+    projects_dir = tmp_path / ".claude" / "projects" / "demo"
+    projects_dir.mkdir(parents=True)
+    transcript = projects_dir / "sess.jsonl"
+    transcript.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    stdin_json = json.dumps({
+        "session_id": "s1",
+        "cwd": str(demo_cwd),
+        "transcript_path": str(transcript),
+    })
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin_json))
+
+    sesslog._run()
+
+    # Assert a session note (not a snapshot) landed in addition to the pre-seeded snapshot
+    session_notes = [p for p in sessions.glob("*.md") if "-snapshot-" not in p.name]
+    assert len(session_notes) == 1, f"expected anchor session note; found: {[p.name for p in sessions.glob('*.md')]}"
+    content = session_notes[0].read_text(encoding="utf-8")
+    assert "snapshots:" in content
+    assert "2026-04-18-demo-abcd-snapshot-143027" in content
+
+
+def test_early_skip_bypass_is_independently_exercised(tmp_path, monkeypatch):
+    """Step 5 (message-count skip) must bypass independently of step 6.
+
+    Strategy: use a project directory name that slugifies to match the
+    pre-seeded snapshot, but have extract_session_metadata return a
+    DIFFERENT canonical project. Then step 4a finds the snapshot (via
+    the cwd-derived slug), step 5 bypasses, but step 6a's canonical
+    re-glob runs against the wrong project and would return []. If
+    step 5 weren't properly checking, the run would skip silently.
+    """
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "2026-04-18-demo-abcd-snapshot-143027.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(sesslog, "load_config", lambda: {
+        "vault_path": str(vault),
+        "sessions_folder": "claude-sessions",
+        "min_messages": 99,          # force step 5 skip
+        "min_duration_minutes": 0,
+        "auto_log_enabled": True,
+    })
+    monkeypatch.setattr(sesslog, "read_transcript", lambda path: [
+        {"type": "user", "message": {"content": "hi"}},
+    ])
+    monkeypatch.setattr(sesslog, "extract_user_messages", lambda msgs: ["hi"])
+    monkeypatch.setattr(sesslog, "extract_assistant_messages", lambda msgs: [])
+    monkeypatch.setattr(sesslog, "extract_tool_uses", lambda msgs: [])
+    # Canonical project differs from cwd basename — step 6a re-glob misses
+    monkeypatch.setattr(sesslog, "extract_session_metadata", lambda msgs, cwd: {
+        "project": "unrelated-project",     # snapshot is under 'demo'
+        "git_branch": "develop", "duration_minutes": 0,
+        "project_path": str(tmp_path), "files_touched": [], "errors": [],
+    })
+
+    # cwd basename slugifies to 'demo' → step 4a glob matches the snapshot
+    demo_cwd = tmp_path / "demo"
+    demo_cwd.mkdir()
+    projects_dir = tmp_path / ".claude" / "projects" / "demo"
+    projects_dir.mkdir(parents=True)
+    transcript = projects_dir / "sess.jsonl"
+    transcript.write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    stdin_json = json.dumps({
+        "session_id": "s1",
+        "cwd": str(demo_cwd),
+        "transcript_path": str(transcript),
+    })
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin_json))
+
+    sesslog._run()
+
+    # If step 5's bypass works, an anchor session note lands (because early
+    # glob found the snapshot). If step 5 weren't bypassing, _run() would
+    # have returned after `should_skip_session(user_msgs, 0, ...)` fires.
+    session_notes = [p for p in sessions.glob("*.md") if "-snapshot-" not in p.name]
+    assert len(session_notes) == 1, (
+        f"step 5 early-bypass did not fire; found: "
+        f"{[p.name for p in sessions.glob('*.md')]}"
+    )

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,38 +1,99 @@
 import datetime
+import io
 import json
 import re
-from pathlib import Path
 
 import hooks.obsidian_context_snapshot as snap
-from hooks.obsidian_utils import read_note_metadata
 
 
-def test_snapshot_frontmatter_has_status_and_source_session_note(tmp_path, monkeypatch):
-    vault = tmp_path / "vault"
-    (vault / "claude-sessions").mkdir(parents=True)
-    monkeypatch.setenv("HOME", str(tmp_path))
-
-    now = datetime.datetime(2026, 4, 18, 14, 30, 27)
+def test_snapshot_frontmatter_has_status_and_source_session_note():
     session_id = "abc-def-ghi"
     metadata = {"project": "demo", "git_branch": "develop"}
-
-    note = snap._build_snapshot_note(session_id, metadata, body="## What was happening\nsome body\n", trigger="compact")
-
-    # Frontmatter assertions
+    note = snap._build_snapshot_note(
+        session_id,
+        metadata,
+        body="## What was happening\nsome body\n",
+        trigger="compact",
+    )
     assert "\nstatus: auto-logged\n" in note
-    # Parent filename is <YYYY-MM-DD>-<project>-<sid4>
-    assert re.search(r"\nsource_session_note: \"\[\[\d{4}-\d{2}-\d{2}-demo-[a-f0-9]{4}\]\]\"\n", note)
+    assert re.search(
+        r'\nsource_session_note: "\[\[\d{4}-\d{2}-\d{2}-demo-[a-f0-9]{4}\]\]"\n',
+        note,
+    )
 
 
-def test_snapshot_filename_includes_hhmmss(monkeypatch):
-    # Freeze datetime.datetime.now so _run() produces a deterministic HHMMSS
+def test_run_writes_file_with_hhmmss_suffix(tmp_path, monkeypatch):
+    """_run() integrates datetime.now() into the snapshot filename."""
+
+    # Freeze datetime so the suffix is deterministic
     class FrozenDatetime(datetime.datetime):
         @classmethod
         def now(cls, tz=None):
             return cls(2026, 4, 18, 14, 30, 27)
+
     monkeypatch.setattr(snap.datetime, "datetime", FrozenDatetime)
 
-    from hooks.obsidian_utils import make_filename
-    fname = make_filename("2026-04-18", "demo", "abc-def-ghi", suffix=f"-snapshot-{FrozenDatetime.now():%H%M%S}")
-    assert fname.endswith("-snapshot-143027.md")
-    assert re.match(r"2026-04-18-demo-[a-f0-9]{4}-snapshot-143027\.md$", fname)
+    # Set up a vault
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+
+    # Stub load_config — the real one reads ~/.claude/obsidian-brain-config.json
+    # via Path.home() bound at import time, so $HOME monkeypatching won't reach it.
+    monkeypatch.setattr(
+        snap,
+        "load_config",
+        lambda: {
+            "vault_path": str(vault),
+            "sessions_folder": "claude-sessions",
+            "snapshot_on_compact": True,
+        },
+    )
+
+    # transcript_path containment check uses os.path.expanduser("~/.claude/projects")
+    # which still reads $HOME at call time, so point it at tmp_path.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Stub transcript-parsing helpers so _run() doesn't need a real JSONL
+    monkeypatch.setattr(
+        snap,
+        "read_transcript",
+        lambda path: [{"type": "user", "message": {"content": "hello"}}],
+    )
+    monkeypatch.setattr(snap, "extract_user_messages", lambda msgs: ["hello"])
+    monkeypatch.setattr(
+        snap,
+        "extract_session_metadata",
+        lambda msgs, cwd: {
+            "project": "demo",
+            "git_branch": "develop",
+            "duration_minutes": 1,
+        },
+    )
+
+    # transcript_path must sit inside ~/.claude/projects/ to pass the containment check
+    projects_dir = tmp_path / ".claude" / "projects" / "demo"
+    projects_dir.mkdir(parents=True)
+    transcript = projects_dir / "sess.jsonl"
+    transcript.write_text("{}\n", encoding="utf-8")
+
+    stdin_json = json.dumps(
+        {
+            "session_id": "abc-def-ghi",
+            "cwd": str(tmp_path),
+            "transcript_path": str(transcript),
+            "source": "compact",
+        }
+    )
+    monkeypatch.setattr("sys.stdin", io.StringIO(stdin_json))
+
+    snap._run()
+
+    # Exactly one snapshot note should have been written with the HHMMSS suffix
+    written = list(sessions.glob("*.md"))
+    assert len(written) == 1
+    assert written[0].name.endswith("-snapshot-143027.md")
+    assert re.match(
+        r"2026-04-18-demo-[a-f0-9]{4}-snapshot-143027\.md$",
+        written[0].name,
+    )

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,0 +1,38 @@
+import datetime
+import json
+import re
+from pathlib import Path
+
+import hooks.obsidian_context_snapshot as snap
+from hooks.obsidian_utils import read_note_metadata
+
+
+def test_snapshot_frontmatter_has_status_and_source_session_note(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    now = datetime.datetime(2026, 4, 18, 14, 30, 27)
+    session_id = "abc-def-ghi"
+    metadata = {"project": "demo", "git_branch": "develop"}
+
+    note = snap._build_snapshot_note(session_id, metadata, body="## What was happening\nsome body\n", trigger="compact")
+
+    # Frontmatter assertions
+    assert "\nstatus: auto-logged\n" in note
+    # Parent filename is <YYYY-MM-DD>-<project>-<sid4>
+    assert re.search(r"\nsource_session_note: \"\[\[\d{4}-\d{2}-\d{2}-demo-[a-f0-9]{4}\]\]\"\n", note)
+
+
+def test_snapshot_filename_includes_hhmmss(monkeypatch):
+    # Freeze datetime.datetime.now so _run() produces a deterministic HHMMSS
+    class FrozenDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return cls(2026, 4, 18, 14, 30, 27)
+    monkeypatch.setattr(snap.datetime, "datetime", FrozenDatetime)
+
+    from hooks.obsidian_utils import make_filename
+    fname = make_filename("2026-04-18", "demo", "abc-def-ghi", suffix=f"-snapshot-{FrozenDatetime.now():%H%M%S}")
+    assert fname.endswith("-snapshot-143027.md")
+    assert re.match(r"2026-04-18-demo-[a-f0-9]{4}-snapshot-143027\.md$", fname)

--- a/tests/test_vault_stats_snapshots.py
+++ b/tests/test_vault_stats_snapshots.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+
+from hooks import vault_index, vault_stats
+
+
+def _setup_vault(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    # 1 session, 2 snapshots (compact + clear) backed by it, 1 orphan
+    (sess / "2026-04-18-demo-aa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+        "status: summarized\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-demo-aa-snapshot-120000.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+        'trigger: compact\nstatus: summarized\nsource_session_note: "[[2026-04-18-demo-aa]]"\n'
+        "---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-demo-aa-snapshot-150000.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+        'trigger: clear\nstatus: auto-logged\nsource_session_note: "[[2026-04-18-demo-aa]]"\n'
+        "---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-demo-zz-snapshot-180000.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: missing\nproject: demo\n"
+        'trigger: compact\nstatus: auto-logged\nsource_session_note: "[[does-not-exist]]"\n'
+        "---\n\n# Orphan\n",
+        encoding="utf-8",
+    )
+    return vault
+
+
+def test_snapshot_stats_counts_by_trigger_and_integrity(tmp_path):
+    vault = _setup_vault(tmp_path)
+    db = vault_index.ensure_index(str(vault), ["claude-sessions"],
+                                  db_path=str(tmp_path / "test.db"))
+    payload = json.loads(vault_stats.compute_stats(db, "demo"))
+    snap = payload["vault_wide"]["snapshots"]
+    assert snap["total_snapshots"] == 3
+    assert snap["by_trigger"] == {"compact": 2, "clear": 1, "auto": 0}
+    assert snap["sessions_with_snapshots"] == 2   # s1 and "missing"
+    assert snap["max_snapshots_per_session"] == 2
+    assert snap["orphaned_snapshots"] == 1
+    assert snap["broken_backlinks"] >= 1
+    assert 0.0 <= snap["summarized_fraction"] <= 1.0
+
+
+def test_snapshot_stats_zero_state(tmp_path):
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    (sess / "2026-04-18-demo-aa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+    db = vault_index.ensure_index(str(vault), ["claude-sessions"],
+                                  db_path=str(tmp_path / "test2.db"))
+    payload = json.loads(vault_stats.compute_stats(db, "demo"))
+    snap = payload["vault_wide"]["snapshots"]
+    assert snap["total_snapshots"] == 0
+    assert snap["summarized_fraction"] == 1.0
+    assert snap["by_trigger"] == {"compact": 0, "clear": 0, "auto": 0}

--- a/tests/test_vault_stats_snapshots.py
+++ b/tests/test_vault_stats_snapshots.py
@@ -139,6 +139,50 @@ def test_compute_stats_corrupt_db_returns_error(tmp_path):
     assert "error" in payload
 
 
+def test_snapshot_stats_counts_summarized_even_when_file_unreadable(tmp_path):
+    """Regression for Copilot PR #43 round 2 finding: a snapshot with
+    `status: summarized` in the index but unreadable on disk must still
+    contribute to summarized_fraction, since status comes from the DB row
+    (which survives file-permission issues).
+    """
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    (sess / "2026-04-18-demo-aa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s1\n"
+        "project: demo\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+    snap_path = sess / "2026-04-18-demo-aa-snapshot-120000.md"
+    snap_path.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\n"
+        "project: demo\ntrigger: compact\nstatus: summarized\n"
+        'source_session_note: "[[2026-04-18-demo-aa]]"\n'
+        "---\n\n# Snap\n\n## Summary\nindexed as summarized\n",
+        encoding="utf-8",
+    )
+    db = vault_index.ensure_index(
+        str(vault), ["claude-sessions"],
+        db_path=str(tmp_path / "summary_vs_unreadable.db"),
+    )
+    # Now render unreadable AFTER indexing so status is captured in the DB row
+    import os
+    os.chmod(snap_path, 0o000)
+    try:
+        payload = json.loads(vault_stats.compute_stats(db, "demo"))
+    finally:
+        os.chmod(snap_path, 0o600)
+
+    snap = payload["vault_wide"]["snapshots"]
+    assert snap["total_snapshots"] == 1
+    assert snap["read_errors"] == 1
+    # The key assertion: summarized_fraction reflects the indexed status,
+    # not the on-disk readability. 1 summarized / 1 total == 1.0.
+    assert snap["summarized_fraction"] == 1.0, (
+        f"summarized_fraction should use indexed status, got {snap['summarized_fraction']}"
+    )
+
+
 def test_snapshot_stats_missing_trigger_folds_into_auto(tmp_path):
     """Regression for Copilot PR #43 finding: a snapshot note with no
     `trigger:` frontmatter field must NOT default into the compact bucket

--- a/tests/test_vault_stats_snapshots.py
+++ b/tests/test_vault_stats_snapshots.py
@@ -65,3 +65,41 @@ def test_snapshot_stats_zero_state(tmp_path):
     assert snap["total_snapshots"] == 0
     assert snap["summarized_fraction"] == 1.0
     assert snap["by_trigger"] == {"compact": 0, "clear": 0, "auto": 0}
+
+
+def test_snapshot_stats_unknown_trigger_folds_into_auto(tmp_path):
+    """Trigger values outside {compact, clear, auto} are counted as 'auto'."""
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    (sess / "2026-04-18-demo-aa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+    (sess / "2026-04-18-demo-aa-snapshot-120000.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+        'trigger: weird_value\nstatus: auto-logged\nsource_session_note: "[[2026-04-18-demo-aa]]"\n'
+        "---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    db = vault_index.ensure_index(str(vault), ["claude-sessions"],
+                                  db_path=str(tmp_path / "test3.db"))
+    payload = json.loads(vault_stats.compute_stats(db, "demo"))
+    snap = payload["vault_wide"]["snapshots"]
+    assert snap["total_snapshots"] == 1
+    assert snap["by_trigger"] == {"compact": 0, "clear": 0, "auto": 1}
+
+
+def test_compute_stats_missing_db_returns_error(tmp_path):
+    """compute_stats on a nonexistent DB returns {'error': ...} instead of raising."""
+    payload = json.loads(vault_stats.compute_stats(str(tmp_path / "does-not-exist.db"), "demo"))
+    assert "error" in payload
+    assert "DB not found" in payload["error"]
+
+
+def test_compute_stats_corrupt_db_returns_error(tmp_path):
+    """compute_stats on a file that isn't a SQLite DB surfaces the inner exception."""
+    corrupt = tmp_path / "corrupt.db"
+    corrupt.write_text("not a sqlite file", encoding="utf-8")
+    payload = json.loads(vault_stats.compute_stats(str(corrupt), "demo"))
+    assert "error" in payload

--- a/tests/test_vault_stats_snapshots.py
+++ b/tests/test_vault_stats_snapshots.py
@@ -137,3 +137,35 @@ def test_compute_stats_corrupt_db_returns_error(tmp_path):
     corrupt.write_text("not a sqlite file", encoding="utf-8")
     payload = json.loads(vault_stats.compute_stats(str(corrupt), "demo"))
     assert "error" in payload
+
+
+def test_snapshot_stats_missing_trigger_folds_into_auto(tmp_path):
+    """Regression for Copilot PR #43 finding: a snapshot note with no
+    `trigger:` frontmatter field must NOT default into the compact bucket
+    (inflates compact counts and masks legacy/malformed notes). Fold into
+    'auto' instead, consistent with the unknown-value handling.
+    """
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    (sess / "2026-04-18-demo-aa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s1\n"
+        "project: demo\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+    # Snapshot has NO trigger: field
+    (sess / "2026-04-18-demo-aa-snapshot-120000.md").write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\n"
+        "project: demo\nstatus: auto-logged\n"
+        'source_session_note: "[[2026-04-18-demo-aa]]"\n'
+        "---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    db = vault_index.ensure_index(
+        str(vault), ["claude-sessions"],
+        db_path=str(tmp_path / "missing_trigger.db"),
+    )
+    payload = json.loads(vault_stats.compute_stats(db, "demo"))
+    snap = payload["vault_wide"]["snapshots"]
+    assert snap["total_snapshots"] == 1
+    assert snap["by_trigger"] == {"compact": 0, "clear": 0, "auto": 1}

--- a/tests/test_vault_stats_snapshots.py
+++ b/tests/test_vault_stats_snapshots.py
@@ -65,6 +65,40 @@ def test_snapshot_stats_zero_state(tmp_path):
     assert snap["total_snapshots"] == 0
     assert snap["summarized_fraction"] == 1.0
     assert snap["by_trigger"] == {"compact": 0, "clear": 0, "auto": 0}
+    assert snap["read_errors"] == 0
+
+
+def test_snapshot_stats_counts_unreadable_snapshots(tmp_path):
+    """OSError on snapshot read is surfaced via read_errors, not silently dropped."""
+    vault = tmp_path / "v"
+    sess = vault / "claude-sessions"
+    sess.mkdir(parents=True)
+    (sess / "2026-04-18-demo-aa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+    snap_path = sess / "2026-04-18-demo-aa-snapshot-120000.md"
+    snap_path.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+        'trigger: compact\nstatus: auto-logged\nsource_session_note: "[[2026-04-18-demo-aa]]"\n'
+        "---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    db = vault_index.ensure_index(str(vault), ["claude-sessions"],
+                                  db_path=str(tmp_path / "unreadable.db"))
+    # Render the snapshot unreadable AFTER indexing (0o000 perms)
+    import os
+    os.chmod(snap_path, 0o000)
+    try:
+        payload = json.loads(vault_stats.compute_stats(db, "demo"))
+    finally:
+        os.chmod(snap_path, 0o600)
+
+    snap = payload["vault_wide"]["snapshots"]
+    assert snap["total_snapshots"] == 1
+    assert snap["read_errors"] == 1
+    # The unreadable snapshot should NOT be silently counted as a trigger
+    assert sum(snap["by_trigger"].values()) + snap["read_errors"] == snap["total_snapshots"]
 
 
 def test_snapshot_stats_unknown_trigger_folds_into_auto(tmp_path):


### PR DESCRIPTION
## Summary
Elevates vault snapshot notes from raw-only unlinked artifacts into first-class mid-session checkpoints — AI-summarized, bidirectionally linked to parent sessions, folded cohesively into the session summary at `/recall` time.

**Phase A + D in this PR** (Tasks 1-12 + closing). Phase B (`snapshot-integrity` vault-doctor) and Phase C (`snapshot-migration`) ship as follow-up PRs.

- Spec: `docs/superpowers/specs/2026-04-17-snapshot-summary-integration-design.md`
- Plan: `docs/superpowers/plans/2026-04-18-snapshot-summary-integration.md`

## What ships

**Write-time contract (Tasks 1-2)** — `-snapshot-HHMMSS` filenames, `status: auto-logged` + `source_session_note` frontmatter, SessionEnd `snapshots: [...]` back-reference + threshold bypass; day-spanning session lookup scans today + yesterday.

**Summarization pipeline (Tasks 3-5)** — `find_unsummarized_notes` with snapshot-first ordering bias (quote-stripped type comparison); dedicated `SNAPSHOT_SUMMARY_PROMPT` + `note_type` routing; `_augment_session_input_with_snapshots()` prepends snapshot bodies for cohesive summaries.

**Presentation + activation (Tasks 6-7)** — `/recall` nested `↳ HH:MM:SS` rows + LOAD_MANIFEST depth; public `fetch_snapshot_summaries()` helper; `log_access()` snapshot→parent cascade via `executemany`.

**Dependent skills (Tasks 8-12)** — `/vault-config` + `/obsidian-setup` warnings; `/emerge --include-snapshots` opt-in; `/check-items` session-only scan; `/vault-stats ## Snapshots` section (trigger buckets + `read_errors` counter + integrity checks); `/vault-search` + `/vault-ask` snapshot markers and cohesive citations.

## Review cycles — **converged**

**Initial pass (pr-review-toolkit 3 agents on `e498f88`):** code-reviewer approved; silent-failure-hunter flagged 2 correctness issues (cache poisoning on sqlite3 transient errors + silent OSError in `_snapshot_stats`) — both fixed in `24d3b4c`.

**Copilot round 1 (on `e423973`):** 4 real findings, all fixed in `87af7fb`:
1. Midnight rollover in `obsidian_session_log` — now scans today+yesterday
2. Snapshot raw-fallback header mismatch — now emits `## Last messages (raw)`
3. `source_session_note` regex too strict — now accepts `"|'|<none>`
4. Missing `trigger:` defaulted to "compact" — now "auto"

**Copilot round 2 (on `87af7fb`):** 4 real findings, all fixed in `49687a6`:
1. `_augment_session_input_with_snapshots` trigger default (2nd location)
2. `fetch_snapshot_summaries` trigger default (3rd location)
3. `_bias_key` type-value quote stripping
4. `_snapshot_stats` `summarized_fraction` under-count when file unreadable

**Copilot round 3 (on `49687a6`):** 2 DISCUSS + 1 SKIP (false positive) — convergence achieved:
- Unified sys.path in conftest.py — **out of scope** (pre-existing design, cross-suite refactor)
- `_bias_key` re-reads files — **deferred** to follow-up optimization; requires threading content through the data structure
- Trigger default "compact" claim — **false positive**, verified line 666 already defaults to `"auto"`

All 11 inline threads resolved. Per pr-review-loop "all new SKIP/DISCUSS = stop" rule, no further iterations.

## Test plan
- [x] 572 pytest tests pass (+39 new across 8 test modules; regression guards for every Copilot finding)
- [x] `hooks/` coverage 90%+ (Task 16 gate)
- [x] Backwards compat: legacy snapshots work without migration; pre-spec notes without `type:` still count as sessions
- [ ] Dev-test smoke (Task 17) — **required before merge**:
  - Automated: `bash scripts/dev-test/test-snapshots-manual.sh` after `/dev-test install`
  - Manual: `scripts/dev-test/DEV-TEST-SNAPSHOTS.md` 9-phase checklist

## Known plan corrections
- Task 11 orphan SQL in plan was invalid (`source_session` column unpopulated on sessions); implementation reads frontmatter.
- Task 10 preserved single-pass `collect_open_items` design instead of `read_note_metadata` call.
- Task 11 plan test expectation was inconsistent with its fixture.

## Follow-up PRs (not in scope)
- Phase B — `scripts/vault_doctor_checks/snapshot_integrity.py` (6 checks)
- Phase C — `scripts/vault_doctor_checks/snapshot_migration.py` (4 legacy backfill checks)

## Deferred review findings (tracked for follow-up)
- `_bias_key` I/O optimization — thread pre-parsed (sid, type) from initial scan (Copilot round 3)
- Unified sys.path style in `tests/conftest.py` (Copilot round 3, cross-suite cleanup)
- E2E integration test for write → summarize → /recall cycle
- `/emerge` cache-key flip regression coverage
- Broad `except Exception` narrowing in `generate_snapshot_summary` + `generate_summary` (pre-existing pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)