### PR TITLE
fix(compress): rank-gap delta guard (issue #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `/compress` Step 3.5 rank-gap guard no longer rejects legitimate same-topic peer matches. Replaced the 1.5× ratio test with a delta-score test (`|top.rank| - |#2.rank| > MIN_RANK_DELTA`) that scales with rank magnitude, so multi-phase PRs and iterative features no longer silently duplicate instead of prompting for an update. `MIN_RANK_DELTA` tuned empirically against `scripts/compress_rank_gap_corpus.json`; chosen value lives in `hooks/compress_guard.py`. Closes #45.
 - `/recall` Step 4 N=1 checkoff branch no longer hits `AskUserQuestion` `minItems=2` validation errors. Single candidates now route to the verbatim text fallback; the `2 ≤ N ≤ 4` picker branch gains an explicit "Skip all — don't check off anything" sentinel option so deferral is a visible selectable choice. Closes #78.
 
 ## [2.4.1] - 2026-04-22

--- a/hooks/compress_guard.py
+++ b/hooks/compress_guard.py
@@ -6,9 +6,10 @@ than shelling out through the SKILL.md embedded block.
 
 MIN_RANK_DELTA is empirically tuned against scripts/compress_rank_gap_corpus.json.
 Hard constraint: must be < 4.75 so the issue #45 repro case (top -29.46,
-runner-up -24.71) resolves to match: True. See the spec at
-docs/superpowers/specs/2026-04-23-compress-rank-gap-delta-guard-design.md
-for the full tuning protocol.
+runner-up -24.71) resolves to match: True. The full tuning protocol lives
+in the external spec-docs repository at
+superpowers/specs/2026-04-23-compress-rank-gap-delta-guard-design.md
+(github.com/abhattacherjee/spec-docs).
 """
 
 MIN_RANK_STRENGTH = -5.0  # top result's FTS5 rank must be <= this (stronger = more negative)

--- a/hooks/compress_guard.py
+++ b/hooks/compress_guard.py
@@ -12,7 +12,7 @@ for the full tuning protocol.
 """
 
 MIN_RANK_STRENGTH = -5.0  # top result's FTS5 rank must be <= this (stronger = more negative)
-MIN_RANK_DELTA = 4.0      # placeholder within feasible band; finalized in Task 5 tuning
+MIN_RANK_DELTA = 0.25     # tuned against scripts/compress_rank_gap_corpus.json on 2026-04-23
 
 
 def is_high_confidence_match(results, min_strength=None, min_delta=None):

--- a/hooks/compress_guard.py
+++ b/hooks/compress_guard.py
@@ -1,0 +1,44 @@
+"""Pure predicate for the /compress Step 3.5 high-confidence match filter.
+
+Kept in its own module so the tuning harness (scripts/tune_compress_rank_gap.py)
+and pytest (tests/test_compress_rank_gap.py) can import it directly rather
+than shelling out through the SKILL.md embedded block.
+
+MIN_RANK_DELTA is empirically tuned against scripts/compress_rank_gap_corpus.json.
+Hard constraint: must be < 4.75 so the issue #45 repro case (top -29.46,
+runner-up -24.71) resolves to match: True. See the spec at
+docs/superpowers/specs/2026-04-23-compress-rank-gap-delta-guard-design.md
+for the full tuning protocol.
+"""
+
+MIN_RANK_STRENGTH = -5.0  # top result's FTS5 rank must be <= this (stronger = more negative)
+MIN_RANK_DELTA = 4.0      # placeholder within feasible band; finalized in Task 5 tuning
+
+
+def is_high_confidence_match(results, min_strength=None, min_delta=None):
+    """Return True if the top search result is a high-confidence match.
+
+    Arguments:
+        results: list of dicts with a "rank" field. Callers must pass the
+            list sorted most-negative first (as SKILL.md Step 3.5 does).
+        min_strength: optional override for MIN_RANK_STRENGTH.
+        min_delta: optional override for MIN_RANK_DELTA.
+
+    Returns:
+        bool. True only if (a) results is non-empty, (b) top.rank passes
+        the absolute-strength gate, and (c) either there is no runner-up
+        or the |top.rank| - |runner_up.rank| gap exceeds the delta gate.
+    """
+    if min_strength is None:
+        min_strength = MIN_RANK_STRENGTH
+    if min_delta is None:
+        min_delta = MIN_RANK_DELTA
+
+    if not results:
+        return False
+    top = results[0]
+    if top["rank"] > min_strength:
+        return False
+    if len(results) < 2:
+        return True
+    return (abs(top["rank"]) - abs(results[1]["rank"])) > min_delta

--- a/scripts/compress_rank_gap_corpus.json
+++ b/scripts/compress_rank_gap_corpus.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "created": "2026-04-23",
+  "description": "Tuning corpus for /compress Step 3.5 rank-gap guard (issue #45). Seeded with the original repro case and a wide-gap synthetic; expanded by scripts/tune_compress_rank_gap.py consumers and via replay mining (see spec tuning protocol).",
+  "queries": [
+    {
+      "id": "replay-pr43-snapshot",
+      "query": "PR 43 snapshot dev-test smoke results",
+      "source": "replay",
+      "expected_match": true,
+      "note": "Original issue #45 repro case — top -29.46, runner-up -24.71, delta 4.75. Threshold >= 4.75 fails to fix the bug."
+    },
+    {
+      "id": "synthetic-single-strong",
+      "query": "snapshot summary integration PR 43",
+      "source": "synthetic",
+      "expected_match": true,
+      "note": "Narrow query with a single strong match. Serves as sanity check that the strength gate alone (no runner-up) still admits obvious matches."
+    }
+  ]
+}

--- a/scripts/compress_rank_gap_corpus.json
+++ b/scripts/compress_rank_gap_corpus.json
@@ -16,6 +16,62 @@
       "source": "synthetic",
       "expected_match": true,
       "note": "Narrow query with a single strong match. Serves as sanity check that the strength gate alone (no runner-up) still admits obvious matches."
+    },
+    {
+      "id": "replay-compress-rank-gap-false-negative",
+      "query": "compress rank gap false negative same topic peers",
+      "source": "replay",
+      "expected_match": true,
+      "note": "Replays the /compress invocation that surfaced the issue #45 bug. Vault has exactly one dedicated insight note on this topic (2026-04-18-compress-rank-gap-rejects-same-topic-peers-0cef.md). Wide gap expected."
+    },
+    {
+      "id": "replay-hook-simulation-precompact",
+      "query": "hook simulation pattern precompact sessionend pipe JSON",
+      "source": "replay",
+      "expected_match": true,
+      "note": "Replays /compress on hook simulation pattern. One dedicated note exists (2026-04-18-hook-simulation-pattern-precompact-sessionend-from-r-1f4b.md). Unique topic with expected wide gap."
+    },
+    {
+      "id": "replay-recall-optimization-parallel-haiku",
+      "query": "recall optimization sprint parallel Haiku session performance",
+      "source": "replay",
+      "expected_match": true,
+      "note": "Replays /compress on recall optimization. One primary insight note (2026-04-10-recall-optimization-sprint-243s-to-80s-67-reduct-d75c.md). Strong unique match expected."
+    },
+    {
+      "id": "replay-novel-unique-topic",
+      "query": "some novel unique topic xyz123",
+      "source": "replay",
+      "expected_match": false,
+      "note": "Extracted verbatim from a session /compress invocation. String xyz123 has zero vault matches; any FTS5 result is unrelated noise. Expected: no high-confidence match."
+    },
+    {
+      "id": "synthetic-wide-gap",
+      "query": "SessionEnd hook atomic write temp rename vault note",
+      "source": "synthetic",
+      "expected_match": true,
+      "note": "Wide-gap synthetic. Targets the obsidian-brain atomic-write pattern; one dominant note covers it. Large delta expected (single strong hit)."
+    },
+    {
+      "id": "synthetic-narrow-gap-multi-match",
+      "query": "obsidian-brain security audit path containment hardening vulnerabilities",
+      "source": "synthetic",
+      "expected_match": true,
+      "note": "Narrow-gap multi-match synthetic. Security hardening topic has ~14 notes; top 2 should be close in rank. Tests whether the guard correctly allows the strongest match through despite multiple nearby results."
+    },
+    {
+      "id": "synthetic-three-close-results",
+      "query": "vault search FTS5 sqlite index recall ranking score",
+      "source": "synthetic",
+      "expected_match": true,
+      "note": "Three-close-results synthetic. FTS5/vault-index topic has ~43 notes; top 3 results likely cluster closely. Tests the guard at the three-peer boundary."
+    },
+    {
+      "id": "synthetic-off-topic-outrank",
+      "query": "fix the code check it",
+      "source": "synthetic",
+      "expected_match": false,
+      "note": "Off-topic outrank synthetic. Generic phrase designed to surface unrelated or low-rank results. No genuine match expected; strength gate or delta gate should reject."
     }
   ]
 }

--- a/scripts/tune_compress_rank_gap.py
+++ b/scripts/tune_compress_rank_gap.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Tuning harness for /compress Step 3.5 rank-gap delta guard.
+
+Reads scripts/compress_rank_gap_corpus.json, runs each query against the
+live vault index using the same search_vault() path as /compress SKILL.md
+Step 3.5, and prints a markdown table showing true-positive / false-
+positive / false-negative counts at each candidate MIN_RANK_DELTA value.
+
+Usage:
+    python3 scripts/tune_compress_rank_gap.py
+
+No arguments. Reads vault_path from ~/.claude/obsidian-brain-config.json
+and the corpus from scripts/compress_rank_gap_corpus.json (relative to
+repo root).
+
+Exit codes: always 0. This is a reporting tool, not a CI gate.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+# Path bootstrap: add hooks/ so we can import the plugin's modules
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HOOKS_DIR = REPO_ROOT / "hooks"
+sys.path.insert(0, str(HOOKS_DIR))
+
+from compress_guard import is_high_confidence_match  # noqa: E402
+from obsidian_utils import load_config  # noqa: E402
+from vault_index import ensure_index, search_vault  # noqa: E402
+
+
+THRESHOLD_GRID = [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0]
+CORPUS_PATH = REPO_ROOT / "scripts" / "compress_rank_gap_corpus.json"
+
+
+def _run_query(db, query):
+    """Run the same search that SKILL.md Step 3.5 runs. Returns sorted results."""
+    results = search_vault(db, query, note_type="claude-insight", limit=3)
+    results += search_vault(db, query, note_type="claude-decision", limit=3)
+    results.sort(key=lambda r: r["rank"])
+    return results
+
+
+def _score_corpus(corpus_entries, results_by_id, min_delta):
+    """Score the corpus at a given MIN_RANK_DELTA threshold."""
+    tp = tn = fp = fn = skipped = 0
+    for entry in corpus_entries:
+        results = results_by_id.get(entry["id"])
+        if not results:
+            skipped += 1
+            continue
+        predicted = is_high_confidence_match(results, min_delta=min_delta)
+        expected = entry["expected_match"]
+        if predicted and expected:
+            tp += 1
+        elif predicted and not expected:
+            fp += 1
+        elif not predicted and expected:
+            fn += 1
+        else:
+            tn += 1
+    return {"tp": tp, "tn": tn, "fp": fp, "fn": fn, "skipped": skipped}
+
+
+def main():
+    # Resolve vault path
+    try:
+        config = load_config()
+    except Exception as exc:
+        print(f"Could not load ~/.claude/obsidian-brain-config.json: {exc}")
+        print("Run /obsidian-setup first.")
+        return 0
+    vault_path = config.get("vault_path")
+    if not vault_path or not os.path.isdir(vault_path):
+        print(f"Config vault_path missing or invalid: {vault_path!r}")
+        return 0
+
+    # Load corpus
+    if not CORPUS_PATH.exists():
+        print(f"Corpus not found: {CORPUS_PATH}")
+        return 0
+    with open(CORPUS_PATH, "r", encoding="utf-8") as fh:
+        corpus = json.load(fh)
+    entries = corpus.get("queries", [])
+    if not entries:
+        print("Corpus is empty. Add queries to scripts/compress_rank_gap_corpus.json.")
+        return 0
+
+    # Open the vault index
+    folders = [
+        config.get("sessions_folder", "claude-sessions"),
+        config.get("insights_folder", "claude-insights"),
+    ]
+    db = ensure_index(vault_path, folders)
+
+    # Run each query once, cache results
+    print(f"# Tuning sweep — {len(entries)} queries against {vault_path}\n")
+    print("## Per-query results\n")
+    print("| id | query | top rank | #2 rank | delta | expected |")
+    print("|---|---|---|---|---|---|")
+    results_by_id = {}
+    for entry in entries:
+        results = _run_query(db, entry["query"])
+        results_by_id[entry["id"]] = results
+        if not results:
+            print(f"| {entry['id']} | `{entry['query']}` | — | — | — | {entry['expected_match']} (SKIPPED: no results) |")
+            continue
+        top_rank = results[0]["rank"]
+        if len(results) >= 2:
+            second_rank = results[1]["rank"]
+            delta = abs(top_rank) - abs(second_rank)
+            print(f"| {entry['id']} | `{entry['query']}` | {top_rank:.2f} | {second_rank:.2f} | {delta:.2f} | {entry['expected_match']} |")
+        else:
+            print(f"| {entry['id']} | `{entry['query']}` | {top_rank:.2f} | — | — | {entry['expected_match']} |")
+
+    # Sweep thresholds
+    print("\n## Threshold sweep\n")
+    print("| MIN_RANK_DELTA | TP | TN | FP | FN | score (TP+TN)/total | repro #45 |")
+    print("|---|---|---|---|---|---|---|")
+    repro_results = results_by_id.get("replay-pr43-snapshot", [])
+    for t in THRESHOLD_GRID:
+        score = _score_corpus(entries, results_by_id, min_delta=t)
+        total = score["tp"] + score["tn"] + score["fp"] + score["fn"]
+        if total == 0:
+            ratio = float("nan")
+        else:
+            ratio = (score["tp"] + score["tn"]) / total
+        if repro_results:
+            repro_pass = is_high_confidence_match(repro_results, min_delta=t)
+        else:
+            repro_pass = "skipped"
+        print(
+            f"| {t:.1f} | {score['tp']} | {score['tn']} | {score['fp']} | {score['fn']} | "
+            f"{ratio:.2f} | {repro_pass} |"
+        )
+
+    print("\n## Selection guidance\n")
+    print("- Hard constraint: MIN_RANK_DELTA must be < 4.75 so the issue #45")
+    print("  repro case resolves True (see spec).")
+    print("- Pick the feasible threshold with the best (TP+TN)/total score.")
+    print("- Ties broken toward lower thresholds (more permissive = fewer")
+    print("  silent duplicates; users can always decline the update prompt).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tune_compress_rank_gap.py
+++ b/scripts/tune_compress_rank_gap.py
@@ -31,7 +31,7 @@ from obsidian_utils import load_config  # noqa: E402
 from vault_index import ensure_index, search_vault  # noqa: E402
 
 
-THRESHOLD_GRID = [2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0]
+THRESHOLD_GRID = [0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 10.0]
 CORPUS_PATH = REPO_ROOT / "scripts" / "compress_rank_gap_corpus.json"
 
 

--- a/scripts/tune_compress_rank_gap.py
+++ b/scripts/tune_compress_rank_gap.py
@@ -132,7 +132,7 @@ def main():
         else:
             repro_pass = "skipped"
         print(
-            f"| {t:.1f} | {score['tp']} | {score['tn']} | {score['fp']} | {score['fn']} | "
+            f"| {t:.2f} | {score['tp']} | {score['tn']} | {score['fp']} | {score['fn']} | "
             f"{ratio:.2f} | {repro_pass} |"
         )
 

--- a/scripts/tune_compress_rank_gap.py
+++ b/scripts/tune_compress_rank_gap.py
@@ -115,10 +115,17 @@ def main():
         else:
             print(f"| {entry['id']} | `{entry['query']}` | {top_rank:.2f} | — | — | {entry['expected_match']} |")
 
+    # All-empty diagnostic (before sweep so the user sees it)
+    total_skipped = sum(1 for r in results_by_id.values() if not r)
+    if total_skipped == len(entries):
+        print("\nWARN: All corpus queries returned no results from the vault.")
+        print("      Check that vault_path is correct and the index is populated.")
+        print("      Run /vault-reindex if the index needs a rebuild.\n")
+
     # Sweep thresholds
     print("\n## Threshold sweep\n")
-    print("| MIN_RANK_DELTA | TP | TN | FP | FN | score (TP+TN)/total | repro #45 |")
-    print("|---|---|---|---|---|---|---|")
+    print("| MIN_RANK_DELTA | TP | TN | FP | FN | skipped | score (TP+TN)/total | repro #45 |")
+    print("|---|---|---|---|---|---|---|---|")
     repro_results = results_by_id.get("replay-pr43-snapshot", [])
     for t in THRESHOLD_GRID:
         score = _score_corpus(entries, results_by_id, min_delta=t)
@@ -133,7 +140,7 @@ def main():
             repro_pass = "skipped"
         print(
             f"| {t:.2f} | {score['tp']} | {score['tn']} | {score['fp']} | {score['fn']} | "
-            f"{ratio:.2f} | {repro_pass} |"
+            f"{score['skipped']} | {ratio:.2f} | {repro_pass} |"
         )
 
     print("\n## Selection guidance\n")

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -75,6 +75,9 @@ import sys, os, json
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
 from vault_index import ensure_index, search_vault
 from obsidian_utils import load_config
+# Pure predicate: top rank must pass absolute-strength gate AND |top|-|#2| delta gate.
+# MIN_RANK_DELTA tuned against scripts/compress_rank_gap_corpus.json (issue #45).
+from compress_guard import is_high_confidence_match
 try:
     c = load_config()
     vp = c["vault_path"]
@@ -84,15 +87,9 @@ try:
     results += search_vault(db, sys.argv[1], note_type="claude-decision", limit=3)
     # Sort combined results by rank (most negative = best match)
     results.sort(key=lambda r: r["rank"])
-    # Apply high-confidence threshold: top result must have rank <= -5.0
-    # AND must be significantly ahead of #2 (at least 1.5x better rank)
-    if results:
+    if is_high_confidence_match(results):
         top = results[0]
-        rank_gap_ok = len(results) < 2 or abs(top["rank"]) > abs(results[1]["rank"]) * 1.5
-        if top["rank"] <= -5.0 and rank_gap_ok:
-            print(json.dumps({"match": True, "path": top["path"], "title": top["title"], "date": top["date"], "tags": top["tags"], "rank": top["rank"]}))
-        else:
-            print(json.dumps({"match": False}))
+        print(json.dumps({"match": True, "path": top["path"], "title": top["title"], "date": top["date"], "tags": top["tags"], "rank": top["rank"]}))
     else:
         print(json.dumps({"match": False}))
 except Exception as e:

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -73,12 +73,12 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
 import sys, os, json
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from vault_index import ensure_index, search_vault
-from obsidian_utils import load_config
-# Pure predicate: top rank must pass absolute-strength gate AND |top|-|#2| delta gate.
-# MIN_RANK_DELTA tuned against scripts/compress_rank_gap_corpus.json (issue #45).
-from compress_guard import is_high_confidence_match
 try:
+    from vault_index import ensure_index, search_vault
+    from obsidian_utils import load_config
+    # Pure predicate: top rank must pass absolute-strength gate AND |top|-|#2| delta gate.
+    # MIN_RANK_DELTA tuned against scripts/compress_rank_gap_corpus.json (issue #45).
+    from compress_guard import is_high_confidence_match
     c = load_config()
     vp = c["vault_path"]
     folders = [c.get("sessions_folder", "claude-sessions"), c.get("insights_folder", "claude-insights")]
@@ -92,6 +92,9 @@ try:
         print(json.dumps({"match": True, "path": top["path"], "title": top["title"], "date": top["date"], "tags": top["tags"], "rank": top["rank"]}))
     else:
         print(json.dumps({"match": False}))
+except ImportError as e:
+    print(f"Warning: plugin module missing ({e}) — run /dev-test install to apply the rank-gap fix", file=sys.stderr)
+    print(json.dumps({"match": False}))
 except Exception as e:
     print(f"Warning: could not search vault index: {e}", file=sys.stderr)
     print(json.dumps({"match": False}))

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -93,7 +93,7 @@ try:
     else:
         print(json.dumps({"match": False}))
 except ImportError as e:
-    print(f"Warning: plugin module missing ({e}) — run /dev-test install to apply the rank-gap fix", file=sys.stderr)
+    print(f"Warning: plugin hooks are out of date or missing ({e}) — run /dev-test install", file=sys.stderr)
     print(json.dumps({"match": False}))
 except Exception as e:
     print(f"Warning: could not search vault index: {e}", file=sys.stderr)

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -65,11 +65,12 @@ def test_issue_45_repro_case():
 
 
 def test_weak_top_rank_rejects():
-    # Top rank -3 fails the strength gate. The second element is also weak,
-    # so the list is properly sorted most-negative first. The strength gate
-    # fires before the delta gate is evaluated — no strong #2 is needed to
-    # prove the point.
-    results = [{"rank": -3.0}, {"rank": -4.0}]
+    # List is sorted most-negative first (predicate's documented contract):
+    # -4.0 is the "top" at index 0, -3.0 is the runner-up at index 1. Top
+    # rank -4 still fails the strength gate (-4 > -5). The strength gate
+    # fires before the delta gate is evaluated — no strong #2 is needed
+    # to prove the point.
+    results = [{"rank": -4.0}, {"rank": -3.0}]
     assert is_high_confidence_match(results) is False
 
 

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -1,0 +1,85 @@
+"""Tests for hooks/compress_guard.py — /compress Step 3.5 rank-gap predicate.
+
+Covers boundary cases for `is_high_confidence_match()`, the pure predicate
+extracted from /compress SKILL.md Step 3.5. The helper is imported
+directly — no FTS5 fixture needed since the predicate takes a pre-sorted
+results list.
+"""
+
+import pytest
+
+from compress_guard import (
+    MIN_RANK_DELTA,
+    MIN_RANK_STRENGTH,
+    is_high_confidence_match,
+)
+
+
+def test_empty_results_rejects():
+    assert is_high_confidence_match([]) is False
+
+
+def test_single_result_matches_when_rank_strong():
+    # rank -10 is stronger than min_strength -5.0
+    assert is_high_confidence_match([{"rank": -10.0}]) is True
+
+
+def test_single_result_rejects_when_rank_weak():
+    # rank -3 is weaker than min_strength -5.0
+    assert is_high_confidence_match([{"rank": -3.0}]) is False
+
+
+def test_delta_above_threshold_matches():
+    # delta = |−29| − |−20| = 9, above default MIN_RANK_DELTA
+    results = [{"rank": -29.0}, {"rank": -20.0}]
+    assert is_high_confidence_match(results) is True
+
+
+def test_delta_below_threshold_rejects():
+    # delta = |−29| − |−26| = 3, below default MIN_RANK_DELTA
+    results = [{"rank": -29.0}, {"rank": -26.0}]
+    assert is_high_confidence_match(results) is False
+
+
+def test_issue_45_repro_case():
+    """Executable form of the issue #45 bug definition.
+
+    Real ranks from the vault: top -29.46, runner-up -24.71, delta 4.75.
+    Must resolve True under the shipped MIN_RANK_DELTA — a failing
+    assertion here means the fix did not land. The shipped constant
+    must be strictly less than 4.75.
+    """
+    results = [{"rank": -29.46}, {"rank": -24.71}]
+    assert is_high_confidence_match(results) is True
+
+
+def test_weak_top_rank_rejects_even_with_large_delta():
+    # Top rank -3 fails strength gate despite enormous delta to -30
+    results = [{"rank": -3.0}, {"rank": -30.0}]
+    assert is_high_confidence_match(results) is False
+
+
+def test_custom_thresholds_respected():
+    # Default accepts (rank -8 <= -5), custom min_strength=-10 rejects
+    results = [{"rank": -8.0}, {"rank": -6.0}]
+    assert is_high_confidence_match(results) is True
+    assert (
+        is_high_confidence_match(results, min_strength=-10.0, min_delta=1.0)
+        is False
+    )
+    # Default rejects (delta 2 < 5), custom min_delta=1 accepts
+    results2 = [{"rank": -8.0}, {"rank": -6.0}]
+    assert is_high_confidence_match(results2) is False
+    assert (
+        is_high_confidence_match(results2, min_delta=1.0) is True
+    )
+
+
+def test_constants_are_exposed():
+    # Import-level contract: callers can reference the defaults.
+    assert isinstance(MIN_RANK_STRENGTH, float)
+    assert isinstance(MIN_RANK_DELTA, float)
+    assert MIN_RANK_STRENGTH <= 0.0
+    assert MIN_RANK_DELTA > 0.0
+    # Hard constraint from issue #45 — fix is not complete without this.
+    assert MIN_RANK_DELTA < 4.75

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -36,8 +36,8 @@ def test_delta_above_threshold_matches():
 
 
 def test_delta_below_threshold_rejects():
-    # delta = |−29| − |−26| = 3, below default MIN_RANK_DELTA
-    results = [{"rank": -29.0}, {"rank": -26.0}]
+    # delta = |−29| − |−28.9| = 0.1, below any viable MIN_RANK_DELTA regardless of tuning
+    results = [{"rank": -29.0}, {"rank": -28.9}]
     assert is_high_confidence_match(results) is False
 
 
@@ -64,14 +64,14 @@ def test_delta_at_threshold_boundary_rejects():
 
     Predicate uses `delta > min_delta`, not `>=`. This test locks that
     semantic so a future tuning change to a different MIN_RANK_DELTA
-    value (say, 3.0) still correctly rejects the at-threshold case.
+    value still correctly rejects the at-threshold case.
     Guards against an off-by-one drift toward `>=`.
     """
-    # delta = |−29| − |−25| = 4.0, exactly equals default MIN_RANK_DELTA (4.0) → reject
-    results = [{"rank": -29.0}, {"rank": -25.0}]
+    # delta = |−29| − |−28.75| = 0.25, exactly equals default MIN_RANK_DELTA (0.25) → reject
+    results = [{"rank": -29.0}, {"rank": -28.75}]
     assert is_high_confidence_match(results) is False
-    # With a custom min_delta=3.0, same input has delta 4.0 > 3.0 → accept
-    assert is_high_confidence_match(results, min_delta=3.0) is True
+    # With a custom min_delta=0.15, same input has delta 0.25 > 0.15 → accept
+    assert is_high_confidence_match(results, min_delta=0.15) is True
 
 
 def test_custom_thresholds_respected():
@@ -83,11 +83,11 @@ def test_custom_thresholds_respected():
     )  # -8 > -10 fails custom strength gate
 
     # Sub-test 2: delta gate (two results; strength gate passes for both calls)
-    results_pair = [{"rank": -8.0}, {"rank": -6.0}]
-    assert is_high_confidence_match(results_pair) is False  # delta 2 below default
+    results_pair = [{"rank": -8.0}, {"rank": -7.9}]
+    assert is_high_confidence_match(results_pair) is False  # delta 0.1 below default 0.25
     assert (
-        is_high_confidence_match(results_pair, min_delta=1.0) is True
-    )  # delta 2 above custom min_delta=1
+        is_high_confidence_match(results_pair, min_delta=0.05) is True
+    )  # delta 0.1 above custom min_delta=0.05
 
 
 def test_constants_are_exposed():

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -6,8 +6,6 @@ directly — no FTS5 fixture needed since the predicate takes a pre-sorted
 results list.
 """
 
-import pytest
-
 from compress_guard import (
     MIN_RANK_DELTA,
     MIN_RANK_STRENGTH,

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -19,6 +19,17 @@ def test_empty_results_rejects():
     assert is_high_confidence_match([]) is False
 
 
+def test_equal_ranks_rejects():
+    """Delta = 0 when top and runner-up have identical ranks.
+
+    FTS5 can produce identical rank values for near-identical notes. The
+    strict-> delta gate rejects (0 is never > any positive MIN_RANK_DELTA),
+    so the guard correctly asks the user to choose rather than auto-picking.
+    """
+    results = [{"rank": -10.0}, {"rank": -10.0}]
+    assert is_high_confidence_match(results) is False
+
+
 def test_single_result_matches_when_rank_strong():
     # rank -10 is stronger than min_strength -5.0
     assert is_high_confidence_match([{"rank": -10.0}]) is True
@@ -55,9 +66,12 @@ def test_issue_45_repro_case():
     assert is_high_confidence_match(results) is True
 
 
-def test_weak_top_rank_rejects_even_with_large_delta():
-    # Top rank -3 fails strength gate despite enormous delta to -30
-    results = [{"rank": -3.0}, {"rank": -30.0}]
+def test_weak_top_rank_rejects():
+    # Top rank -3 fails the strength gate. The second element is also weak,
+    # so the list is properly sorted most-negative first. The strength gate
+    # fires before the delta gate is evaluated — no strong #2 is needed to
+    # prove the point.
+    results = [{"rank": -3.0}, {"rank": -4.0}]
     assert is_high_confidence_match(results) is False
 
 

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -69,7 +69,10 @@ def test_delta_at_threshold_boundary_rejects():
     value still correctly rejects the at-threshold case.
     Guards against an off-by-one drift toward `>=`.
     """
-    # delta = |−29| − |−28.75| = 0.25, exactly equals default MIN_RANK_DELTA (0.25) → reject
+    # delta = |−29| − |−28.75| = 0.25, exactly equals default MIN_RANK_DELTA (0.25) → reject.
+    # Input values are multiples of 0.25, so they're exact binary fractions (no IEEE 754
+    # rounding); this makes the at-threshold equality check reliable. Future boundary tests
+    # should pick similarly-exact inputs rather than (say) 0.1, which is not exactly representable.
     results = [{"rank": -29.0}, {"rank": -28.75}]
     assert is_high_confidence_match(results) is False
     # With a custom min_delta=0.15, same input has delta 0.25 > 0.15 → accept

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -21,7 +21,7 @@ def test_equal_ranks_rejects():
     """Delta = 0 when top and runner-up have identical ranks.
 
     FTS5 can produce identical rank values for near-identical notes. The
-    strict-> delta gate rejects (0 is never > any positive MIN_RANK_DELTA),
+    strict '>' delta gate rejects (0 is never > any positive MIN_RANK_DELTA),
     so the guard correctly asks the user to choose rather than auto-picking.
     """
     results = [{"rank": -10.0}, {"rank": -10.0}]

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -60,19 +60,19 @@ def test_weak_top_rank_rejects_even_with_large_delta():
 
 
 def test_custom_thresholds_respected():
-    # Default accepts (rank -8 <= -5), custom min_strength=-10 rejects
-    results = [{"rank": -8.0}, {"rank": -6.0}]
-    assert is_high_confidence_match(results) is True
+    # Sub-test 1: strength gate only (single result, delta gate bypassed)
+    results_single = [{"rank": -8.0}]
+    assert is_high_confidence_match(results_single) is True  # -8 <= default -5.0
     assert (
-        is_high_confidence_match(results, min_strength=-10.0, min_delta=1.0)
-        is False
-    )
-    # Default rejects (delta 2 < 5), custom min_delta=1 accepts
-    results2 = [{"rank": -8.0}, {"rank": -6.0}]
-    assert is_high_confidence_match(results2) is False
+        is_high_confidence_match(results_single, min_strength=-10.0) is False
+    )  # -8 > -10 fails custom strength gate
+
+    # Sub-test 2: delta gate (two results; strength gate passes for both calls)
+    results_pair = [{"rank": -8.0}, {"rank": -6.0}]
+    assert is_high_confidence_match(results_pair) is False  # delta 2 below default
     assert (
-        is_high_confidence_match(results2, min_delta=1.0) is True
-    )
+        is_high_confidence_match(results_pair, min_delta=1.0) is True
+    )  # delta 2 above custom min_delta=1
 
 
 def test_constants_are_exposed():

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -59,6 +59,21 @@ def test_weak_top_rank_rejects_even_with_large_delta():
     assert is_high_confidence_match(results) is False
 
 
+def test_delta_at_threshold_boundary_rejects():
+    """Strict > comparison: delta exactly at threshold must reject.
+
+    Predicate uses `delta > min_delta`, not `>=`. This test locks that
+    semantic so a future tuning change to a different MIN_RANK_DELTA
+    value (say, 3.0) still correctly rejects the at-threshold case.
+    Guards against an off-by-one drift toward `>=`.
+    """
+    # delta = |−29| − |−25| = 4.0, exactly equals default MIN_RANK_DELTA (4.0) → reject
+    results = [{"rank": -29.0}, {"rank": -25.0}]
+    assert is_high_confidence_match(results) is False
+    # With a custom min_delta=3.0, same input has delta 4.0 > 3.0 → accept
+    assert is_high_confidence_match(results, min_delta=3.0) is True
+
+
 def test_custom_thresholds_respected():
     # Sub-test 1: strength gate only (single result, delta gate bypassed)
     results_single = [{"rank": -8.0}]

--- a/tests/test_compress_rank_gap.py
+++ b/tests/test_compress_rank_gap.py
@@ -36,7 +36,9 @@ def test_delta_above_threshold_matches():
 
 
 def test_delta_below_threshold_rejects():
-    # delta = |−29| − |−28.9| = 0.1, below any viable MIN_RANK_DELTA regardless of tuning
+    # delta ≈ 0.1 (|-29| - |-28.9| = 0.1000...142 due to IEEE 754);
+    # below the current THRESHOLD_GRID minimum of 0.25, so this case
+    # rejects at every grid-selectable MIN_RANK_DELTA.
     results = [{"rank": -29.0}, {"rank": -28.9}]
     assert is_high_confidence_match(results) is False
 


### PR DESCRIPTION
## Summary

- Replaces the 1.5× ratio guard in `/compress` Step 3.5 with a delta-score guard (`|top.rank| - |#2.rank| > MIN_RANK_DELTA`), so genuine same-topic peer matches are no longer silently rejected as duplicates.
- Extracts the predicate into `hooks/compress_guard.py` so pytest and the tuning harness can import it directly.
- Ships a re-runnable tuning harness (`scripts/tune_compress_rank_gap.py`) + committed corpus (`scripts/compress_rank_gap_corpus.json`) so the threshold is auditable and re-tunable.

**Spec:** [github.com/abhattacherjee/spec-docs/.../2026-04-23-compress-rank-gap-delta-guard-design.md](https://github.com/abhattacherjee/spec-docs/blob/feature/issue-45-compress-rank-gap-peers/superpowers/specs/2026-04-23-compress-rank-gap-delta-guard-design.md)
**Plan:** [github.com/abhattacherjee/spec-docs/.../2026-04-23-compress-rank-gap-delta-guard-plan.md](https://github.com/abhattacherjee/spec-docs/blob/feature/issue-45-compress-rank-gap-peers/superpowers/plans/2026-04-23-compress-rank-gap-delta-guard-plan.md)

Closes #45.

## Empirical tuning

Ran the harness against the live vault. Found that vault growth since issue capture has compressed FTS5 rank deltas: the original issue's replay query (delta 4.75 at capture) now produces delta 0.78. The spec's stated feasible band (`[2.0, 4.5]`) no longer contains any threshold that fixes the bug against the live vault.

The spec's halt-and-revisit rule was triggered and followed. The tuning grid was extended downward and the spec's tuning protocol was updated (see `cbb7f2d` in the spec-docs repo). Shipped value: **`MIN_RANK_DELTA = 0.25`** (best feasible-band score 0.80).

### Tuning table

# Tuning sweep — 10 queries against /Users/abhishek/obsidian/claude-code-vault

## Per-query results

| id | query | top rank | #2 rank | delta | expected |
|---|---|---|---|---|---|
| replay-pr43-snapshot | `PR 43 snapshot dev-test smoke results` | -25.77 | -24.99 | 0.78 | True |
| synthetic-single-strong | `snapshot summary integration PR 43` | -15.48 | -14.99 | 0.49 | True |
| replay-compress-rank-gap-false-negative | `compress rank gap false negative same topic peers` | -44.68 | -15.67 | 29.01 | True |
| replay-hook-simulation-precompact | `hook simulation pattern precompact sessionend pipe JSON` | -40.64 | -11.19 | 29.44 | True |
| replay-recall-optimization-parallel-haiku | `recall optimization sprint parallel Haiku session performance` | -27.69 | -15.68 | 12.01 | True |
| replay-novel-unique-topic | `some novel unique topic xyz123` | -9.91 | -7.95 | 1.96 | False |
| synthetic-wide-gap | `SessionEnd hook atomic write temp rename vault note` | -22.26 | -20.17 | 2.09 | True |
| synthetic-narrow-gap-multi-match | `obsidian-brain security audit path containment hardening vulnerabilities` | -37.67 | -25.44 | 12.24 | True |
| synthetic-three-close-results | `vault search FTS5 sqlite index recall ranking score` | -33.34 | -31.08 | 2.26 | True |
| synthetic-off-topic-outrank | `fix the code check it` | -13.19 | -11.44 | 1.75 | False |

## Threshold sweep

| MIN_RANK_DELTA | TP | TN | FP | FN | score (TP+TN)/total | repro #45 |
|---|---|---|---|---|---|---|
| 0.25 | 8 | 0 | 2 | 0 | 0.80 | True |
| 0.50 | 7 | 0 | 2 | 1 | 0.70 | True |
| 0.75 | 7 | 0 | 2 | 1 | 0.70 | True |
| 1.00 | 6 | 0 | 2 | 2 | 0.60 | False |
| 1.50 | 6 | 0 | 2 | 2 | 0.60 | False |
| 2.00 | 6 | 2 | 0 | 2 | 0.80 | False |
| 3.00 | 4 | 2 | 0 | 4 | 0.60 | False |
| 4.00 | 4 | 2 | 0 | 4 | 0.60 | False |
| 5.00 | 4 | 2 | 0 | 4 | 0.60 | False |
| 6.00 | 4 | 2 | 0 | 4 | 0.60 | False |
| 7.00 | 4 | 2 | 0 | 4 | 0.60 | False |
| 8.00 | 4 | 2 | 0 | 4 | 0.60 | False |
| 10.00 | 4 | 2 | 0 | 4 | 0.60 | False |

## Selection guidance

- Hard constraint: MIN_RANK_DELTA must be < 4.75 so the issue #45
  repro case resolves True (see spec).
- Pick the feasible threshold with the best (TP+TN)/total score.
- Ties broken toward lower thresholds (more permissive = fewer
  silent duplicates; users can always decline the update prompt).

At the chosen threshold (0.25), 2 FPs remain (`replay-novel-unique-topic`, `synthetic-off-topic-outrank`). Both exemplify the off-topic-outrank failure mode explicitly listed as non-goal #2 in the spec — a user sees a wrong "update this note?" prompt and declines. Preferable to silent duplication (the issue #45 failure mode). A follow-up to address the outrank mode is already scoped in the spec's "Out of scope / follow-ups" section.

## Known pre-release gap

The installed plugin cache at `~/.claude/plugins/cache/.../obsidian-brain/2.4.1/hooks/` does not yet contain `hooks/compress_guard.py`. Until the next release ships:

- `/dev-test install` from this branch is the correct path for live smoke testing. The install script copies `hooks/*.py` so `compress_guard.py` lands in the cache.
- A live `/compress <topic>` invocation *without* `/dev-test install` will hit an `ImportError` which is now caught by a dedicated handler (see commit for this PR fixing the import-placement bug). The user-facing outcome is the same silent `{"match": false}` fallback, but stderr now shows an actionable message pointing at `/dev-test install`.

This matches spec Risk #3 (helper-import-from-SKILL.md risk class). Documented here for transparency.

## Test plan

- [x] `pytest tests/test_compress_rank_gap.py -v` → **11 passed** (boundary cases + repro lock + equal-ranks corner case + constant invariant)
- [x] `pytest tests/ -x` → **687 passed** (no regressions)
- [x] Direct Python smoke test with the issue #45 repro topic (`PR 43 snapshot dev-test smoke results`) returns `{"match": true, "path": .../2026-04-18-pr-43-snapshot-summary-dev-test-automated-baseli-e465.md, "rank": -25.64}` — the correct existing note
- [ ] Post-merge: one `/compress "PR 43 snapshot dev-test smoke results"` from a live session (after release) to confirm the update prompt surfaces

## Non-goals

- The absolute-strength threshold (`top.rank <= -5.0`) is unchanged.
- The off-topic-outranking false-negative (tracked as `feedback_compress_search_false_negative.md`) remains operator-side for now.
- No dev-test merge gate applies — this PR touches SKILL.md + a new library module, not hook lifecycle files. Memory rule `feedback_devtest_merge_gate` scopes that gate to hook-adjacent PRs.