### PR TITLE
fix(vault-doctor): snapshot_migration §3 cross-midnight backlink (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `/recall` Step 4 N=1 checkoff branch no longer hits `AskUserQuestion` `minItems=2` validation errors. Single candidates now route to the verbatim text fallback; the `2 ≤ N ≤ 4` picker branch gains an explicit "Skip all — don't check off anything" sentinel option so deferral is a visible selectable choice. Closes #78.
-- `vault_doctor` `snapshot-migration` §3 (`snapshot-missing-backlink`) now resolves the parent session note via the `session_id` index built in the same scan, instead of composing a filename from `(snapshot.date, project, sha256(session_id)[:4])`. The old date-heuristic wrote wrong `source_session_note` wikilinks for cross-midnight sessions (PreCompact on day N, SessionEnd on day N+1). Orphan snapshots now emit `unresolved=True` with no speculative wikilink. Closes #68.
+- `vault-doctor` `snapshot-migration` §3 (`snapshot-missing-backlink`) now resolves the parent session note via the `session_id` index built in the same scan, instead of composing a filename from `(snapshot.date, project, sha256(session_id)[:4])`. The old date-heuristic wrote wrong `source_session_note` wikilinks for cross-midnight sessions (PreCompact on day N, SessionEnd on day N+1). Orphan snapshots now emit `unresolved=True` with no speculative wikilink. Closes #68.
 
 ## [2.4.1] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `/recall` Step 4 N=1 checkoff branch no longer hits `AskUserQuestion` `minItems=2` validation errors. Single candidates now route to the verbatim text fallback; the `2 ≤ N ≤ 4` picker branch gains an explicit "Skip all — don't check off anything" sentinel option so deferral is a visible selectable choice. Closes #78.
+- `vault_doctor` `snapshot-migration` §3 (`snapshot-missing-backlink`) now resolves the parent session note via the `session_id` index built in the same scan, instead of composing a filename from `(snapshot.date, project, sha256(session_id)[:4])`. The old date-heuristic wrote wrong `source_session_note` wikilinks for cross-midnight sessions (PreCompact on day N, SessionEnd on day N+1). Orphan snapshots now emit `unresolved=True` with no speculative wikilink. Closes #68.
 
 ## [2.4.1] - 2026-04-22
 

--- a/scripts/vault_doctor_checks/snapshot_migration.py
+++ b/scripts/vault_doctor_checks/snapshot_migration.py
@@ -185,7 +185,7 @@ def scan(vault_path, sessions_folder, insights_folder, days, project=None):
                 project=proj,
                 current_source="(no source_session_note)",
                 proposed_source="",
-                reason=f"parent session not found — no session_note with session_id={sid!r} in sessions folder",
+                reason=f"parent session not found — no session note with session_id={sid!r} in sessions folder",
                 confidence=0.0,
                 extra={"unresolved": True},
             ))

--- a/scripts/vault_doctor_checks/snapshot_migration.py
+++ b/scripts/vault_doctor_checks/snapshot_migration.py
@@ -156,21 +156,27 @@ def scan(vault_path, sessions_folder, insights_folder, days, project=None):
         sid = fm.get("session_id", "")
         proj = fm.get("project", "")
         if not sid or not proj:
+            missing = []
+            if not sid:
+                missing.append("session_id")
+            if not proj:
+                missing.append("project")
             issues.append(Issue(
                 check="snapshot-missing-backlink",
                 note_path=str(p),
                 project=proj,
                 current_source="(no source_session_note)",
                 proposed_source="",
-                reason="cannot resolve parent (missing session_id/project)",
+                reason=f"cannot resolve parent (missing frontmatter: {', '.join(missing)})",
                 confidence=0.0,
                 extra={"unresolved": True},
             ))
             continue
         parent_path = sessions_by_id.get(sid)
         if parent_path is None:
-            # Orphan — no session note with matching session_id anywhere
-            # in the vault. Let a future snapshot-orphan check own this
+            # Orphan — no session note with matching session_id in the
+            # sessions folder (sessions_by_id is built from sess_dir only,
+            # non-recursive). Let a future snapshot-orphan check own this
             # case; do NOT fabricate a wikilink from (date, slug,
             # sid_hash) — that is exactly the bug #68 fixed.
             issues.append(Issue(
@@ -179,7 +185,7 @@ def scan(vault_path, sessions_folder, insights_folder, days, project=None):
                 project=proj,
                 current_source="(no source_session_note)",
                 proposed_source="",
-                reason="parent session not found — no session_note with matching session_id",
+                reason=f"parent session not found — no session_note with session_id={sid!r} in sessions folder",
                 confidence=0.0,
                 extra={"unresolved": True},
             ))

--- a/scripts/vault_doctor_checks/snapshot_migration.py
+++ b/scripts/vault_doctor_checks/snapshot_migration.py
@@ -72,11 +72,6 @@ def _hhmmss_from_mtime(p: Path) -> str:
     return datetime.datetime.fromtimestamp(ts).strftime("%H%M%S")
 
 
-def _slugify(text: str) -> str:
-    """Minimal inline copy; avoids import cycles with hooks/ module."""
-    return re.sub(r"[^a-zA-Z0-9]+", "-", text.strip()).strip("-").lower() or "project"
-
-
 def scan(vault_path, sessions_folder, insights_folder, days, project=None):
     sess_dir = Path(vault_path) / sessions_folder
     if not sess_dir.is_dir():

--- a/scripts/vault_doctor_checks/snapshot_migration.py
+++ b/scripts/vault_doctor_checks/snapshot_migration.py
@@ -15,7 +15,6 @@ filenames still resolve after migration.
 from __future__ import annotations
 
 import datetime
-import hashlib
 import os
 import re
 import shutil
@@ -71,10 +70,6 @@ def _legacy_filename(p: Path) -> bool:
 def _hhmmss_from_mtime(p: Path) -> str:
     ts = p.stat().st_mtime
     return datetime.datetime.fromtimestamp(ts).strftime("%H%M%S")
-
-
-def _short_session_hash(session_id: str) -> str:
-    return hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:4] if session_id else "e3b0"
 
 
 def _slugify(text: str) -> str:

--- a/scripts/vault_doctor_checks/snapshot_migration.py
+++ b/scripts/vault_doctor_checks/snapshot_migration.py
@@ -159,32 +159,46 @@ def scan(vault_path, sessions_folder, insights_folder, days, project=None):
         if "source_session_note" in fm and fm["source_session_note"]:
             continue
         sid = fm.get("session_id", "")
-        date = fm.get("date", "")
         proj = fm.get("project", "")
-        if not sid or not date or not proj:
+        if not sid or not proj:
             issues.append(Issue(
                 check="snapshot-missing-backlink",
                 note_path=str(p),
                 project=proj,
                 current_source="(no source_session_note)",
                 proposed_source="",
-                reason="cannot compute parent stem (missing session_id/date/project)",
+                reason="cannot resolve parent (missing session_id/project)",
                 confidence=0.0,
                 extra={"unresolved": True},
             ))
             continue
-        parent_stem = f"{date}-{_slugify(proj)}-{_short_session_hash(sid)}"
-        parent_exists = (sess_dir / f"{parent_stem}.md").exists()
+        parent_path = sessions_by_id.get(sid)
+        if parent_path is None:
+            # Orphan — no session note with matching session_id anywhere
+            # in the vault. Let a future snapshot-orphan check own this
+            # case; do NOT fabricate a wikilink from (date, slug,
+            # sid_hash) — that is exactly the bug #68 fixed.
+            issues.append(Issue(
+                check="snapshot-missing-backlink",
+                note_path=str(p),
+                project=proj,
+                current_source="(no source_session_note)",
+                proposed_source="",
+                reason="parent session not found — no session_note with matching session_id",
+                confidence=0.0,
+                extra={"unresolved": True},
+            ))
+            continue
+        parent_stem = parent_path.stem
         issues.append(Issue(
             check="snapshot-missing-backlink",
             note_path=str(p),
             project=proj,
             current_source="(no source_session_note)",
             proposed_source=f'source_session_note: "[[{parent_stem}]]"',
-            reason=("parent session found" if parent_exists else
-                    "parent session not found — will warn only"),
-            confidence=0.95 if parent_exists else 0.3,
-            extra={"unresolved": not parent_exists, "parent_stem": parent_stem},
+            reason="parent session resolved via session_id index",
+            confidence=0.95,
+            extra={"unresolved": False, "parent_stem": parent_stem},
         ))
 
     # 4. session-missing-snapshots-list

--- a/tests/test_vault_doctor_snapshot_migration.py
+++ b/tests/test_vault_doctor_snapshot_migration.py
@@ -74,18 +74,28 @@ def test_missing_status_summarized_when_summary_exists(tmp_path):
 
 
 def test_missing_backlink_populates_source_session_note(tmp_path):
+    """Normal same-date case — parent resolves via sessions_by_id.
+
+    Uses an arbitrary (non-hash-based) parent filename to prove the
+    resolver is truly keyed on session_id frontmatter, not on a
+    filename shape that happens to match the old (date, slug, sid_hash)
+    composer. Under pre-#68 code, the fabricated stem
+    "2026-04-18-demo-<sha256('s4')[:4]>" would NOT match the actual
+    filename here — pre-#68 would emit unresolved=True, this test
+    would fail.
+    """
     sess = tmp_path / "claude-sessions"; sess.mkdir()
-    # After #68, the resolver uses sessions_by_id keyed by session_id, so
-    # the parent filename shape is irrelevant — the test sets up a parent
-    # file with matching session_id in frontmatter, which is what matters.
-    # The explicit hash prefix here preserves the pre-#68 filename scheme
-    # for consistency with the test fixture helpers.
-    import hashlib as _h
     sid = "s4"
-    hash4 = _h.sha256(sid.encode()).hexdigest()[:4]
-    parent_stem = f"2026-04-18-demo-{hash4}"
-    _write_session(sess / f"{parent_stem}.md", session_id=sid)
-    p = sess / f"{parent_stem}-snapshot-110000.md"
+    # Non-hash filename — deliberately does not match the old
+    # (date, slug, sid_hash) composer output.
+    parent_stem = "2026-04-18-demo-parent"
+    (sess / f"{parent_stem}.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-18\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# S\n",
+        encoding="utf-8",
+    )
+    # Snapshot filename also does not need to follow any specific scheme.
+    p = sess / "2026-04-18-demo-snap-110000.md"
     p.write_text(
         f"---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: {sid}\nproject: demo\n"
         "trigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
@@ -94,7 +104,8 @@ def test_missing_backlink_populates_source_session_note(tmp_path):
     issues = snapshot_migration.scan(str(tmp_path), "claude-sessions", "claude-insights", 3650)
     miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
     assert len(miss) == 1
-    assert not miss[0].extra.get("unresolved")  # parent exists
+    assert not miss[0].extra.get("unresolved")  # parent resolved via session_id
+    assert miss[0].extra["parent_stem"] == parent_stem
     snapshot_migration.apply(miss, str(tmp_path / "backup"))
     text = p.read_text(encoding="utf-8")
     assert f'source_session_note: "[[{parent_stem}]]"' in text
@@ -103,11 +114,11 @@ def test_missing_backlink_populates_source_session_note(tmp_path):
 def test_missing_backlink_unresolved_when_parent_absent(tmp_path):
     """Orphan snapshot (no session note matches session_id) -> unresolved.
 
-    Post-#68, the orphan branch emits confidence=0.0 with empty
-    proposed_source — no speculative wikilink fabricated from
-    (date, slug, sid_hash). The assertion set here (len==1 and
-    unresolved=True) holds for both the old and new behavior; this
-    docstring documents the tighter post-fix semantics.
+    Only the first two assertions (len==1, unresolved=True) held under
+    pre-#68 behavior; the three new assertions below (proposed_source=="",
+    confidence==0.0, reason contains "parent session not found") encode
+    tighter post-fix semantics that the old code — which fabricated a
+    speculative wikilink with confidence=0.3 — did not satisfy.
     """
     sess = tmp_path / "claude-sessions"; sess.mkdir()
     p = sess / "2026-04-18-demo-zz-snapshot-110000.md"
@@ -162,7 +173,10 @@ def test_wikilink_rewrite_across_vault_on_rename(tmp_path):
 def test_migration_is_idempotent(tmp_path):
     sess = tmp_path / "claude-sessions"; sess.mkdir()
     _write_legacy_snapshot(sess / "2026-04-18-demo-ee-snapshot.md", session_id="eeee")
-    # Parent stem must match hash of "eeee" since _write_legacy_snapshot hardcodes project="demo"
+    # The hash-based parent stem is vestigial — post-#68 the resolver
+    # matches on session_id in frontmatter, not on filename shape. Any
+    # filename carrying session_id="eeee" in frontmatter would work;
+    # this form preserves the pre-#68 fixture for minimal churn.
     import hashlib as _h
     hash4 = _h.sha256(b"eeee").hexdigest()[:4]
     _write_session(sess / f"2026-04-18-demo-{hash4}.md", session_id="eeee")
@@ -192,6 +206,27 @@ def test_missing_backlink_unresolved_when_sid_missing(tmp_path):
     # Apply should record unresolved status
     results = snapshot_migration.apply(miss, str(tmp_path / "backup"))
     assert results[0].status == "unresolved"
+
+
+def test_missing_backlink_unresolved_when_project_missing(tmp_path):
+    """No project in snapshot frontmatter -> unresolved.
+
+    Covers the second half of the `not sid or not proj` guard (the
+    sid-missing half is covered by test_missing_backlink_unresolved_when_sid_missing).
+    """
+    sess = tmp_path / "claude-sessions"; sess.mkdir()
+    p = sess / "2026-04-18-demo-ff-snapshot-100000.md"
+    p.write_text(
+        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: sid-abc\n"
+        "trigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+    issues = snapshot_migration.scan(str(tmp_path), "claude-sessions", "claude-insights", 3650)
+    miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
+    assert len(miss) == 1
+    assert miss[0].extra.get("unresolved")
+    assert "project" in miss[0].reason
+    assert "session_id" not in miss[0].reason
 
 
 def test_scan_returns_empty_when_sessions_folder_missing(tmp_path):

--- a/tests/test_vault_doctor_snapshot_migration.py
+++ b/tests/test_vault_doctor_snapshot_migration.py
@@ -101,6 +101,14 @@ def test_missing_backlink_populates_source_session_note(tmp_path):
 
 
 def test_missing_backlink_unresolved_when_parent_absent(tmp_path):
+    """Orphan snapshot (no session note matches session_id) -> unresolved.
+
+    Post-#68, the orphan branch emits confidence=0.0 with empty
+    proposed_source — no speculative wikilink fabricated from
+    (date, slug, sid_hash). The assertion set here (len==1 and
+    unresolved=True) holds for both the old and new behavior; this
+    docstring documents the tighter post-fix semantics.
+    """
     sess = tmp_path / "claude-sessions"; sess.mkdir()
     p = sess / "2026-04-18-demo-zz-snapshot-110000.md"
     p.write_text(
@@ -112,6 +120,9 @@ def test_missing_backlink_unresolved_when_parent_absent(tmp_path):
     miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
     assert len(miss) == 1
     assert miss[0].extra.get("unresolved")
+    assert miss[0].proposed_source == ""
+    assert miss[0].confidence == 0.0
+    assert "parent session not found" in miss[0].reason
 
 
 def test_session_missing_snapshots_list_is_backfilled(tmp_path):

--- a/tests/test_vault_doctor_snapshot_migration.py
+++ b/tests/test_vault_doctor_snapshot_migration.py
@@ -75,8 +75,11 @@ def test_missing_status_summarized_when_summary_exists(tmp_path):
 
 def test_missing_backlink_populates_source_session_note(tmp_path):
     sess = tmp_path / "claude-sessions"; sess.mkdir()
-    # Parent filename must match the computed stem: <date>-<slug(project)>-<sha256(sid)[:4]>
-    # For session_id="s4" the hash prefix is computed deterministically.
+    # After #68, the resolver uses sessions_by_id keyed by session_id, so
+    # the parent filename shape is irrelevant — the test sets up a parent
+    # file with matching session_id in frontmatter, which is what matters.
+    # The explicit hash prefix here preserves the pre-#68 filename scheme
+    # for consistency with the test fixture helpers.
     import hashlib as _h
     sid = "s4"
     hash4 = _h.sha256(sid.encode()).hexdigest()[:4]

--- a/tests/test_vault_doctor_snapshot_migration.py
+++ b/tests/test_vault_doctor_snapshot_migration.py
@@ -746,3 +746,44 @@ def test_no_rollback_after_partial_wikilink_rewrite(tmp_path, monkeypatch):
     # Result.note_path points at the surviving (renamed) file so the user
     # can locate it for manual review.
     assert results[0].note_path == str(new_path)
+
+
+def test_missing_backlink_cross_midnight_uses_session_id_index(tmp_path):
+    """Snapshot from before-midnight must backlink to after-midnight parent.
+
+    Regression for #68: §3 previously composed the parent stem from the
+    snapshot's own `date` field, which breaks when PreCompact fires on
+    day N and SessionEnd on day N+1. The parent is now resolved via
+    sessions_by_id keyed by session_id, which is stable across midnight.
+    """
+    import hashlib as _h
+    sess = tmp_path / "claude-sessions"; sess.mkdir()
+    sid = "cross-midnight-sid"
+    hash4 = _h.sha256(sid.encode()).hexdigest()[:4]
+
+    # Parent session — dated the day AFTER the snapshot
+    parent_stem = f"2026-04-10-demo-{hash4}"
+    _write_session(sess / f"{parent_stem}.md", session_id=sid)
+
+    # Snapshot — dated the day BEFORE its parent session (cross-midnight)
+    snap = sess / f"2026-04-09-demo-{hash4}-snapshot-235959.md"
+    snap.write_text(
+        f"---\ntype: claude-snapshot\ndate: 2026-04-09\nsession_id: {sid}\n"
+        "project: demo\ntrigger: compact\nstatus: auto-logged\n---\n\n# Snap\n",
+        encoding="utf-8",
+    )
+
+    issues = snapshot_migration.scan(
+        str(tmp_path), "claude-sessions", "claude-insights", 3650,
+    )
+    miss = [i for i in issues if i.check == "snapshot-missing-backlink"]
+    assert len(miss) == 1
+    assert not miss[0].extra.get("unresolved")
+    assert miss[0].extra["parent_stem"] == parent_stem
+    # Proposal must reference the AFTER-midnight parent, not the snapshot's own date
+    assert f'source_session_note: "[[{parent_stem}]]"' in miss[0].proposed_source
+    assert "2026-04-09-demo-" not in miss[0].proposed_source
+
+    snapshot_migration.apply(miss, str(tmp_path / "backup"))
+    text = snap.read_text(encoding="utf-8")
+    assert f'source_session_note: "[[{parent_stem}]]"' in text

--- a/tests/test_vault_doctor_snapshot_migration.py
+++ b/tests/test_vault_doctor_snapshot_migration.py
@@ -761,9 +761,16 @@ def test_missing_backlink_cross_midnight_uses_session_id_index(tmp_path):
     sid = "cross-midnight-sid"
     hash4 = _h.sha256(sid.encode()).hexdigest()[:4]
 
-    # Parent session — dated the day AFTER the snapshot
+    # Parent session — dated the day AFTER the snapshot. Written inline
+    # (not via _write_session helper) so the frontmatter date matches
+    # the filename date — keeps this cross-midnight fixture internally
+    # consistent and self-documenting.
     parent_stem = f"2026-04-10-demo-{hash4}"
-    _write_session(sess / f"{parent_stem}.md", session_id=sid)
+    (sess / f"{parent_stem}.md").write_text(
+        f"---\ntype: claude-session\ndate: 2026-04-10\nsession_id: {sid}\n"
+        "project: demo\nstatus: summarized\n---\n\n# S\n",
+        encoding="utf-8",
+    )
 
     # Snapshot — dated the day BEFORE its parent session (cross-midnight)
     snap = sess / f"2026-04-09-demo-{hash4}-snapshot-235959.md"


### PR DESCRIPTION
## Summary

- `snapshot-migration` §3 (`snapshot-missing-backlink`) now resolves the parent session note via the `sessions_by_id` index already built in the same scan, instead of composing a filename from `(snapshot.date, project, sha256(session_id)[:4])`.
- Cross-midnight sessions (PreCompact on day N, SessionEnd on day N+1) get correct `source_session_note` wikilinks on first pass — no more need to run `snapshot-integrity` as a cleanup pass for this defect class.
- Orphan snapshots (no session note with matching `session_id`) emit `unresolved=True` with `confidence=0.0` and empty `proposed_source`. The old speculative-wikilink pathway is removed — it never wrote anyway (`unresolved=True` gated `apply()`), so all it did was clutter the report.
- Dead `_short_session_hash` helper and its now-unused `import hashlib` removed from `snapshot_migration.py`.

## Spec

Design and implementation plan live on the companion `abhattacherjee/spec-docs` repo (NOT in this repo, so Copilot should not flag them missing):

- Spec: https://github.com/abhattacherjee/spec-docs/blob/feature/issue-68-snapshot-backlink-cross-midnight/superpowers/specs/2026-04-23-snapshot-migration-cross-midnight-backlink-design.md
- Plan: https://github.com/abhattacherjee/spec-docs/blob/feature/issue-68-snapshot-backlink-cross-midnight/superpowers/plans/2026-04-23-snapshot-migration-cross-midnight-backlink.md

## Test plan

- [x] New regression test `test_missing_backlink_cross_midnight_uses_session_id_index` covers the cross-midnight case end-to-end (scan → apply → assert the written wikilink).
- [x] `test_missing_backlink_unresolved_when_parent_absent` tightened with `confidence=0.0`, empty `proposed_source`, and reason-string assertions.
- [x] Stale comment in `test_missing_backlink_populates_source_session_note` updated to reflect the post-fix resolver.
- [x] Full `pytest tests/test_vault_doctor_snapshot_migration.py` — 32 passed.
- [x] Full `pytest tests/test_vault_doctor*.py` — 100 passed.
- [x] Full pre-commit preflight `./scripts/commit-preflight.sh` — 677 tests pass, secrets clean, version sync OK.
- [x] Manual smoke on seeded throwaway vault: cross-midnight snapshot/session pair → `snapshot_migration.apply()` writes `source_session_note: "[[2026-04-10-demo-aaaa]]"` (after-midnight parent, correct); subsequent `snapshot_integrity.scan()` reports zero `snapshot-broken-backlink` results.

## Follow-ups

- Insight note `claude-insights/2026-04-21-snapshot-migration-cross-midnight-wrong-backlink-3fa6-error.md` will get a `Fixed in #<this-PR>` footer after merge — deferred since PR number is unknown at commit time.

Closes #68.