### PR TITLE
feat(recall): verbatim checkoff presentation + Read-verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/recall` Step 4 could silently close still-open items when Claude's paraphrased candidate presentation didn't match the candidate's actual text. Approval now lands on the verbatim text that will be matched on disk, and each candidate's source line is Read-verified before any Edit. Closes #47.
 
 ### Changed
-- `/recall` Step 4 now uses Claude Code's native `AskUserQuestion` multi-select picker when ≤4 checkoff candidates are surfaced. At >4 candidates, the text prompt still applies but now shows each candidate's verbatim `- [ ] <text>` line and `file:line` anchor so users can verify before confirming. Items skipped due to source drift are excluded from the cascade step.
+- `/recall` Step 4 now uses Claude Code's native `AskUserQuestion` multi-select picker when ≤4 checkoff candidates are surfaced. At >4 candidates, the text prompt still applies but now shows each candidate's verbatim `- [ ] <text>` line and `file:line` anchor so users can verify before confirming. Items skipped due to source drift are excluded from the cascade step. (See #47.)
 
 ## [2.4.0] - 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `/recall` Step 4 could silently close still-open items when Claude's paraphrased candidate presentation didn't match the candidate's actual text. Approval now lands on the verbatim text that will be matched on disk, and each candidate's source line is Read-verified before any Edit. Closes #47.
+
+### Changed
+- `/recall` Step 4 now uses Claude Code's native `AskUserQuestion` multi-select picker when ≤4 checkoff candidates are surfaced. At >4 candidates, the text prompt still applies but now shows each candidate's verbatim `- [ ] <text>` line and `file:line` anchor so users can verify before confirming. Items skipped due to source drift are excluded from the cascade step.
+
 ## [2.4.0] - 2026-04-21
 
 ### Added

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -307,7 +307,7 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
    b. **Match check.** Scan the read region for any line that, after stripping leading whitespace, the `- [ ] ` prefix, AND trailing whitespace/newline, equals `candidate.text` byte-for-byte. The candidate text was already normalized by `open_item_dedup.collect_open_items` via `line.strip()` (leading+trailing whitespace removed) followed by `[6:]` (prefix removed), so both sides of the comparison end up as the same fully-stripped item text. The bullet prefix is exactly `- [ ] ` (hyphen, space, open-bracket, space, close-bracket, single trailing space) — `open_item_dedup.collect_open_items` emits only this form, so `- [ ]` with other spacing or `*`/`+` bullets will correctly fail to match and trigger the drift-skip branch.
 
-   c. **If match found:** use `Edit` with `replace_all: false` to change that specific line from `- [ ] <candidate.text>` to `- [x] <candidate.text>`. Include enough surrounding text in the Edit call to ensure uniqueness. Append `candidate.text` to `successfully_edited`.
+   c. **If match found:** use `Edit` with `replace_all: false` to update the already-matched raw line in place, preserving any leading whitespace/indentation and changing only its checkbox marker from `[ ]` to `[x]`. Do not reconstruct the line from `candidate.text` — use the raw line as seen in the Read output. Include enough surrounding text in the Edit call to ensure uniqueness. Append `candidate.text` to `successfully_edited`.
 
    d. **If no match found in the read region:** skip this candidate, increment `skipped_drift`, and emit:
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -335,17 +335,17 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
 6. **Confirm checkoffs to user.** Print:
 
-```
-✅ Checked off N item(s) across <list of files>.
-```
+   ```
+   ✅ Checked off N item(s) across <list of files>.
+   ```
 
-If `skipped_drift > 0` or `skipped_other > 0`, append:
+   If `skipped_drift > 0` or `skipped_other > 0`, append:
 
-```
-⚠️  Skipped M item(s) total (drift: <skipped_drift>, other: <skipped_other>) — see warnings above.
-```
+   ```
+   ⚠️  Skipped M item(s) total (drift: <skipped_drift>, other: <skipped_other>) — see warnings above.
+   ```
 
-Where `N = len(successfully_edited)` and `M = skipped_drift + skipped_other`.
+   Where `N = len(successfully_edited)` and `M = skipped_drift + skipped_other`.
 
 7. **Cascade check-offs to duplicate items in older notes.** Run:
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -291,17 +291,18 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
    a. **Read** the source file at `offset = max(1, candidate.line - 3), limit = 7` (±3 lines context, clamped at file start). This also satisfies the Edit tool's "must Read before Edit" requirement.
 
-   b. **Match check.** Scan the read region for any line that, after stripping optional leading whitespace and the `- [ ] ` prefix, equals `candidate.text` byte-for-byte. The candidate text itself is used verbatim — no trimming.
+   b. **Match check.** Scan the read region for any line that, after stripping optional leading whitespace and the `- [ ] ` prefix, equals `candidate.text` byte-for-byte. The candidate text itself is used verbatim — no trimming. The bullet prefix is exactly `- [ ] ` (hyphen, space, open-bracket, space, close-bracket, single trailing space) — the candidate producer in `obsidian_utils.collect_open_items` emits only this form, so `- [ ]` with other spacing or `*`/`+` bullets will correctly fail to match and trigger the drift-skip branch.
 
    c. **If match found:** use `Edit` with `replace_all: false` to change that specific line from `- [ ] <candidate.text>` to `- [x] <candidate.text>`. Include enough surrounding text in the Edit call to ensure uniqueness. Append `candidate.text` to `successfully_edited`.
 
    d. **If no match:** skip this candidate, increment `skipped_drift`, and emit:
 
    ```
-   ⚠️  Skipped checkoff "<candidate.text>" — source line at <basename(file)>:<line>
-   reads "<actual line with leading whitespace and bullet stripped>" which does
-   not match candidate text. File may have changed since /recall started.
-   Edit manually in Obsidian.
+   ⚠️  Skipped checkoff "<candidate.text>" — source line at <basename(file)>:<line> reads
+   "<raw text of the line at candidate.line, verbatim including leading whitespace — or
+   "(line is no longer a checkbox)" if the line does not start with `- [` after stripping
+   leading whitespace>" which does not match candidate text. File may have changed since
+   /recall started. Edit manually in Obsidian.
    ```
 
    e. **If the Edit itself fails** (non-unique match despite the Read context), skip and emit:

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -270,7 +270,7 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
    I noticed these open items may now be done:
 
    1. <basename(file)>:<line>
-      `- [ ] <verbatim candidate.text>`
+      - [ ] <verbatim candidate.text>
       Evidence: "<short evidence snippet>"
 
    2. ...
@@ -311,16 +311,12 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
    ```
    ⚠️  Skipped checkoff at <basename(file)>:<line>
-       expected: "- [ ] <candidate.text>"
-       found:    "<raw text of the line at the position in the read buffer
-                  corresponding to candidate.line — or "(line is past EOF)"
-                  if the read region is shorter than expected, or
-                  "(line is no longer a checkbox)" if the line doesn't start
-                  with `- [` after stripping leading whitespace>"
+       expected: - [ ] <candidate.text>
+       found:    <RAW_LINE>
    File changed since /recall Step 3. Edit manually in Obsidian.
    ```
 
-   The position within the read buffer is `min(3, candidate.line - 1)` because Read clamped `offset = max(1, candidate.line - 3)` — when `candidate.line ≥ 4`, the target line sits at buffer index 3; when `candidate.line ∈ {1,2,3}`, it sits at buffer index `candidate.line - 1`. Do NOT append to `successfully_edited`.
+   `<RAW_LINE>` is the raw text (verbatim, leading whitespace preserved) of the line at buffer index `min(3, candidate.line - 1)` in the read region. Use the literal substitute `(line is past EOF)` if the read region is shorter than expected, or `(line is no longer a checkbox)` if the line's content (after stripping leading whitespace) does not start with `- [`. The buffer-index formula follows from Read's clamp `offset = max(1, candidate.line - 3)` — when `candidate.line ≥ 4`, the target line sits at buffer index 3; when `candidate.line ∈ {1,2,3}`, it sits at buffer index `candidate.line - 1`. Do NOT append to `successfully_edited`.
 
    e. **If the Edit call itself fails** (string not found, ambiguous match, or file-modified-since-read): skip, increment `skipped_other`, and emit the Edit tool's error message verbatim:
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -285,11 +285,35 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
    - `all` → check off all candidates
    - Comma-separated numbers (e.g. `1,3`) → check off only those
 
-5. **For each confirmed checkoff, edit the source file.** Use Read to load the full source file. Find the exact line containing `- [ ] <item text>`. Replace it with `- [x] <item text>`. Use the Edit tool with `replace_all: false` and provide enough context to ensure uniqueness. If the line is ambiguous, skip and warn:
+5. **For each confirmed checkoff, Read-verify then Edit.** Maintain a `successfully_edited` list (starts empty) and a `skipped_drift` counter (starts 0).
 
-```
-⚠️  Could not check off item "<item text>" — line is not unique in <file>. Edit manually in Obsidian.
-```
+   For each confirmed candidate:
+
+   a. **Read** the source file at `offset = max(1, candidate.line - 3), limit = 7` (±3 lines context, clamped at file start). This also satisfies the Edit tool's "must Read before Edit" requirement.
+
+   b. **Match check.** Scan the read region for any line that, after stripping optional leading whitespace and the `- [ ] ` prefix, equals `candidate.text` byte-for-byte. The candidate text itself is used verbatim — no trimming.
+
+   c. **If match found:** use `Edit` with `replace_all: false` to change that specific line from `- [ ] <candidate.text>` to `- [x] <candidate.text>`. Include enough surrounding text in the Edit call to ensure uniqueness. Append `candidate.text` to `successfully_edited`.
+
+   d. **If no match:** skip this candidate, increment `skipped_drift`, and emit:
+
+   ```
+   ⚠️  Skipped checkoff "<candidate.text>" — source line at <basename(file)>:<line>
+   reads "<actual line with leading whitespace and bullet stripped>" which does
+   not match candidate text. File may have changed since /recall started.
+   Edit manually in Obsidian.
+   ```
+
+   e. **If the Edit itself fails** (non-unique match despite the Read context), skip and emit:
+
+   ```
+   ⚠️  Could not check off item "<candidate.text>" — line is not unique in
+   <basename(file)>. Edit manually in Obsidian.
+   ```
+
+   Do NOT append to `successfully_edited` in cases (d) and (e).
+
+   Continue with remaining confirmed candidates regardless of any individual skip.
 
 6. **Confirm checkoffs to user.** Print:
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -281,9 +281,11 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
    The `- [ ] <verbatim candidate.text>` line MUST be shown in a code block using the exact `candidate.text` content (no paraphrase, no ellipsis). Step 5's match rule then compares this text against the file line after normalizing the file side (strip leading whitespace, `- [ ] ` prefix, and trailing whitespace/newline) — so the presented text is what matches after normalization, not byte-for-byte against raw file bytes.
 
 4. **Wait for user response** (N > 4 branch only — the N ≤ 4 branch returns from `AskUserQuestion`). Parse the response:
-   - `none` or empty → skip checkoff entirely, proceed to Step 5
+   - `none` or empty → skip the remaining checkoff sub-steps (5–7) and proceed directly to the "Show load manifest" block at the end of Step 4
    - `all` → check off all candidates
    - Comma-separated numbers (e.g. `1,3`) → check off only those
+
+   **N ≤ 4 branch:** if the user's `AskUserQuestion` selection is empty, treat it the same way — skip sub-steps 5–7 and proceed to the "Show load manifest" block at the end of Step 4.
 
 5. **For each confirmed checkoff, Read-verify then Edit.** Maintain a `successfully_edited` list (starts empty), a `skipped_drift` counter (starts 0), and a `skipped_other` counter (starts 0).
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -232,22 +232,55 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
 2. **Parse candidates.** The JSON array contains objects with `file`, `line`, `text`, `evidence`, `confidence`, `has_completion_phrase`.
 
-3. **Present candidates to user.** Print:
+3. **Present candidates to user.** Branch by N (number of candidates):
 
-```
-I noticed these open items may now be done:
+   **N ≤ 4 — native multi-select picker:**
 
-1. [x] <item text>
-     From: <basename of source file>
-     Evidence: "<short snippet from evidence showing the match>"
+   Call `AskUserQuestion` with `multiSelect: true`. Build one `option` per candidate:
 
-2. [x] <item text>
-     ...
+   - `label`: first ~40 characters of the candidate's `text` field, ellipsized with `…` if truncated. No paraphrase — take a prefix of the verbatim text.
+   - `description`: `<basename(file)>:<line> — "<full verbatim candidate.text>" — Evidence: <short evidence snippet>`
 
-Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
-```
+   Example shape:
 
-4. **Wait for user response.** Parse the response:
+   ```
+   AskUserQuestion({
+     questions: [{
+       question: "Which open items should I check off?",
+       header: "Checkoff",
+       multiSelect: true,
+       options: [
+         {
+           label: "File #69: Investigate /recall parallel subpro…",
+           description: "2026-04-20-obsidian-brain-7769.md:42 — \"File #69: Investigate /recall parallel subprocess dispatch sequentiality in Claude Code harness\" — Evidence: \"...shipped v2.4.0 ...completing issue #69...\""
+         },
+         ...
+       ]
+     }]
+   })
+   ```
+
+   Record the user's selected options. Empty selection → treat as `none`.
+
+   **N > 4 — verbatim text fallback:**
+
+   Print:
+
+   ```
+   I noticed these open items may now be done:
+
+   1. <basename(file)>:<line>
+      `- [ ] <verbatim candidate.text>`
+      Evidence: "<short evidence snippet>"
+
+   2. ...
+
+   Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
+   ```
+
+   The `- [ ] <verbatim candidate.text>` line MUST be shown in a code block exactly as it will be matched on disk. Do not paraphrase. Do not add ellipsis.
+
+4. **Wait for user response** (N > 4 branch only — the N ≤ 4 branch returns from `AskUserQuestion`). Parse the response:
    - `none` or empty → skip checkoff entirely, proceed to Step 5
    - `all` → check off all candidates
    - Comma-separated numbers (e.g. `1,3`) → check off only those

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -228,7 +228,7 @@ If unsummarized notes were upgraded in Step 2, also mention:
 
 Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
-1. **Skip if no candidates.** If the value is `NO_ITEMS` or `NO_CANDIDATES`, skip to Step 5 silently.
+1. **Skip if no candidates.** If the value is `NO_ITEMS` or `NO_CANDIDATES`, skip the rest of Step 4's checkoff sub-steps and proceed directly to the "Show load manifest" block at the end of Step 4 silently.
 
 2. **Parse candidates.** The JSON array contains objects with `file`, `line`, `text`, `evidence`, `confidence`, `has_completion_phrase`.
 
@@ -287,7 +287,7 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
 5. **For each confirmed checkoff, Read-verify then Edit.** Maintain a `successfully_edited` list (starts empty), a `skipped_drift` counter (starts 0), and a `skipped_other` counter (starts 0).
 
-   **5-pre. Within-batch dedup:** if the confirmed candidate list contains two entries with the same `(file, line)`, keep only the first and silently drop the rest — they are scan duplicates, not drift. Report: `De-duplicated K within-batch candidate(s).` if K > 0.
+   **5-pre. Within-batch dedup:** if the confirmed candidate list contains two entries with the same `(file, line)`, keep only the first and drop the rest automatically — they are scan duplicates, not drift. Do not emit per-duplicate warnings or treat them as skips. If any duplicates were removed, print this one-line informational message: `De-duplicated K within-batch candidate(s).`
 
    For each confirmed candidate:
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -285,34 +285,53 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
    - `all` → check off all candidates
    - Comma-separated numbers (e.g. `1,3`) → check off only those
 
-5. **For each confirmed checkoff, Read-verify then Edit.** Maintain a `successfully_edited` list (starts empty) and a `skipped_drift` counter (starts 0).
+5. **For each confirmed checkoff, Read-verify then Edit.** Maintain a `successfully_edited` list (starts empty), a `skipped_drift` counter (starts 0), and a `skipped_other` counter (starts 0).
+
+   **5-pre. Within-batch dedup:** if the confirmed candidate list contains two entries with the same `(file, line)`, keep only the first and silently drop the rest — they are scan duplicates, not drift. Report: `De-duplicated K within-batch candidate(s).` if K > 0.
 
    For each confirmed candidate:
 
    a. **Read** the source file at `offset = max(1, candidate.line - 3), limit = 7` (±3 lines context, clamped at file start). This also satisfies the Edit tool's "must Read before Edit" requirement.
 
-   b. **Match check.** Scan the read region for any line that, after stripping optional leading whitespace and the `- [ ] ` prefix, equals `candidate.text` byte-for-byte. The candidate text itself is used verbatim — no trimming. The bullet prefix is exactly `- [ ] ` (hyphen, space, open-bracket, space, close-bracket, single trailing space) — the candidate producer in `obsidian_utils.collect_open_items` emits only this form, so `- [ ]` with other spacing or `*`/`+` bullets will correctly fail to match and trigger the drift-skip branch.
+   a'. **If Read fails** (file missing, permission denied, or the read region returns empty content): skip this candidate, increment `skipped_other`, and emit:
+
+   ```
+   ⚠️  Skipped checkoff "<candidate.text>" — cannot read <basename(file)>:<line>
+   (<error class from Read tool>). File may have been moved, deleted, or
+   permissions changed. Edit manually in Obsidian.
+   ```
+
+   Do NOT append to `successfully_edited`. Continue with next candidate.
+
+   b. **Match check.** Scan the read region for any line that, after stripping leading whitespace, the `- [ ] ` prefix, AND trailing whitespace/newline, equals `candidate.text` byte-for-byte. The candidate text was already rstripped by `open_item_dedup.collect_open_items`, so the comparison is symmetric. The bullet prefix is exactly `- [ ] ` (hyphen, space, open-bracket, space, close-bracket, single trailing space) — the candidate producer in `obsidian_utils.collect_open_items` emits only this form, so `- [ ]` with other spacing or `*`/`+` bullets will correctly fail to match and trigger the drift-skip branch.
 
    c. **If match found:** use `Edit` with `replace_all: false` to change that specific line from `- [ ] <candidate.text>` to `- [x] <candidate.text>`. Include enough surrounding text in the Edit call to ensure uniqueness. Append `candidate.text` to `successfully_edited`.
 
-   d. **If no match:** skip this candidate, increment `skipped_drift`, and emit:
+   d. **If no match found in the read region:** skip this candidate, increment `skipped_drift`, and emit:
 
    ```
-   ⚠️  Skipped checkoff "<candidate.text>" — source line at <basename(file)>:<line> reads
-   "<raw text of the line at candidate.line, verbatim including leading whitespace — or
-   "(line is no longer a checkbox)" if the line does not start with `- [` after stripping
-   leading whitespace>" which does not match candidate text. File may have changed since
-   /recall started. Edit manually in Obsidian.
+   ⚠️  Skipped checkoff at <basename(file)>:<line>
+       expected: "- [ ] <candidate.text>"
+       found:    "<raw text of the line at the position in the read buffer
+                  corresponding to candidate.line — or "(line is past EOF)"
+                  if the read region is shorter than expected, or
+                  "(line is no longer a checkbox)" if the line doesn't start
+                  with `- [` after stripping leading whitespace>"
+   File changed since /recall Step 3. Edit manually in Obsidian.
    ```
 
-   e. **If the Edit itself fails** (non-unique match despite the Read context), skip and emit:
+   The position within the read buffer is `min(3, candidate.line - 1)` because Read clamped `offset = max(1, candidate.line - 3)` — when `candidate.line ≥ 4`, the target line sits at buffer index 3; when `candidate.line ∈ {1,2,3}`, it sits at buffer index `candidate.line - 1`. Do NOT append to `successfully_edited`.
+
+   e. **If the Edit call itself fails** (string not found, ambiguous match, or file-modified-since-read): skip, increment `skipped_other`, and emit the Edit tool's error message verbatim:
 
    ```
-   ⚠️  Could not check off item "<candidate.text>" — line is not unique in
-   <basename(file)>. Edit manually in Obsidian.
+   ⚠️  Could not check off "<candidate.text>" in <basename(file)>:<line> —
+   Edit failed: <verbatim Edit error message>. The line may have been edited
+   externally since /recall started, or the same text appears multiple times.
+   Edit manually in Obsidian.
    ```
 
-   Do NOT append to `successfully_edited` in cases (d) and (e).
+   Do NOT append to `successfully_edited`.
 
    Continue with remaining confirmed candidates regardless of any individual skip.
 
@@ -322,13 +341,13 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 ✅ Checked off N item(s) across <list of files>.
 ```
 
-If `skipped_drift > 0`, append on a new line:
+If `skipped_drift > 0` or `skipped_other > 0`, append:
 
 ```
-⚠️  Skipped M item(s) due to source drift (see warnings above).
+⚠️  Skipped M item(s) total (drift: <skipped_drift>, other: <skipped_other>) — see warnings above.
 ```
 
-Where `N = len(successfully_edited)` and `M = skipped_drift`.
+Where `N = len(successfully_edited)` and `M = skipped_drift + skipped_other`.
 
 7. **Cascade check-offs to duplicate items in older notes.** Run:
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -321,6 +321,14 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 ✅ Checked off N item(s) across <list of files>.
 ```
 
+If `skipped_drift > 0`, append on a new line:
+
+```
+⚠️  Skipped M item(s) due to source drift (see warnings above).
+```
+
+Where `N = len(successfully_edited)` and `M = skipped_drift`.
+
 7. **Cascade check-offs to duplicate items in older notes.** Run:
 
     ```bash
@@ -335,7 +343,7 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
     ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
     ```
 
-    Construct `$CHECKED_ITEMS_JSON` as a JSON array of the confirmed item texts (passed via stdin to avoid shell quoting issues). Report the cascade summary.
+    Construct `$CHECKED_ITEMS_JSON` as a JSON array of the `successfully_edited` item texts (the ones where the Read-verify matched AND the Edit succeeded — NOT the originally-confirmed set). Items skipped due to drift or non-unique matches are excluded so we don't cascade a closed state the primary-edit step could not confirm. Pass via stdin to avoid shell quoting issues. Report the cascade summary.
 
 **Show load manifest** (same step — saves one parent round):
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -278,7 +278,7 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
    Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
    ```
 
-   The `- [ ] <verbatim candidate.text>` line MUST be shown in a code block exactly as it will be matched on disk. Do not paraphrase. Do not add ellipsis.
+   The `- [ ] <verbatim candidate.text>` line MUST be shown in a code block using the exact `candidate.text` content (no paraphrase, no ellipsis). Step 5's match rule then compares this text against the file line after normalizing the file side (strip leading whitespace, `- [ ] ` prefix, and trailing whitespace/newline) — so the presented text is what matches after normalization, not byte-for-byte against raw file bytes.
 
 4. **Wait for user response** (N > 4 branch only — the N ≤ 4 branch returns from `AskUserQuestion`). Parse the response:
    - `none` or empty → skip checkoff entirely, proceed to Step 5
@@ -303,7 +303,7 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
    Do NOT append to `successfully_edited`. Continue with next candidate.
 
-   b. **Match check.** Scan the read region for any line that, after stripping leading whitespace, the `- [ ] ` prefix, AND trailing whitespace/newline, equals `candidate.text` byte-for-byte. The candidate text was already rstripped by `open_item_dedup.collect_open_items`, so the comparison is symmetric. The bullet prefix is exactly `- [ ] ` (hyphen, space, open-bracket, space, close-bracket, single trailing space) — the candidate producer in `obsidian_utils.collect_open_items` emits only this form, so `- [ ]` with other spacing or `*`/`+` bullets will correctly fail to match and trigger the drift-skip branch.
+   b. **Match check.** Scan the read region for any line that, after stripping leading whitespace, the `- [ ] ` prefix, AND trailing whitespace/newline, equals `candidate.text` byte-for-byte. The candidate text was already normalized by `open_item_dedup.collect_open_items` via `line.strip()` (leading+trailing whitespace removed) followed by `[6:]` (prefix removed), so both sides of the comparison end up as the same fully-stripped item text. The bullet prefix is exactly `- [ ] ` (hyphen, space, open-bracket, space, close-bracket, single trailing space) — `open_item_dedup.collect_open_items` emits only this form, so `- [ ]` with other spacing or `*`/`+` bullets will correctly fail to match and trigger the drift-skip branch.
 
    c. **If match found:** use `Edit` with `replace_all: false` to change that specific line from `- [ ] <candidate.text>` to `- [x] <candidate.text>`. Include enough surrounding text in the Edit call to ensure uniqueness. Append `candidate.text` to `successfully_edited`.
 


### PR DESCRIPTION
## Summary

Hardens `/recall` Step 4 open-item checkoff to prevent silent close-out of still-open items. Three independent layers:

1. **Verbatim presentation.** Candidates are shown with the raw `text` field (no paraphrase) plus `file:line` anchor. User approval lands on the exact string that will be matched on disk. Closes the 2026-04-18 incident where a paraphrased summary described item A but the edit targeted item B.
2. **Read-verify before Edit.** Each confirmed candidate is Read at `offset = max(1, line - 3), limit = 7`; if the `- [ ] <text>` line no longer matches (after symmetric rstrip), the edit is skipped with a drift warning. Separate paths for Read-failure, no-match drift, and Edit-tool failure, each with verbatim error surfacing. Within-batch dedup prevents self-induced false drift. Two counters (`skipped_drift` + `skipped_other`) drive an accurate section 6 summary. The cascade step (`batch_cascade_checkoff`) is gated on the `successfully_edited` set so drift-skipped items don't propagate.
3. **Interactive multi-select** via `AskUserQuestion(multiSelect: true)` when ≤4 candidates; verbatim text fallback when >4.

Scope is strictly `skills/recall/SKILL.md` Step 4 sections 3–7 and the CHANGELOG. No Python changes, no new files.

## Commits

- `f8ff59d` feat: two-branch checkoff presentation (AskUserQuestion + verbatim fallback)
- `4048fdf` feat: Read-verify before Edit on each confirmed checkoff
- `5da9bfd` feat: gate cascade + drift count on successfully_edited set
- `e4b4a68` docs: CHANGELOG entries for #47
- `feed023` docs: cross-reference #47 in Changed entry
- `ae22f74` docs: tighten match rule + drift warning prose (code-review round 1)
- `3dd6a3d` fix: close silent-failure-hunter + code-reviewer findings (newline match, dual counters, Read-failure branch, TOCTOU, within-batch dedup)
- `86de2a4` fix: address Copilot round-1 (backticks in fenced block, nested quotes in drift warning)

## Test plan

- [x] Spec + code-quality subagent reviews (multiple rounds, all green)
- [x] Silent-failure hunter review (3 critical + 2 high — all addressed in 3dd6a3d)
- [x] Copilot review round 1 (3 inline comments — 2 fixed in 86de2a4, 1 replied as non-applicable after symmetric-rstrip rewrite)
- [x] `/dev-test install` + fresh Claude Code session `/recall` live smoke
- [x] CHANGELOG updated under `[Unreleased]` with both Fixed and Changed entries referencing #47

## Design

Spec: `docs/superpowers/specs/2026-04-21-recall-open-item-checkoff-verify-design.md` (in separate docs repo at github.com/abhattacherjee/spec-docs, branch `spec/recall-checkoff-verify-design`)
Plan: `docs/superpowers/plans/2026-04-21-recall-open-item-checkoff-verify.md` (same docs repo & branch)

Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
