### PR TITLE
fix(recall): N=1 checkoff + Skip-all sentinel for picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `/recall` Step 4 N=1 checkoff branch no longer hits `AskUserQuestion` `minItems=2` validation errors. Single candidates now route to the verbatim text fallback; the `2 ≤ N ≤ 4` picker branch gains an explicit "Skip all — don't check off anything" sentinel option so deferral is a visible selectable choice. Closes #78.
+
 ## [2.4.1] - 2026-04-22
 
 ### Fixed

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -234,9 +234,9 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
 3. **Present candidates to user.** Branch by N (number of candidates):
 
-   **2 ≤ N ≤ 4 — native multi-select picker:**
+   **2 ≤ N ≤ 3 — native multi-select picker:**
 
-   Call `AskUserQuestion` with `multiSelect: true`. Build one `option` per candidate, then append exactly one sentinel option (described below). `AskUserQuestion` enforces `options: { minItems: 2, maxItems: 4 }` — that is why N=1 routes to the text fallback below instead of this branch.
+   Call `AskUserQuestion` with `multiSelect: true`. Build one `option` per candidate, then append exactly one sentinel option (described below). `AskUserQuestion` enforces `options: { minItems: 2, maxItems: 4 }`, so this branch covers N ∈ {2, 3} real candidates (plus the sentinel = 3 or 4 total options). N=1 routes to the text fallback below because minItems=2 would be violated; N=4+ routes to the text fallback because N=4 real + 1 sentinel = 5 options, which exceeds maxItems=4.
 
    Per-candidate option:
 
@@ -245,10 +245,10 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
    Sentinel option (always appended last):
 
-   - `label`: `Skip all — don't check off anything`
+   - `label` (exact string, treat as the sentinel identity key): `Skip all — don't check off anything`
    - `description`: `Leave all open items as-is`
 
-   The sentinel makes "defer everything" a visible, selectable choice rather than an empty-submit convention. Tag it internally (e.g., store under a known constant like `SKIP_ALL_SENTINEL_LABEL`) so Step 5 can filter it out before Read-verify.
+   The sentinel makes "defer everything" a visible, selectable choice rather than an empty-submit convention. Step 5 will compare each selected option's `label` against the exact sentinel string above and drop any match before Read-verify.
 
    Example shape (N=2 real candidates + sentinel = 3 options, within the `maxItems: 4` cap):
 
@@ -276,11 +276,18 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
    })
    ```
 
-   Record the user's selected options. Filter out the sentinel before passing to Step 5. Empty selection, or a selection that contained **only** the sentinel, → treat as `none`. Note the `maxItems: 4` cap means this branch covers N ∈ {2, 3, 4} real candidates (plus the sentinel); N=5+ falls through to the text fallback below, so no truncation is possible here.
+   Record the user's selected options, then normalize in this exact order:
 
-   **N == 1 or N > 4 — verbatim text fallback:**
+   1. **Filter out the sentinel** by dropping any selected option whose `label` equals the exact string `Skip all — don't check off anything`.
+   2. **If the filtered list is empty** (whether the pre-filter selection was empty *or* contained only the sentinel), treat as `none` → skip sub-steps 5–7 and proceed to the "Show load manifest" block at the end of Step 4.
+   3. **Otherwise** pass the filtered list (real candidates only) to Step 5.
 
-   Print one numbered entry per candidate. The `Confirm` line's example syntax adapts to N: at N=1 show `(e.g. `1` or `none`)`; at N>4 show `(e.g. `1` or `1,2` or `all` or `none`)`.
+   **N == 1 or N ≥ 4 — verbatim text fallback:**
+
+   Print one numbered entry per candidate using the template below, with the `<CONFIRM_EXAMPLE>` placeholder replaced per N:
+
+   - N == 1 → `(e.g. `1` or `none`)`
+   - N ≥ 4 → `(e.g. `1` or `1,2` or `all` or `none`)`
 
    Template (repeat the numbered block for each candidate):
 
@@ -293,19 +300,20 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
    2. ...
 
-   Confirm checkoff? (e.g. `1` or `1,2` or `all` or `none`)
+   Confirm checkoff? <CONFIRM_EXAMPLE>
    ```
 
    The `- [ ] <verbatim candidate.text>` line MUST be shown in a code block using the exact `candidate.text` content (no paraphrase, no ellipsis). Step 5's match rule then compares this text against the file line after normalizing the file side (strip leading whitespace, `- [ ] ` prefix, and trailing whitespace/newline) — so the presented text is what matches after normalization, not byte-for-byte against raw file bytes.
 
-4. **Wait for user response** (text-fallback branch only — the `2 ≤ N ≤ 4` picker branch returns from `AskUserQuestion`). Parse the response:
+4. **Wait for user response** (text-fallback branch only — the `2 ≤ N ≤ 3` picker branch already returned a filtered list from the normalization steps above). Parse the response:
    - `none` or empty → skip the remaining checkoff sub-steps (5–7) and proceed directly to the "Show load manifest" block at the end of Step 4
    - `all` → check off all candidates
-   - Comma-separated numbers (e.g. `1,3`) → check off only those (for N=1, `1` checks off the single candidate)
-
-   **Picker branch (`2 ≤ N ≤ 4`):** if the user's `AskUserQuestion` selection is empty, or contains only the Skip-all sentinel, treat it the same way — skip sub-steps 5–7 and proceed to the "Show load manifest" block at the end of Step 4.
+   - Comma-separated numbers (e.g. `1,3`) → check off the candidates at those 1-indexed positions (for N=1, `1` checks off the single candidate)
+   - **Ambiguous or invalid input** — any index outside `1..N`, non-numeric tokens (e.g. `yes`, `y`), or mixed garbage: re-prompt exactly once with `I didn't understand "<input>". Reply with \`none\`, \`all\`, or a comma-separated list of numbers in 1..<N>.` On the second ambiguous reply, treat as `none` and print `Treating "<input>" as none — no items checked off.` so the fallback surfaces explicitly rather than silently defaulting.
 
 5. **For each confirmed checkoff, Read-verify then Edit.** Maintain a `successfully_edited` list (starts empty), a `skipped_drift` counter (starts 0), and a `skipped_other` counter (starts 0).
+
+   **5-pre-sentinel. Sentinel-leak guard:** before the per-candidate loop, assert that no entry's `text` equals the exact sentinel string `Skip all — don't check off anything`. If one slipped through the Step 4 normalization, abort Step 5 entirely, emit `⚠️  Internal: Skip-all sentinel leaked into checkoff list — deferring all items.`, and proceed to the "Show load manifest" block. This surfaces filter bugs as diagnostic output instead of trying to Read a label-string as a file path.
 
    **5-pre. Within-batch dedup:** if the confirmed candidate list contains two entries with the same `(file, line)`, keep only the first and drop the rest automatically — they are scan duplicates, not drift. Do not emit per-duplicate warnings or treat them as skips. If any duplicates were removed, print this one-line informational message: `De-duplicated K within-batch candidate(s).`
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -234,14 +234,23 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
 3. **Present candidates to user.** Branch by N (number of candidates):
 
-   **N ≤ 4 — native multi-select picker:**
+   **2 ≤ N ≤ 4 — native multi-select picker:**
 
-   Call `AskUserQuestion` with `multiSelect: true`. Build one `option` per candidate:
+   Call `AskUserQuestion` with `multiSelect: true`. Build one `option` per candidate, then append exactly one sentinel option (described below). `AskUserQuestion` enforces `options: { minItems: 2, maxItems: 4 }` — that is why N=1 routes to the text fallback below instead of this branch.
+
+   Per-candidate option:
 
    - `label`: first ~40 characters of the candidate's `text` field, ellipsized with `…` if truncated. No paraphrase — take a prefix of the verbatim text.
    - `description`: `<basename(file)>:<line> — "<full verbatim candidate.text>" — Evidence: <short evidence snippet>`
 
-   Example shape:
+   Sentinel option (always appended last):
+
+   - `label`: `Skip all — don't check off anything`
+   - `description`: `Leave all open items as-is`
+
+   The sentinel makes "defer everything" a visible, selectable choice rather than an empty-submit convention. Tag it internally (e.g., store under a known constant like `SKIP_ALL_SENTINEL_LABEL`) so Step 5 can filter it out before Read-verify.
+
+   Example shape (N=2 real candidates + sentinel = 3 options, within the `maxItems: 4` cap):
 
    ```
    AskUserQuestion({
@@ -254,17 +263,26 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
            label: "File #69: Investigate /recall parallel subpro…",
            description: "2026-04-20-obsidian-brain-7769.md:42 — \"File #69: Investigate /recall parallel subprocess dispatch sequentiality in Claude Code harness\" — Evidence: \"...shipped v2.4.0 ...completing issue #69...\""
          },
-         ...
+         {
+           label: "Another item…",
+           description: "..."
+         },
+         {
+           label: "Skip all — don't check off anything",
+           description: "Leave all open items as-is"
+         }
        ]
      }]
    })
    ```
 
-   Record the user's selected options. Empty selection → treat as `none`.
+   Record the user's selected options. Filter out the sentinel before passing to Step 5. Empty selection, or a selection that contained **only** the sentinel, → treat as `none`. Note the `maxItems: 4` cap means this branch covers N ∈ {2, 3, 4} real candidates (plus the sentinel); N=5+ falls through to the text fallback below, so no truncation is possible here.
 
-   **N > 4 — verbatim text fallback:**
+   **N == 1 or N > 4 — verbatim text fallback:**
 
-   Print:
+   Print one numbered entry per candidate. The `Confirm` line's example syntax adapts to N: at N=1 show `(e.g. `1` or `none`)`; at N>4 show `(e.g. `1` or `1,2` or `all` or `none`)`.
+
+   Template (repeat the numbered block for each candidate):
 
    ```
    I noticed these open items may now be done:
@@ -280,12 +298,12 @@ Parse the `OPEN_ITEM_CANDIDATES` section from the Step 3 Python output.
 
    The `- [ ] <verbatim candidate.text>` line MUST be shown in a code block using the exact `candidate.text` content (no paraphrase, no ellipsis). Step 5's match rule then compares this text against the file line after normalizing the file side (strip leading whitespace, `- [ ] ` prefix, and trailing whitespace/newline) — so the presented text is what matches after normalization, not byte-for-byte against raw file bytes.
 
-4. **Wait for user response** (N > 4 branch only — the N ≤ 4 branch returns from `AskUserQuestion`). Parse the response:
+4. **Wait for user response** (text-fallback branch only — the `2 ≤ N ≤ 4` picker branch returns from `AskUserQuestion`). Parse the response:
    - `none` or empty → skip the remaining checkoff sub-steps (5–7) and proceed directly to the "Show load manifest" block at the end of Step 4
    - `all` → check off all candidates
-   - Comma-separated numbers (e.g. `1,3`) → check off only those
+   - Comma-separated numbers (e.g. `1,3`) → check off only those (for N=1, `1` checks off the single candidate)
 
-   **N ≤ 4 branch:** if the user's `AskUserQuestion` selection is empty, treat it the same way — skip sub-steps 5–7 and proceed to the "Show load manifest" block at the end of Step 4.
+   **Picker branch (`2 ≤ N ≤ 4`):** if the user's `AskUserQuestion` selection is empty, or contains only the Skip-all sentinel, treat it the same way — skip sub-steps 5–7 and proceed to the "Show load manifest" block at the end of Step 4.
 
 5. **For each confirmed checkoff, Read-verify then Edit.** Maintain a `successfully_edited` list (starts empty), a `skipped_drift` counter (starts 0), and a `skipped_other` counter (starts 0).
 


### PR DESCRIPTION
## Summary

- `/recall` Step 4 N=1 branch was calling `AskUserQuestion` with a single option, failing the tool's `minItems=2` schema and raising `InputValidationError` before the user ever saw a picker. This made checking off the *last* open item impossible, and the self-demonstrating instance (an open item literally titled *"Fix /recall N=1 case"*) recurred for 6 consecutive `/recall` runs on obsidian-brain.
- Narrowed the picker branch to `2 ≤ N ≤ 3` (see round-2 below for why not 4); route N=1 and N≥4 to the existing verbatim text fallback.
- Added an explicit `Skip all — don't check off anything` sentinel option to the picker so deferral is a visible, selectable choice (filtered out before Read-verify by exact label-string match).
- Made the text-fallback confirm prompt N-aware via a `<CONFIRM_EXAMPLE>` placeholder substituted per N.
- Added a sentinel-leak guard at the top of Step 5 and a re-prompt-once rule for invalid input at N=1.

Closes #78.

## Files changed

- `skills/recall/SKILL.md` — Step 4 predicate rewrites, sentinel option, Step 5 precondition, invalid-input handling
- `CHANGELOG.md` — `[Unreleased]` Fixed entry referencing #78

No Python surface changed — this is a prompt-prose fix.

## Test plan

- [x] `./scripts/test-dev-skill.sh install` — 27 security tests passed, installed SKILL.md byte-matches working copy (re-verified after round-2 changes via restore+install)
- [x] `./scripts/commit-preflight.sh` — 676 pytest tests passed (coverage drift is pre-existing on develop, unrelated to this branch)
- [x] **Live merge gate**: fresh CC session, `/recall` on obsidian-brain with the N=1 item surfaced — no `InputValidationError`, text fallback rendered verbatim line in a code block, `(e.g. 1 or none)` prompt variant selected correctly
- [ ] Post-merge: verify the `Skip all` sentinel renders in the picker on a project with 2-3 open items (N∈{2,3} path isn't exercised by this repo's current vault state — low-risk since the picker branch itself already worked; only the sentinel option and narrower cap are new)

## Review rounds

### Round 2 — pr-review-toolkit fixes (commit `8506cf7`)

Three review agents returned. Six findings addressed:

1. **Off-by-one picker cap** (comment-analyzer): at N=4, 4 real + 1 sentinel = 5 options violates `maxItems: 4`. Picker narrowed to `2 ≤ N ≤ 3`; N=4+ falls through to text fallback.
2. **Template hardcoded N>4 example at N=1** (code-reviewer): replaced literal with `<CONFIRM_EXAMPLE>` placeholder + explicit per-N substitution rules.
3. **Rot-risk "SKIP_ALL_SENTINEL_LABEL constant"** (comment-analyzer): Claude has no persistent constants; reworded to literal label-string equality.
4. **Sentinel-leak path was loud-but-confusing** (silent-failure-hunter): added `5-pre-sentinel` Step 5 precondition that aborts cleanly with a diagnostic message.
5. **N=1 invalid-input silent default** (silent-failure-hunter): added re-prompt-once rule with loud fallback to `none`.
6. **Filter-then-none ordering implicit** (silent-failure-hunter): replaced with numbered operation list.

## Notes for reviewers

- The fix lives entirely in prose predicates that Claude follows — there are no Python function signatures or return-shape changes, so review focus should be on: (1) predicate coverage (no N value falls through a gap), (2) sentinel filtering logic being clear, (3) the N-aware confirm prompt example reading cleanly.
- Per `feedback_check_pr_base_branch`: base is explicitly `develop`, not `main`.
- Per memory `technical_github_closes_only_default_branch`: the `Closes #78` keyword may silently skip on squash-to-develop merges. Issue will be closed manually post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)