### PR TITLE
fix(vault-doctor): source-sessions capture-time uses immutable signals (issue #93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - E2E integration test for snapshot → summarize → /recall pipeline (`tests/test_snapshot_e2e.py`). Closes #50.
+- **`created_at:` ISO-8601 frontmatter** is now written by `error-log`,
+  `decide`, `retro`, and `compress` (new-note flow) for sub-day-precision
+  capture-time matching by vault-doctor. Net-additive — older notes continue
+  to fall back to `date:` (day precision).
 
 ### Fixed
+- **vault-doctor source-sessions silently corrupted backlinks** when a note's
+  mtime drifted past the originating session's JSONL window (any later edit
+  by `/check-items`, `/link`, `/compress`, sync clients, or another vault-doctor
+  check). The check now uses an immutable signal chain
+  (`created_at` → `date` → filename prefix → mtime) for capture-time matching,
+  and trusts an existing `source_session` whose JSONL window overlaps the
+  note's calendar day. Issue payloads surface `capture_signal` and
+  `capture_confidence` so operators can spot heuristic falls. Closes #93.
 - `/compress` Step 3.5 rank-gap guard no longer rejects legitimate same-topic peer matches. Replaced the 1.5× ratio test with a delta-score test (`|top.rank| - |#2.rank| > MIN_RANK_DELTA`) that scales with rank magnitude, so multi-phase PRs and iterative features no longer silently duplicate instead of prompting for an update. `MIN_RANK_DELTA` tuned empirically against `scripts/compress_rank_gap_corpus.json`; chosen value lives in `hooks/compress_guard.py`. Closes #45.
 - `/recall` Step 4 N=1 checkoff branch no longer hits `AskUserQuestion` `minItems=2` validation errors. Single candidates now route to the verbatim text fallback; the `2 ≤ N ≤ 4` picker branch gains an explicit "Skip all — don't check off anything" sentinel option so deferral is a visible selectable choice. Closes #78.
 - `vault-doctor` `snapshot-migration` §3 (`snapshot-missing-backlink`) now resolves the parent session note via the `session_id` index built in the same scan, instead of composing a filename from `(snapshot.date, project, sha256(session_id)[:4])`. The old date-heuristic wrote wrong `source_session_note` wikilinks for cross-midnight sessions (PreCompact on day N, SessionEnd on day N+1). Orphan snapshots now emit `unresolved=True` with no speculative wikilink. Closes #68.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and trusts an existing `source_session` whose JSONL window overlaps the
   note's calendar day. Issue payloads surface `capture_signal` and
   `capture_confidence` so operators can spot heuristic falls. Closes #93.
+- **vault-doctor source-sessions multi-session-day convergence**: when a
+  worktree-launched insight records `project: <main>` but its source
+  session has `project: <main>--<worktree-slug>`, the UUID lookup
+  previously failed and the matcher converged every flagged note onto
+  whatever session's window contained noon-UTC. Now uses cross-project
+  UUID indexing (Phase 1b looks up UUIDs across all projects, not just
+  the note's declared project), basename-only repair when UUID resolves
+  but the stored basename is stale, capped confidence (≤ 0.6) on
+  date-only signals, and convergence-guard tagging when ≥2 flags in a
+  project target the same proposed session (confidence further capped to
+  ≤ 0.4).
 - `/compress` Step 3.5 rank-gap guard no longer rejects legitimate same-topic peer matches. Replaced the 1.5× ratio test with a delta-score test (`|top.rank| - |#2.rank| > MIN_RANK_DELTA`) that scales with rank magnitude, so multi-phase PRs and iterative features no longer silently duplicate instead of prompting for an update. `MIN_RANK_DELTA` tuned empirically against `scripts/compress_rank_gap_corpus.json`; chosen value lives in `hooks/compress_guard.py`. Closes #45.
 - `/recall` Step 4 N=1 checkoff branch no longer hits `AskUserQuestion` `minItems=2` validation errors. Single candidates now route to the verbatim text fallback; the `2 ≤ N ≤ 4` picker branch gains an explicit "Skip all — don't check off anything" sentinel option so deferral is a visible selectable choice. Closes #78.
 - `vault-doctor` `snapshot-migration` §3 (`snapshot-missing-backlink`) now resolves the parent session note via the `session_id` index built in the same scan, instead of composing a filename from `(snapshot.date, project, sha256(session_id)[:4])`. The old date-heuristic wrote wrong `source_session_note` wikilinks for cross-midnight sessions (PreCompact on day N, SessionEnd on day N+1). Orphan snapshots now emit `unresolved=True` with no speculative wikilink. Closes #68.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   internal path-encoded JSONL/bootstrap lookups are unaffected. Existing
   notes with worktree-derived project names continue to work via the
   UUID-first cross-project fallback in source-sessions.
+- **PR #97 reviewer findings (issue #93)**: 8 follow-up fixes applied:
+  C1+I6 surface `convergence_warning` and `convergence_count` at the
+  top level of the JSON payload (not under `extra.*`) and document the
+  `[CONVERGED <N> flags]` rendering in vault-doctor SKILL.md;
+  C2 cap `mtime`-signal proposed confidence at 0.3 (below the 0.4
+  convergence floor) so an mtime-only proposal is never auto-applied;
+  C3 emit an unresolved diagnostic Issue (with `missing_session_note`
+  and `jsonl_path`) when the source UUID has a real JSONL but no vault
+  session note, instead of silently skipping; C4 `canonical_project_name`
+  returns `"unknown"` when `os.getcwd()` raises (deleted-cwd safety so
+  hooks honor their must-exit-0 contract); C5 log a stderr warning when
+  `_list_all_session_notes` skips a `.md` file with malformed
+  frontmatter (parity with `_list_session_notes`); I4 Phase 1b now falls
+  back to `_find_jsonl_anywhere` when `_jsonl_dir_for_project` misses
+  on worktree-suffixed project names, preventing date-matcher false
+  positives; I7 tighten the UUID-trust regression test to assert the
+  C3 unresolved-Issue contract unconditionally.
 
 ## [2.4.1] - 2026-04-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and trusts an existing `source_session` whose JSONL window overlaps the
   note's calendar day. Issue payloads surface `capture_signal` and
   `capture_confidence` so operators can spot heuristic falls. Closes #93.
+- **vault-doctor source-sessions further hardening** (issue #93 follow-ups
+  surfaced via dev-test verification):
+  - Snapshot notes are now filtered out of the session-note SID index.
+    PreCompact snapshots inherit the parent session's UUID; without the
+    filter they could clobber the parent in the index, causing T5c's
+    basename-only repairs to propose snapshot basenames as 'correct'.
+  - Notes whose `source_session` UUID has a real JSONL but no session
+    note are no longer routed to the date-window matcher. The UUID is
+    authoritative; the missing session note is tracked separately
+    (issue #98).
+  - Day-precision signals (`date`, `filename`) now use a day-overlap
+    matcher (greatest overlap with the UTC calendar day) instead of a
+    noon-UTC point match. Morning-only and evening-only sessions are
+    no longer silently excluded from candidacy.
 - **vault-doctor source-sessions multi-session-day convergence**: when a
   worktree-launched insight records `project: <main>` but its source
   session has `project: <main>--<worktree-slug>`, the UUID lookup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `/recall` Step 4 N=1 checkoff branch no longer hits `AskUserQuestion` `minItems=2` validation errors. Single candidates now route to the verbatim text fallback; the `2 ≤ N ≤ 4` picker branch gains an explicit "Skip all — don't check off anything" sentinel option so deferral is a visible selectable choice. Closes #78.
 - `vault-doctor` `snapshot-migration` §3 (`snapshot-missing-backlink`) now resolves the parent session note via the `session_id` index built in the same scan, instead of composing a filename from `(snapshot.date, project, sha256(session_id)[:4])`. The old date-heuristic wrote wrong `source_session_note` wikilinks for cross-midnight sessions (PreCompact on day N, SessionEnd on day N+1). Orphan snapshots now emit `unresolved=True` with no speculative wikilink. Closes #68.
 - `vault-doctor` `sessions_by_id` in both `snapshot_migration.py` and `snapshot_integrity.py` no longer silently relies on an arbitrary filesystem-order-dependent winner when two session notes share a `session_id`. Colliding sids are tracked in a `_sid_collisions` set at build time, and the four consumers (migration §3 / §4 and integrity §1 / §4) now treat those collisions as ambiguous: the §1/§3 emission paths surface unresolved `"ambiguous parent — multiple session notes share session_id=<sid>; resolve by deduping the colliding session notes in the sessions folder"` Issues, while the §4 fix-proposal loops skip proposing a confidently-wrong backlink or snapshots-list fix. Collision detection is project-blind so `--project=foo` can't silently filter out a cross-project collider and resurrect arbitrary-winner selection inside the filtered scan; emission indices remain project-filtered. `snapshot_integrity.py` also gains an empty-`session_id` pre-guard with a specific reason (parity with `snapshot_migration.py` §3). Surfaced during PR #80 review as a pre-existing weakness made consequential by the #68 fix. Closes #81.
+- **Project-name divergence across worktrees**: session notes and insights
+  written from a worktree previously recorded the worktree's basename as
+  their `project:` field (e.g., `obsidian-brain--issue-81-...`), causing
+  vault-doctor's source-sessions check to mis-resolve UUID lookups when
+  the same insight referenced a session run in a different worktree.
+  All vault notes now record the canonical main-repo basename (e.g.,
+  `obsidian-brain`), derived via `git rev-parse --git-common-dir`. CC's
+  internal path-encoded JSONL/bootstrap lookups are unaffected. Existing
+  notes with worktree-derived project names continue to work via the
+  UUID-first cross-project fallback in source-sessions.
 
 ## [2.4.1] - 2026-04-22
 

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -117,6 +117,9 @@ def _run() -> None:
     cwd = hook_input.get("cwd", os.getcwd())
 
     # 2. Derive project name (needed for bootstrap before vault config).
+    # Cwd-based project name (NOT canonical) — used for CC's path-encoded
+    # JSONL/bootstrap directory lookups. Frontmatter project is canonical;
+    # see canonical_project_name().
     project = get_project_name(cwd)
 
     # 2a. Refresh the bootstrap file with the authoritative session_id from stdin.

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -134,12 +134,18 @@ def canonical_project_name(cwd: str | None = None) -> str:
     is what should be written to vault-note frontmatter `project:` fields
     so cross-worktree work groups under one logical project.
 
-    Falls back to cwd basename if not in a git repo. Result is lowercased
-    and underscores/spaces normalized to hyphens (matching existing convention).
+    Falls back to cwd basename if not in a git repo. Returns 'unknown' when
+    the working directory cannot be determined (e.g., the directory was
+    deleted mid-session via `gh pr merge --delete-branch`); hooks must exit
+    0, so raising would violate the contract. Result is lowercased and
+    underscores/spaces normalized to hyphens.
     """
     name = _git_canonical_project_name(cwd)
     if name is None:
-        base = cwd if cwd else os.getcwd()
+        try:
+            base = cwd if cwd else os.getcwd()
+        except (OSError, FileNotFoundError):
+            return "unknown"
         name = os.path.basename(base)
     return name.lower().replace(" ", "-").replace("_", "-")
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -91,6 +91,59 @@ def _safe_mtime(path: str) -> float:
         return -1.0
 
 
+def _git_canonical_project_name(cwd: str | None = None) -> str | None:
+    """Return the main-repo basename via `git rev-parse --git-common-dir`.
+
+    For a worktree, `--git-common-dir` returns the path to the SHARED .git
+    of the main repo (e.g., `/path/main-repo/.git`). The parent's basename
+    is the canonical project name across all worktrees.
+
+    Returns None if not in a git repository or git is unavailable. Caller
+    should fall back to cwd basename in that case.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd or None,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    common_dir = result.stdout.strip()
+    if not common_dir:
+        return None
+    common_dir_path = Path(common_dir)
+    if not common_dir_path.is_absolute():
+        base = Path(cwd) if cwd else Path.cwd()
+        try:
+            common_dir_path = (base / common_dir).resolve()
+        except OSError:
+            return None
+    name = common_dir_path.parent.name
+    return name or None
+
+
+def canonical_project_name(cwd: str | None = None) -> str:
+    """Return the canonical (main-repo) project name for cwd.
+
+    Worktrees of the same repo all return the same canonical name. This
+    is what should be written to vault-note frontmatter `project:` fields
+    so cross-worktree work groups under one logical project.
+
+    Falls back to cwd basename if not in a git repo. Result is lowercased
+    and underscores/spaces normalized to hyphens (matching existing convention).
+    """
+    name = _git_canonical_project_name(cwd)
+    if name is None:
+        base = cwd if cwd else os.getcwd()
+        name = os.path.basename(base)
+    return name.lower().replace(" ", "-").replace("_", "-")
+
+
 def _glob_project_jsonls(safe_project: str, suffix: str = "*.jsonl") -> list[str]:
     """Glob ~/.claude/projects/*<project>/<suffix>, with underscore-to-hyphen fallback.
 
@@ -117,6 +170,9 @@ def _slow_path_newest_sid() -> str:
     entries. Returns 'unknown' if no JSONLs are found for the current cwd.
     """
     import glob as _glob
+    # Cwd-based project name (NOT canonical) — used for CC's path-encoded
+    # JSONL/bootstrap directory lookups. Frontmatter project is canonical;
+    # see canonical_project_name().
     project = os.path.basename(os.getcwd())
     safe_project = _glob.escape(project)
     matches = _glob_project_jsonls(safe_project)
@@ -159,6 +215,9 @@ def _get_session_id_fast() -> str:
     this, before CC has flushed the new session's JSONL to disk).
     """
     import glob as _glob
+    # Cwd-based project name (NOT canonical) — used for CC's path-encoded
+    # JSONL/bootstrap directory lookups. Frontmatter project is canonical;
+    # see canonical_project_name().
     project = os.path.basename(os.getcwd())
     bootstrap = f"{_bootstrap_prefix()}{project}"
     safe_project = _glob.escape(project)
@@ -418,6 +477,9 @@ def check_hook_status() -> dict:
     "ok" is False only when the bootstrap file is missing entirely or no
     session files can be found.
     """
+    # Cwd-based project name (NOT canonical) — used for CC's path-encoded
+    # JSONL/bootstrap directory lookups. Frontmatter project is canonical;
+    # see canonical_project_name().
     project = os.path.basename(os.getcwd())
     bootstrap = f"{_bootstrap_prefix()}{project}"
 
@@ -473,7 +535,7 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
     """Get session ID, hash, project, and session note name. Cached.
 
     Returns {session_id, hash, project, session_note_name} or
-    {session_id: 'unknown', hash: '', project: <cwd basename>, session_note_name: ''}.
+    {session_id: 'unknown', hash: '', project: <canonical-project>, session_note_name: ''}.
     """
     sid = _get_session_id_fast()
     # Include args in cache key so different call signatures don't collide
@@ -482,7 +544,7 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
     if cached is not None:
         return cached
 
-    project = os.path.basename(os.getcwd()).lower().replace(' ', '-').replace('_', '-')
+    project = canonical_project_name()
     if sid == "unknown":
         # Don't cache "unknown" — would pollute cache shared across projects
         return {"session_id": "unknown", "hash": "", "project": project, "session_note_name": ""}
@@ -960,7 +1022,7 @@ def extract_session_metadata(messages: list[dict], cwd: str) -> dict:
     errors, duration_minutes, commits.
     """
     meta: dict = {
-        "project": Path(cwd).name.lower().replace(" ", "-").replace("_", "-") if cwd else "unknown",
+        "project": canonical_project_name(cwd) if cwd else "unknown",
         "project_path": cwd or "",
         "git_branch": "",
         "files_touched": [],

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -2585,7 +2585,12 @@ def extract_tool_uses(messages: list[dict]) -> list[dict]:
 
 
 def get_project_name(cwd: str) -> str:
-    """Return the basename of the working directory as the project name."""
+    """Return the basename of the working directory as the project name.
+
+    Used for CC's path-encoded bootstrap/JSONL lookups; for vault frontmatter
+    use ``canonical_project_name()`` instead so worktrees of the same repo
+    share one logical project value.
+    """
     return Path(cwd).name if cwd else "unknown"
 
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -96,15 +96,19 @@ def _safe_mtime(path: str) -> float:
 _git_fallback_warned: bool = False
 
 
-def _git_canonical_project_name(cwd: str | None = None) -> str | None:
-    """Return the main-repo basename via `git rev-parse --git-common-dir`.
+def _git_canonical_project_name_with_reason(
+    cwd: str | None = None,
+) -> tuple[str | None, str]:
+    """Return (canonical_name_or_None, reason).
 
-    For a worktree, `--git-common-dir` returns the path to the SHARED .git
-    of the main repo (e.g., `/path/main-repo/.git`). The parent's basename
-    is the canonical project name across all worktrees.
-
-    Returns None if not in a git repository or git is unavailable. Caller
-    should fall back to cwd basename in that case.
+    reason is one of:
+      - "ok" — name resolved successfully
+      - "not-a-repo" — git ran but cwd is not inside a git work-tree (returncode != 0).
+        This is a NORMAL operating condition; callers should NOT warn.
+      - "git-unavailable" — git binary missing or subprocess raised OSError.
+        Genuine error; callers SHOULD warn.
+      - "empty-output" — git ran clean but returned no path. Should not happen.
+      - "resolve-failed" — relative-path resolve raised OSError.
     """
     try:
         result = subprocess.run(
@@ -115,21 +119,37 @@ def _git_canonical_project_name(cwd: str | None = None) -> str | None:
             cwd=cwd or None,
         )
     except (OSError, subprocess.SubprocessError):
-        return None
+        return (None, "git-unavailable")
     if result.returncode != 0:
-        return None
+        return (None, "not-a-repo")
     common_dir = result.stdout.strip()
     if not common_dir:
-        return None
+        return (None, "empty-output")
     common_dir_path = Path(common_dir)
     if not common_dir_path.is_absolute():
         base = Path(cwd) if cwd else Path.cwd()
         try:
             common_dir_path = (base / common_dir).resolve()
         except OSError:
-            return None
+            return (None, "resolve-failed")
     name = common_dir_path.parent.name
-    return name or None
+    if not name:
+        return (None, "empty-output")
+    return (name, "ok")
+
+
+def _git_canonical_project_name(cwd: str | None = None) -> str | None:
+    """Return the main-repo basename via `git rev-parse --git-common-dir`.
+
+    For a worktree, `--git-common-dir` returns the path to the SHARED .git
+    of the main repo (e.g., `/path/main-repo/.git`). The parent's basename
+    is the canonical project name across all worktrees.
+
+    Returns None if not in a git repository or git is unavailable. Caller
+    should fall back to cwd basename in that case.
+    """
+    name, _reason = _git_canonical_project_name_with_reason(cwd)
+    return name
 
 
 def canonical_project_name(cwd: str | None = None) -> str:
@@ -145,21 +165,24 @@ def canonical_project_name(cwd: str | None = None) -> str:
     0, so raising would violate the contract. Result is lowercased and
     underscores/spaces normalized to hyphens.
 
-    Emits a one-shot stderr warning per process when git is unavailable
-    and the cwd-basename fallback engages. Inside a worktree this fallback
-    re-creates the worktree-divergent `project:` write that the canonical
-    helper exists to prevent (review SF7).
+    Emits a one-shot stderr warning per process ONLY when git is genuinely
+    unavailable or errors out (binary missing, empty output, resolve failure).
+    Does NOT warn for the normal "cwd is not in a git repo" case — that's a
+    common, expected operating condition and warning would be noise (review
+    Copilot R2).
     """
-    name = _git_canonical_project_name(cwd)
+    name, reason = _git_canonical_project_name_with_reason(cwd)
     if name is None:
-        global _git_fallback_warned
-        if not _git_fallback_warned:
-            _git_fallback_warned = True
-            print(
-                "[obsidian_utils] canonical_project_name: git unavailable, "
-                "using cwd basename — verify project: frontmatter writes",
-                file=sys.stderr,
-            )
+        if reason in ("git-unavailable", "empty-output", "resolve-failed"):
+            global _git_fallback_warned
+            if not _git_fallback_warned:
+                _git_fallback_warned = True
+                print(
+                    f"[obsidian_utils] canonical_project_name: git error "
+                    f"({reason}), using cwd basename — verify project: "
+                    f"frontmatter writes",
+                    file=sys.stderr,
+                )
         try:
             base = cwd if cwd else os.getcwd()
         except (OSError, FileNotFoundError):

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -91,6 +91,11 @@ def _safe_mtime(path: str) -> float:
         return -1.0
 
 
+# Module-level flag for SF7 one-shot warning. Avoids spamming stderr on every
+# canonical_project_name() call when git is unavailable for the whole process.
+_git_fallback_warned: bool = False
+
+
 def _git_canonical_project_name(cwd: str | None = None) -> str | None:
     """Return the main-repo basename via `git rev-parse --git-common-dir`.
 
@@ -139,9 +144,22 @@ def canonical_project_name(cwd: str | None = None) -> str:
     deleted mid-session via `gh pr merge --delete-branch`); hooks must exit
     0, so raising would violate the contract. Result is lowercased and
     underscores/spaces normalized to hyphens.
+
+    Emits a one-shot stderr warning per process when git is unavailable
+    and the cwd-basename fallback engages. Inside a worktree this fallback
+    re-creates the worktree-divergent `project:` write that the canonical
+    helper exists to prevent (review SF7).
     """
     name = _git_canonical_project_name(cwd)
     if name is None:
+        global _git_fallback_warned
+        if not _git_fallback_warned:
+            _git_fallback_warned = True
+            print(
+                "[obsidian_utils] canonical_project_name: git unavailable, "
+                "using cwd basename — verify project: frontmatter writes",
+                file=sys.stderr,
+            )
         try:
             base = cwd if cwd else os.getcwd()
         except (OSError, FileNotFoundError):

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -183,6 +183,8 @@ def main() -> int:
                     "unresolved": i.extra.get("unresolved", False),
                     "capture_signal": i.extra.get("capture_signal", ""),
                     "capture_confidence": i.extra.get("capture_confidence", 0.0),
+                    "convergence_warning": i.extra.get("convergence_warning", False),
+                    "convergence_count": i.extra.get("convergence_count", 0),
                 }
                 for issues in issues_by_check.values() for i in issues
             ],

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -181,6 +181,8 @@ def main() -> int:
                     "reason": i.reason,
                     "confidence": i.confidence,
                     "unresolved": i.extra.get("unresolved", False),
+                    "capture_signal": i.extra.get("capture_signal", ""),
+                    "capture_confidence": i.extra.get("capture_confidence", 0.0),
                 }
                 for issues in issues_by_check.values() for i in issues
             ],

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -14,6 +14,7 @@ Detection strategy:
 
 from __future__ import annotations
 
+import dataclasses
 import glob
 import json
 import os
@@ -248,6 +249,40 @@ def _jsonl_dir_for_project(project: str) -> Path | None:
     return Path(max(viable, key=lambda pair: (pair[1], pair[0]))[0])
 
 
+def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
+    """Map session_id → {path, basename, date, project} across ALL projects.
+
+    Used by Phase 1b's UUID-first lookup to handle the case where a note's
+    declared `project:` doesn't match its actual source session note's
+    `project:` (e.g., insight written from main repo's cwd while the
+    session ran in a worktree). The session_id is globally unique, so
+    cross-project lookup is safe.
+    """
+    out: dict[str, dict] = {}
+    if not sessions_dir.is_dir():
+        return out
+    for entry in sessions_dir.iterdir():
+        if not entry.name.endswith(".md"):
+            continue
+        try:
+            text = entry.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        fm = _parse_frontmatter(text)
+        if not fm:
+            continue
+        sid = fm.get("session_id", "")
+        if not sid:
+            continue
+        out[sid] = {
+            "path": entry,
+            "basename": entry.name[:-3],
+            "date": fm.get("date", ""),
+            "project": fm.get("project", ""),
+        }
+    return out
+
+
 def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
     """Map session_id → {path, basename, date} for a project's session notes."""
     out: dict[str, dict] = {}
@@ -335,6 +370,7 @@ def scan(
     issues: list[Issue] = []
     session_index_cache: dict[str, dict[str, dict]] = {}
     jsonl_dir_cache: dict[str, Path | None] = {}
+    global_sid_index: dict[str, dict] | None = None  # built lazily on first need
 
     for folder in scan_folders:
         folder_path = vault / folder
@@ -392,39 +428,73 @@ def scan(
             else:
                 current_source_display = ""
 
-            # Phase 1b — early-exit (issue #93): if the current source's JSONL
-            # window overlaps the note's calendar day, trust it. The JSONL
-            # window is the ground-truth signal for when a session was active;
-            # session-note `date:` fields can drift due to migrations, renames,
-            # or sibling vault-doctor checks. Window-overlap correctly handles
-            # strict same-day sessions, cross-midnight (started prev day, ran
-            # into note's day), early-morning captures from previous-night
-            # sessions, and multi-day sessions.
+            # Phase 1b — UUID-first authoritative signal (issue #93):
+            # if current source's UUID resolves to ANY session note in the
+            # vault (cross-project, since worktree-launched skills may write
+            # `project:` from main-repo cwd while their source session ran
+            # in a worktree), check whether the JSONL window overlaps the
+            # note's calendar day. If yes, the UUID is correct; only the
+            # basename in source_session_note may need updating.
             #
             # Only applies for day-precision signals (date, filename, mtime).
-            # When created_at provides a precise sub-day timestamp we trust
-            # the matcher — it has enough resolution to detect intra-day
-            # session boundaries even on multi-session days.
-            if (
-                current_sid
-                and current_sid in idx
-                and capture_signal != "created_at"
-                and jsonl_dir is not None
-            ):
-                note_date = fm.get("date", "")
-                if not note_date:
-                    fn_match = _FILENAME_DATE_RE.match(note.name)
-                    note_date = fn_match.group(1) if fn_match else ""
-                day_start = _parse_date_start(note_date) if note_date else None
-                if day_start is not None:
-                    day_end = day_start + 86400  # next midnight UTC
-                    current_jsonl = jsonl_dir / f"{current_sid}.jsonl"
-                    if current_jsonl.exists():
-                        window = _jsonl_window(str(current_jsonl))
-                        if window is not None:
-                            first_ts, last_ts = window
-                            if first_ts < day_end and last_ts > day_start:
-                                continue  # session active during note's day — trust
+            # When created_at provides a precise sub-day timestamp the matcher
+            # has enough resolution; let it run.
+            if current_sid and capture_signal != "created_at":
+                if global_sid_index is None:
+                    global_sid_index = _list_all_session_notes(sessions_dir)
+                if current_sid in global_sid_index:
+                    sess = global_sid_index[current_sid]
+                    sess_project = sess.get("project", "")
+                    sess_jsonl_dir = (
+                        _jsonl_dir_for_project(sess_project) if sess_project else None
+                    )
+                    note_date = fm.get("date", "")
+                    if not note_date:
+                        fn_match = _FILENAME_DATE_RE.match(note.name)
+                        note_date = fn_match.group(1) if fn_match else ""
+                    day_start = _parse_date_ts(note_date, hour=0) if note_date else None
+                    window = None
+                    if sess_jsonl_dir is not None:
+                        jsonl_path = sess_jsonl_dir / f"{current_sid}.jsonl"
+                        if jsonl_path.exists():
+                            window = _jsonl_window(str(jsonl_path))
+                    if day_start is not None and window is not None:
+                        day_end = day_start + 86400
+                        first_ts, last_ts = window
+                        if first_ts < day_end and last_ts > day_start:
+                            # UUID resolves AND window overlaps note's day → UUID is correct.
+                            # Now check if source_session_note basename is stale.
+                            actual_basename = sess["basename"]
+                            if (
+                                current_src_basename
+                                and current_src_basename != actual_basename
+                            ):
+                                # Basename mismatch (e.g., un-truncated worktree slug
+                                # vs truncated actual filename). Propose basename-only
+                                # repair; UUID stays the same.
+                                issues.append(
+                                    Issue(
+                                        check=NAME,
+                                        note_path=str(note),
+                                        project=note_project,
+                                        current_source=current_source_display,
+                                        proposed_source=f"[[{actual_basename}]]",
+                                        reason=(
+                                            f"source_session UUID {current_sid[:8]} resolves "
+                                            f"correctly but source_session_note basename is "
+                                            f"stale (expected '{actual_basename}', got "
+                                            f"'{current_src_basename}')"
+                                        ),
+                                        confidence=0.99,
+                                        extra={
+                                            "proposed_sid": current_sid,
+                                            "basename_only": True,
+                                            "capture_signal": capture_signal,
+                                            "capture_confidence": capture_conf,
+                                        },
+                                    )
+                                )
+                            continue  # UUID is authoritative either way; skip matcher
 
             match = _find_matching_session(capture_time, jsonl_dir, idx)
             if match is None:
@@ -457,6 +527,13 @@ def scan(
             if match["sid"] == current_sid:
                 continue  # correct
 
+            # Cap confidence on date-only signals: multi-session days collapse
+            # onto a single noon-UTC bucket and produce uniform proposals.
+            # `created_at` is the only signal precise enough for high confidence.
+            if capture_signal == "created_at":
+                proposed_conf = 0.95
+            else:
+                proposed_conf = 0.6
             issues.append(
                 Issue(
                     check=NAME,
@@ -471,7 +548,7 @@ def scan(
                         f" matches session {match['sid'][:8]} window, "
                         f"not current source {current_sid[:8]}"
                     ),
-                    confidence=0.95,
+                    confidence=proposed_conf,
                     extra={
                         "proposed_sid": match["sid"],
                         "capture_signal": capture_signal,
@@ -479,6 +556,35 @@ def scan(
                     },
                 )
             )
+
+    # Convergence guard (issue #93): if multiple flags in a project propose
+    # the same target session, the date-window heuristic has structurally
+    # collapsed across a multi-session day. Lower confidence and tag for
+    # operator review.
+    from collections import Counter
+    targets = Counter(
+        (i.project, i.extra.get("proposed_sid", ""))
+        for i in issues
+        if i.extra.get("proposed_sid") and not i.extra.get("basename_only")
+    )
+    issues = [
+        dataclasses.replace(
+            i,
+            confidence=min(i.confidence, 0.4),
+            extra={
+                **i.extra,
+                "convergence_warning": True,
+                "convergence_count": targets[(i.project, i.extra.get("proposed_sid", ""))],
+            },
+        )
+        if (
+            not i.extra.get("basename_only")
+            and i.extra.get("proposed_sid")
+            and targets[(i.project, i.extra.get("proposed_sid", ""))] >= 2
+        )
+        else i
+        for i in issues
+    ]
 
     return issues
 

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -682,10 +682,14 @@ def scan(
 
             # Day-precision signals: match by greatest overlap with UTC calendar day.
             # Sub-day precision (created_at): match by point-in-window.
+            # Track which matcher actually ran so the reason text below
+            # describes the right contract (Copilot R4: mtime with no date or
+            # filename prefix falls through to point-in-window matching).
+            note_date_for_match = ""
+            used_day_overlap = False
             if capture_signal == "created_at":
                 match = _find_matching_session(capture_time, jsonl_dir, idx)
             else:
-                # Derive note's date from frontmatter or filename prefix
                 note_date_for_match = fm.get("date", "")
                 if not note_date_for_match:
                     fn_match = _FILENAME_DATE_RE.match(note.name)
@@ -694,6 +698,7 @@ def scan(
                     match = _find_matching_session_by_day_overlap(
                         note_date_for_match, jsonl_dir, idx
                     )
+                    used_day_overlap = True
                 else:
                     match = _find_matching_session(capture_time, jsonl_dir, idx)
             if match is None:
@@ -736,27 +741,23 @@ def scan(
                 proposed_conf = 0.3  # below convergence floor; never auto-apply
             else:
                 proposed_conf = 0.6
-            # Build reason text matching the matcher used: point-in-window
-            # for created_at (timestamp inside session window) vs day-overlap
-            # for date/filename (calendar day overlaps session window).
-            if capture_signal == "created_at":
+            # Build reason text matching the matcher actually used (Copilot R4):
+            # day-overlap → describe calendar-day match; point-in-window →
+            # describe capture_time match. mtime with no date/filename takes
+            # the point-in-window branch even though signal != created_at.
+            if used_day_overlap:
+                reason = (
+                    f"note calendar day {note_date_for_match}"
+                    f" (signal={capture_signal}, conf={capture_conf})"
+                    f" overlaps session {match['sid'][:8]} window most, "
+                    f"not current source {current_sid[:8]}"
+                )
+            else:
                 reason = (
                     f"note capture_time "
                     f"{datetime.fromtimestamp(capture_time, timezone.utc).isoformat(timespec='seconds')}"
                     f" (signal={capture_signal}, conf={capture_conf})"
                     f" matches session {match['sid'][:8]} window, "
-                    f"not current source {current_sid[:8]}"
-                )
-            else:
-                # day-overlap matcher: synthetic capture_time may NOT be inside
-                # the winning session's window — describe the calendar-day match.
-                note_day = datetime.fromtimestamp(
-                    capture_time, timezone.utc
-                ).strftime("%Y-%m-%d")
-                reason = (
-                    f"note calendar day {note_day}"
-                    f" (signal={capture_signal}, conf={capture_conf})"
-                    f" overlaps session {match['sid'][:8]} window most, "
                     f"not current source {current_sid[:8]}"
                 )
             issues.append(
@@ -776,15 +777,24 @@ def scan(
                 )
             )
 
-    # Convergence guard: if multiple flags in a project propose
-    # the same target session, the date-window heuristic has structurally
-    # collapsed across a multi-session day. Lower confidence and tag for
-    # operator review.
+    # Convergence guard: if multiple flags in a project propose the same
+    # target session, the date-window heuristic has structurally collapsed
+    # across a multi-session day. Lower confidence and tag for operator review.
+    #
+    # Restrict the guard to day-precision signals (date/filename/mtime) —
+    # `created_at` matches use point-in-window with sub-day precision, so two
+    # legitimate stale notes from the same session sharing a proposal target
+    # is just normal cluster behavior, not heuristic collapse (Copilot R4-2).
     from collections import Counter
+    _DAY_PRECISION_SIGNALS = {"date", "filename", "mtime"}
     targets = Counter(
         (i.project, i.extra.get("proposed_sid", ""))
         for i in issues
-        if i.extra.get("proposed_sid") and not i.extra.get("basename_only")
+        if (
+            i.extra.get("proposed_sid")
+            and not i.extra.get("basename_only")
+            and i.extra.get("capture_signal") in _DAY_PRECISION_SIGNALS
+        )
     )
     issues = [
         dataclasses.replace(
@@ -799,6 +809,7 @@ def scan(
         if (
             not i.extra.get("basename_only")
             and i.extra.get("proposed_sid")
+            and i.extra.get("capture_signal") in _DAY_PRECISION_SIGNALS
             and targets[(i.project, i.extra.get("proposed_sid", ""))] >= 2
         )
         else i

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -346,11 +346,16 @@ def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
     `project:` (e.g., insight written from main repo's cwd while the
     session ran in a worktree). The session_id is globally unique, so
     cross-project lookup is safe.
+
+    Iterates entries in sorted order so the winner is deterministic across
+    runs (Copilot R5). When two session notes share the same session_id
+    (a known possible vault state — typically a vault-import collision or
+    a rename gone wrong), warn to stderr instead of silently overwriting.
     """
     out: dict[str, dict] = {}
     if not sessions_dir.is_dir():
         return out
-    for entry in sessions_dir.iterdir():
+    for entry in sorted(sessions_dir.iterdir()):
         if not entry.name.endswith(".md"):
             continue
         try:
@@ -370,6 +375,14 @@ def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
             continue
         if fm.get("type") != "claude-session":
             continue  # skip claude-snapshot — same UUID, not the canonical session
+        if sid in out:
+            print(
+                f"[vault_doctor] duplicate session_id {sid[:8]} across "
+                f"{out[sid]['path'].name} and {entry.name} — keeping first "
+                f"(sorted-order winner); rename one to disambiguate",
+                file=sys.stderr,
+            )
+            continue
         out[sid] = {
             "path": entry,
             "basename": entry.name[:-3],
@@ -380,11 +393,15 @@ def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
 
 
 def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
-    """Map session_id → {path, basename, date} for a project's session notes."""
+    """Map session_id → {path, basename, date} for a project's session notes.
+
+    Iterates in sorted order for a deterministic duplicate-SID winner; warns
+    on collisions (Copilot R5; mirrors _list_all_session_notes).
+    """
     out: dict[str, dict] = {}
     if not sessions_dir.is_dir():
         return out
-    for entry in sessions_dir.iterdir():
+    for entry in sorted(sessions_dir.iterdir()):
         if not entry.name.endswith(".md"):
             continue
         try:
@@ -405,6 +422,14 @@ def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
             continue
         if fm.get("type") != "claude-session":
             continue  # skip claude-snapshot — same UUID, not the canonical session
+        if sid in out:
+            print(
+                f"[vault_doctor] duplicate session_id {sid[:8]} across "
+                f"{out[sid]['path'].name} and {entry.name} — keeping first "
+                f"(sorted-order winner); rename one to disambiguate",
+                file=sys.stderr,
+            )
+            continue
         out[sid] = {
             "path": entry,
             "basename": entry.name[:-3],

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -274,6 +274,8 @@ def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
         sid = fm.get("session_id", "")
         if not sid:
             continue
+        if fm.get("type") != "claude-session":
+            continue  # skip claude-snapshot — same UUID, not the canonical session
         out[sid] = {
             "path": entry,
             "basename": entry.name[:-3],
@@ -307,6 +309,8 @@ def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
         sid = fm.get("session_id", "")
         if not sid:
             continue
+        if fm.get("type") != "claude-session":
+            continue  # skip claude-snapshot — same UUID, not the canonical session
         out[sid] = {
             "path": entry,
             "basename": entry.name[:-3],

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -117,6 +117,17 @@ def _parse_date_midpoint(date_str: str) -> float | None:
         return None
 
 
+def _parse_date_start(date_str: str) -> float | None:
+    """Parse YYYY-MM-DD to POSIX timestamp at 00:00 UTC of that day, or None."""
+    if not date_str:
+        return None
+    try:
+        d = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+        return d.timestamp()
+    except ValueError:
+        return None
+
+
 # Filename prefix YYYY-MM-DD-...
 _FILENAME_DATE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})-")
 
@@ -379,24 +390,39 @@ def scan(
             else:
                 current_source_display = ""
 
-            # Phase 1b — early-exit (issue #93): if current source resolves
-            # to a same-day session note in the project's index, trust it.
-            # Avoids paying for a heuristic match when nothing has changed
-            # and prevents matcher boundary-tie misclassifications on
-            # cross-midnight or multi-session days.
+            # Phase 1b — early-exit (issue #93): if the current source's JSONL
+            # window overlaps the note's calendar day, trust it. The JSONL
+            # window is the ground-truth signal for when a session was active;
+            # session-note `date:` fields can drift due to migrations, renames,
+            # or sibling vault-doctor checks. Window-overlap correctly handles
+            # strict same-day sessions, cross-midnight (started prev day, ran
+            # into note's day), early-morning captures from previous-night
+            # sessions, and multi-day sessions.
             #
             # Only applies for day-precision signals (date, filename, mtime).
             # When created_at provides a precise sub-day timestamp we trust
             # the matcher — it has enough resolution to detect intra-day
             # session boundaries even on multi-session days.
-            if current_sid and current_sid in idx and capture_signal != "created_at":
-                current_session_date = idx[current_sid].get("date", "")
+            if (
+                current_sid
+                and current_sid in idx
+                and capture_signal != "created_at"
+                and jsonl_dir is not None
+            ):
                 note_date = fm.get("date", "")
                 if not note_date:
                     fn_match = _FILENAME_DATE_RE.match(note.name)
                     note_date = fn_match.group(1) if fn_match else ""
-                if note_date and current_session_date == note_date:
-                    continue  # current source already correct
+                day_start = _parse_date_start(note_date) if note_date else None
+                if day_start is not None:
+                    day_end = day_start + 86400  # next midnight UTC
+                    current_jsonl = jsonl_dir / f"{current_sid}.jsonl"
+                    if current_jsonl.exists():
+                        window = _jsonl_window(str(current_jsonl))
+                        if window is not None:
+                            first_ts, last_ts = window
+                            if first_ts < day_end and last_ts > day_start:
+                                continue  # session active during note's day — trust
 
             match = _find_matching_session(capture_time, jsonl_dir, idx)
             if match is None:

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -556,10 +556,34 @@ def scan(
                 else:
                     # UUID not in session-note index — but a real JSONL may
                     # still exist (SessionEnd hook missed; see issue #98).
-                    # In that case, the UUID is authoritative; refuse to
-                    # propose a different-session rewrite.
-                    if _find_jsonl_anywhere(current_sid) is not None:
-                        continue  # trust UUID, skip matcher
+                    # Emit an unresolved diagnostic Issue so operators can see
+                    # the coverage gap; UUID is authoritative, so don't propose
+                    # a different-session rewrite.
+                    jsonl_path = _find_jsonl_anywhere(current_sid)
+                    if jsonl_path is not None:
+                        issues.append(
+                            Issue(
+                                check=NAME,
+                                note_path=str(note),
+                                project=note_project,
+                                current_source=current_source_display,
+                                proposed_source="",
+                                reason=(
+                                    f"source UUID {current_sid[:8]} has a JSONL "
+                                    f"but no session note in the vault "
+                                    f"(see issue #98 for coverage-gap detector)"
+                                ),
+                                confidence=0.0,
+                                extra={
+                                    "unresolved": True,
+                                    "missing_session_note": True,
+                                    "jsonl_path": str(jsonl_path),
+                                    "capture_signal": capture_signal,
+                                    "capture_confidence": capture_conf,
+                                },
+                            )
+                        )
+                        continue  # UUID is authoritative; skip matcher
 
             # Day-precision signals: match by greatest overlap with UTC calendar day.
             # Sub-day precision (created_at): match by point-in-window.

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -381,10 +381,10 @@ def scan(
 
             match = _find_matching_session(capture_time, jsonl_dir, idx)
             if match is None:
-                # No JSONL window contains this mtime. Flag as unresolved ONLY if
-                # the current source doesn't resolve to any known session note — that
-                # way we don't get false positives on notes whose current source is
-                # correct but just doesn't have a matching JSONL window locally.
+                # No JSONL window contains the note's capture_time. Flag as unresolved
+                # ONLY if the current source doesn't resolve to any known session note
+                # — that way we don't get false positives on notes whose current source
+                # is correct but just doesn't have a matching JSONL window locally.
                 if current_sid not in idx:
                     issues.append(
                         Issue(
@@ -393,9 +393,16 @@ def scan(
                             project=note_project,
                             current_source=current_source_display,
                             proposed_source="",
-                            reason="no session window contains note mtime",
+                            reason=(
+                                f"no session window contains note capture_time"
+                                f" (signal={capture_signal}, conf={capture_conf})"
+                            ),
                             confidence=0.0,
-                            extra={"unresolved": True},
+                            extra={
+                                "unresolved": True,
+                                "capture_signal": capture_signal,
+                                "capture_confidence": capture_conf,
+                            },
                         )
                     )
                 continue
@@ -418,7 +425,11 @@ def scan(
                         f"not current source {current_sid[:8]}"
                     ),
                     confidence=0.95,
-                    extra={"proposed_sid": match["sid"]},
+                    extra={
+                        "proposed_sid": match["sid"],
+                        "capture_signal": capture_signal,
+                        "capture_confidence": capture_conf,
+                    },
                 )
             )
 

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -612,6 +612,8 @@ def scan(
             # `created_at` is the only signal precise enough for high confidence.
             if capture_signal == "created_at":
                 proposed_conf = 0.95
+            elif capture_signal == "mtime":
+                proposed_conf = 0.3  # below convergence floor; never auto-apply
             else:
                 proposed_conf = 0.6
             issues.append(

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -114,6 +114,41 @@ def _parse_date_midpoint(date_str: str) -> float | None:
         return None
 
 
+# Filename prefix YYYY-MM-DD-...
+_FILENAME_DATE_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})-")
+
+
+def _capture_time(note_path: Path, fm: dict) -> tuple[float, float, str]:
+    """Return (POSIX_ts, confidence, signal_name) using immutable signals first.
+
+    Preference order:
+      1. fm['created_at'] ISO-8601                 → conf 1.0,  signal 'created_at'
+      2. fm['date'] YYYY-MM-DD (interpreted as     → conf 0.9,  signal 'date'
+         midpoint of UTC day)
+      3. filename prefix YYYY-MM-DD-...            → conf 0.85, signal 'filename'
+      4. os.path.getmtime() (last resort)          → conf 0.5,  signal 'mtime'
+      5. unreadable file                           → conf 0.0,  signal 'none'
+
+    Confidence is surfaced in the issue payload so the report can
+    distinguish high-signal matches from low-signal fallbacks.
+    """
+    # 1. created_at
+    if (ts := _parse_iso_ts(fm.get("created_at", ""))) is not None:
+        return (ts, 1.0, "created_at")
+    # 2. date (day-precision)
+    if (ts := _parse_date_midpoint(fm.get("date", ""))) is not None:
+        return (ts, 0.9, "date")
+    # 3. filename prefix
+    if (m := _FILENAME_DATE_RE.match(note_path.name)):
+        if (ts := _parse_date_midpoint(m.group(1))) is not None:
+            return (ts, 0.85, "filename")
+    # 4. mtime (last resort)
+    try:
+        return (os.path.getmtime(note_path), 0.5, "mtime")
+    except OSError:
+        return (0.0, 0.0, "none")
+
+
 def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
     """Return (first_entry_ts, mtime) for a JSONL session file, or None.
 

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -72,19 +72,52 @@ def _safe_project_slug(project: str) -> str:
     return slug or "unknown"
 
 
-def _parse_frontmatter(text: str) -> dict:
-    """Parse a flat key: value YAML frontmatter block. Nested blocks ignored."""
+def _parse_frontmatter(text: str, source: str | None = None) -> dict:
+    """Parse a flat key: value YAML frontmatter block. Nested blocks ignored.
+
+    Flat-only by design — multiline scalars, folded YAML (``key:\\n  value``),
+    block sequences nested under a key, and other non-flat YAML constructs are
+    silently skipped. When a key without a same-line value is followed by an
+    indented continuation line that looks like folded YAML, a one-shot stderr
+    warning is emitted (review SF5) so operators can spot high-confidence
+    signals being silently degraded to mtime fallbacks.
+
+    Args:
+        text: full file contents (frontmatter must start at byte 0).
+        source: optional path/identifier surfaced in the SF5 warning so the
+            offending file is locatable in operator logs.
+    """
     m = _FRONT_RE.match(text)
     if not m:
         return {}
     out: dict = {}
-    for line in m.group(1).splitlines():
+    lines = m.group(1).splitlines()
+    folded_warned: set[str] = set()
+    for i, line in enumerate(lines):
         if not line or line.startswith(" ") or line.startswith("-"):
             continue  # skip list items and nested keys
         if ":" not in line:
             continue
         key, _, value = line.partition(":")
-        out[key.strip()] = value.strip().strip('"').strip("'")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if not value:
+            # Key with no same-line value. If the next line is indented,
+            # it's folded/multiline YAML — log once per (file, key) so the
+            # silent degradation is visible. Skip the key as before.
+            nxt = lines[i + 1] if (i + 1) < len(lines) else ""
+            if nxt and (nxt.startswith(" ") or nxt.startswith("\t")):
+                tag = f"{source or '?'}::{key}"
+                if tag not in folded_warned:
+                    folded_warned.add(tag)
+                    print(
+                        f"[vault_doctor] folded-YAML key skipped "
+                        f"(parser is flat-only): {key} "
+                        f"(file: {source or 'unknown'})",
+                        file=sys.stderr,
+                    )
+                continue
+        out[key] = value
     return out
 
 
@@ -203,6 +236,14 @@ def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
                 file=sys.stderr,
             )
             return None
+        # SF6: parseable lines but no `timestamp` field — log the synthesized
+        # 1-hour window so a future schema variant can't silently produce
+        # confidently-wrong matches.
+        print(
+            f"[vault_doctor] JSONL has no timestamp fields; "
+            f"using synthetic 1h window: {jsonl_path}",
+            file=sys.stderr,
+        )
         first_ts = mtime - 3600
     return (first_ts, mtime)
 
@@ -246,7 +287,17 @@ def _jsonl_dir_for_project(project: str) -> Path | None:
     # same-mtime dirs pick the same winner across runs instead of depending
     # on glob order. Matches the (mtime, path) pattern used for JSONL
     # selection elsewhere in the fast path.
-    return Path(max(viable, key=lambda pair: (pair[1], pair[0]))[0])
+    winner = Path(max(viable, key=lambda pair: (pair[1], pair[0]))[0])
+    if len(viable) > 1:
+        # SF8: silent picker on collision is invisible to operators when a
+        # path-encoding variant masks a real cross-project ambiguity. Log the
+        # candidates + winner so it's auditable.
+        print(
+            f"[vault_doctor] multiple project dirs matched {project}: "
+            f"{[m for m, _ in viable]}; using {winner}",
+            file=sys.stderr,
+        )
+    return winner
 
 
 def _find_jsonl_anywhere(sid: str) -> Path | None:
@@ -281,7 +332,7 @@ def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
             text = entry.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        fm = _parse_frontmatter(text)
+        fm = _parse_frontmatter(text, source=str(entry))
         if not fm:
             if text.startswith("---"):
                 print(
@@ -315,7 +366,7 @@ def _list_session_notes(sessions_dir: Path, project: str) -> dict[str, dict]:
             text = entry.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        fm = _parse_frontmatter(text)
+        fm = _parse_frontmatter(text, source=str(entry))
         if not fm and text.startswith("---"):
             print(
                 f"[vault_doctor] malformed frontmatter, skipped: {entry}",
@@ -452,7 +503,7 @@ def scan(
                 text = note.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
-            fm = _parse_frontmatter(text)
+            fm = _parse_frontmatter(text, source=str(note))
             if "source_session" not in fm:
                 continue  # non-source-session note type (e.g., standups with source_notes[])
             note_project = fm.get("project", "")

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -379,6 +379,25 @@ def scan(
             else:
                 current_source_display = ""
 
+            # Phase 1b — early-exit (issue #93): if current source resolves
+            # to a same-day session note in the project's index, trust it.
+            # Avoids paying for a heuristic match when nothing has changed
+            # and prevents matcher boundary-tie misclassifications on
+            # cross-midnight or multi-session days.
+            #
+            # Only applies for day-precision signals (date, filename, mtime).
+            # When created_at provides a precise sub-day timestamp we trust
+            # the matcher — it has enough resolution to detect intra-day
+            # session boundaries even on multi-session days.
+            if current_sid and current_sid in idx and capture_signal != "created_at":
+                current_session_date = idx[current_sid].get("date", "")
+                note_date = fm.get("date", "")
+                if not note_date:
+                    fn_match = _FILENAME_DATE_RE.match(note.name)
+                    note_date = fn_match.group(1) if fn_match else ""
+                if note_date and current_session_date == note_date:
+                    continue  # current source already correct
+
             match = _find_matching_session(capture_time, jsonl_dir, idx)
             if match is None:
                 # No JSONL window contains the note's capture_time. Flag as unresolved

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -78,9 +78,11 @@ def _parse_frontmatter(text: str, source: str | None = None) -> dict:
     Flat-only by design — multiline scalars, folded YAML (``key:\\n  value``),
     block sequences nested under a key, and other non-flat YAML constructs are
     silently skipped. When a key without a same-line value is followed by an
-    indented continuation line that looks like folded YAML, a one-shot stderr
-    warning is emitted (review SF5) so operators can spot high-confidence
-    signals being silently degraded to mtime fallbacks.
+    indented continuation line that looks like folded YAML, a stderr warning
+    is emitted once per ``(file, key)`` within this parse (review SF5) so
+    operators can spot high-confidence signals being silently degraded to
+    mtime fallbacks. Note: dedup is per-call — the same folded key in two
+    different files (or two re-parses of the same file) will each warn.
 
     Args:
         text: full file contents (frontmatter must start at byte 0).
@@ -312,7 +314,9 @@ def _jsonl_dir_for_project(project: str) -> Path | None:
     return winner
 
 
-def _find_jsonl_anywhere(sid: str) -> Path | None:
+def _find_jsonl_anywhere(
+    sid: str, cache: dict[str, Path | None] | None = None
+) -> Path | None:
     """Locate ~/.claude/projects/*/<sid>.jsonl across all CC project dirs.
 
     UUIDs are globally unique, so this is safe even though it ignores the
@@ -323,10 +327,15 @@ def _find_jsonl_anywhere(sid: str) -> Path | None:
     normalization is irrelevant here — there's no need to normalize the
     input project name (the SID alone is sufficient to disambiguate).
     """
+    if cache is not None and sid in cache:
+        return cache[sid]
     home = os.environ.get("HOME", os.path.expanduser("~"))
     pattern = os.path.join(home, ".claude", "projects", "*", f"{sid}.jsonl")
     matches = sorted(glob.glob(pattern))
-    return Path(matches[0]) if matches else None
+    result = Path(matches[0]) if matches else None
+    if cache is not None:
+        cache[sid] = result
+    return result
 
 
 def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
@@ -501,6 +510,9 @@ def scan(
     session_index_cache: dict[str, dict[str, dict]] = {}
     jsonl_dir_cache: dict[str, Path | None] = {}
     global_sid_index: dict[str, dict] | None = None  # built lazily on first need
+    # Per-scan memoization for _find_jsonl_anywhere — avoids O(N_notes * N_projects)
+    # filesystem walks when many notes hit the worktree-suffixed project fallback.
+    jsonl_anywhere_cache: dict[str, Path | None] = {}
 
     for folder in scan_folders:
         folder_path = vault / folder
@@ -592,7 +604,9 @@ def scan(
                         # I4 fix: when project-dir lookup misses (e.g., worktree-
                         # suffixed project name in the session note), try global
                         # JSONL search by UUID.
-                        fallback_path = _find_jsonl_anywhere(current_sid)
+                        fallback_path = _find_jsonl_anywhere(
+                            current_sid, cache=jsonl_anywhere_cache
+                        )
                         if fallback_path is not None:
                             window = _jsonl_window(str(fallback_path))
                     if day_start is not None and window is not None:
@@ -638,7 +652,9 @@ def scan(
                     # Emit an unresolved diagnostic Issue so operators can see
                     # the coverage gap; UUID is authoritative, so don't propose
                     # a different-session rewrite.
-                    jsonl_path = _find_jsonl_anywhere(current_sid)
+                    jsonl_path = _find_jsonl_anywhere(
+                        current_sid, cache=jsonl_anywhere_cache
+                    )
                     if jsonl_path is not None:
                         issues.append(
                             Issue(
@@ -710,15 +726,39 @@ def scan(
             if match["sid"] == current_sid:
                 continue  # correct
 
-            # Cap confidence on date-only signals: multi-session days collapse
-            # onto a single noon-UTC bucket and produce uniform proposals.
-            # `created_at` is the only signal precise enough for high confidence.
+            # Cap confidence on date-only signals: day-precision matching can still
+            # be ambiguous on multi-session days because multiple windows may overlap
+            # the same UTC calendar day. `created_at` is the only signal precise
+            # enough for high confidence.
             if capture_signal == "created_at":
                 proposed_conf = 0.95
             elif capture_signal == "mtime":
                 proposed_conf = 0.3  # below convergence floor; never auto-apply
             else:
                 proposed_conf = 0.6
+            # Build reason text matching the matcher used: point-in-window
+            # for created_at (timestamp inside session window) vs day-overlap
+            # for date/filename (calendar day overlaps session window).
+            if capture_signal == "created_at":
+                reason = (
+                    f"note capture_time "
+                    f"{datetime.fromtimestamp(capture_time, timezone.utc).isoformat(timespec='seconds')}"
+                    f" (signal={capture_signal}, conf={capture_conf})"
+                    f" matches session {match['sid'][:8]} window, "
+                    f"not current source {current_sid[:8]}"
+                )
+            else:
+                # day-overlap matcher: synthetic capture_time may NOT be inside
+                # the winning session's window — describe the calendar-day match.
+                note_day = datetime.fromtimestamp(
+                    capture_time, timezone.utc
+                ).strftime("%Y-%m-%d")
+                reason = (
+                    f"note calendar day {note_day}"
+                    f" (signal={capture_signal}, conf={capture_conf})"
+                    f" overlaps session {match['sid'][:8]} window most, "
+                    f"not current source {current_sid[:8]}"
+                )
             issues.append(
                 Issue(
                     check=NAME,
@@ -726,13 +766,7 @@ def scan(
                     project=note_project,
                     current_source=current_source_display,
                     proposed_source=f"[[{match['basename']}]]",
-                    reason=(
-                        f"note capture_time "
-                        f"{datetime.fromtimestamp(capture_time, timezone.utc).isoformat(timespec='seconds')}"
-                        f" (signal={capture_signal}, conf={capture_conf})"
-                        f" matches session {match['sid'][:8]} window, "
-                        f"not current source {current_sid[:8]}"
-                    ),
+                    reason=reason,
                     confidence=proposed_conf,
                     extra={
                         "proposed_sid": match["sid"],

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -2,11 +2,14 @@
 
 Detection strategy:
   For each insight-type note with a `source_session` frontmatter field,
-  read the note's file mtime as the "capture time." For each JSONL file
-  under ~/.claude/projects/*<project>/*.jsonl, determine its activity
-  window (first entry timestamp → file mtime). The correct source session
-  is the JSONL whose window contains the note's capture time. Flag as
-  stale whenever the note's current source_session does not match.
+  determine capture-time via an immutable-signal preference chain
+  (`created_at` ISO-8601 → `date` YYYY-MM-DD midday UTC → filename prefix
+  YYYY-MM-DD-... midday UTC → mtime as low-confidence last resort).
+  For each JSONL file under ~/.claude/projects/*<project>/*.jsonl,
+  determine its activity window (first entry timestamp → file mtime).
+  The correct source session is the JSONL whose window contains the
+  note's capture-time. Flag as stale whenever the note's current
+  source_session does not match.
 """
 
 from __future__ import annotations
@@ -346,6 +349,12 @@ def scan(
             if project and note_project.replace("_", "-") != project.replace("_", "-"):
                 continue
 
+            # Capture-time for JSONL-window matching uses immutable signals (issue #93).
+            # mtime above is only the --days cutoff, not the matcher input.
+            capture_time, capture_conf, capture_signal = _capture_time(note, fm)
+            if capture_conf == 0.0:
+                continue  # corrupt note — no usable signal
+
             # Normalize cache key so personal_ws and personal-ws share index
             cache_key = note_project.replace("_", "-")
             if cache_key not in session_index_cache:
@@ -370,7 +379,7 @@ def scan(
             else:
                 current_source_display = ""
 
-            match = _find_matching_session(mtime, jsonl_dir, idx)
+            match = _find_matching_session(capture_time, jsonl_dir, idx)
             if match is None:
                 # No JSONL window contains this mtime. Flag as unresolved ONLY if
                 # the current source doesn't resolve to any known session note — that
@@ -402,8 +411,11 @@ def scan(
                     current_source=current_source_display,
                     proposed_source=f"[[{match['basename']}]]",
                     reason=(
-                        f"note mtime {datetime.fromtimestamp(mtime, timezone.utc).isoformat(timespec='seconds')}"
-                        f" matches session {match['sid'][:8]} window, not current source {current_sid[:8]}"
+                        f"note capture_time "
+                        f"{datetime.fromtimestamp(capture_time, timezone.utc).isoformat(timespec='seconds')}"
+                        f" (signal={capture_signal}, conf={capture_conf})"
+                        f" matches session {match['sid'][:8]} window, "
+                        f"not current source {current_sid[:8]}"
                     ),
                     confidence=0.95,
                     extra={"proposed_sid": match["sid"]},
@@ -521,8 +533,8 @@ def apply(issues, backup_root) -> list[Result]:
             continue
 
         # Capture original stat so we can preserve mtime across the rewrite.
-        # scan() uses note mtime as capture_time for JSONL window matching —
-        # updating mtime on apply would cause re-runs to re-flag fixed notes.
+        # scan() may fall back to mtime for the --days cutoff filter; preserving
+        # mtime prevents the cutoff from silently excluding recently-fixed notes.
         try:
             original_stat = os.stat(issue.note_path)
         except OSError as exc:

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -364,6 +364,47 @@ def _find_matching_session(
     return {**session_note_index[best_sid], "sid": best_sid}
 
 
+def _find_matching_session_by_day_overlap(
+    date_str: str,
+    jsonl_dir: Path | None,
+    session_note_index: dict[str, dict],
+) -> dict | None:
+    """Return the session note dict whose JSONL window has the largest
+    overlap with the UTC calendar day of date_str.
+
+    Used for day-precision signals (`date`, `filename`) where a single
+    capture_time anchor (e.g., noon UTC) excludes morning-only or
+    evening-only sessions. Tie-break: largest overlap, then latest
+    first_ts (mirrors point-match behavior).
+    """
+    if not jsonl_dir or not jsonl_dir.is_dir():
+        return None
+    day_start = _parse_date_ts(date_str, hour=0)
+    if day_start is None:
+        return None
+    day_end = day_start + 86400
+    best_sid: str | None = None
+    best_overlap: float = 0
+    best_first_ts: float = 0
+    for jsonl in sorted(jsonl_dir.glob("*.jsonl")):
+        sid = jsonl.stem
+        if sid not in session_note_index:
+            continue
+        window = _jsonl_window(str(jsonl))
+        if window is None:
+            continue
+        first_ts, last_ts = window
+        overlap = max(0.0, min(day_end, last_ts) - max(day_start, first_ts))
+        if overlap <= 0:
+            continue
+        # Pick largest overlap; tie-break by latest first_ts
+        if (overlap > best_overlap) or (overlap == best_overlap and first_ts > best_first_ts):
+            best_sid, best_overlap, best_first_ts = sid, overlap, first_ts
+    if best_sid is None:
+        return None
+    return {**session_note_index[best_sid], "sid": best_sid}
+
+
 def scan(
     vault_path: str,
     sessions_folder: str,
@@ -520,7 +561,22 @@ def scan(
                     if _find_jsonl_anywhere(current_sid) is not None:
                         continue  # trust UUID, skip matcher
 
-            match = _find_matching_session(capture_time, jsonl_dir, idx)
+            # Day-precision signals: match by greatest overlap with UTC calendar day.
+            # Sub-day precision (created_at): match by point-in-window.
+            if capture_signal == "created_at":
+                match = _find_matching_session(capture_time, jsonl_dir, idx)
+            else:
+                # Derive note's date from frontmatter or filename prefix
+                note_date_for_match = fm.get("date", "")
+                if not note_date_for_match:
+                    fn_match = _FILENAME_DATE_RE.match(note.name)
+                    note_date_for_match = fn_match.group(1) if fn_match else ""
+                if note_date_for_match:
+                    match = _find_matching_session_by_day_overlap(
+                        note_date_for_match, jsonl_dir, idx
+                    )
+                else:
+                    match = _find_matching_session(capture_time, jsonl_dir, idx)
             if match is None:
                 # No JSONL window contains the note's capture_time. Flag as unresolved
                 # ONLY if the current source doesn't resolve to any known session note

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -96,6 +96,24 @@ def _parse_iso_ts(ts: str) -> float | None:
         return None
 
 
+def _parse_date_midpoint(date_str: str) -> float | None:
+    """Parse a YYYY-MM-DD date string to the POSIX timestamp at 12:00 UTC.
+
+    Day-precision input cannot tell us _when_ during the day a note was
+    captured; using midday makes the JSONL-window matcher symmetric across
+    both ends of a multi-session day.
+    """
+    if not date_str:
+        return None
+    try:
+        d = datetime.strptime(date_str, "%Y-%m-%d").replace(
+            hour=12, minute=0, second=0, tzinfo=timezone.utc
+        )
+        return d.timestamp()
+    except ValueError:
+        return None
+
+
 def _jsonl_window(jsonl_path: str) -> tuple[float, float] | None:
     """Return (first_entry_ts, mtime) for a JSONL session file, or None.
 

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -283,6 +283,11 @@ def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
             continue
         fm = _parse_frontmatter(text)
         if not fm:
+            if text.startswith("---"):
+                print(
+                    f"[vault_doctor] malformed frontmatter, skipped: {entry}",
+                    file=sys.stderr,
+                )
             continue
         sid = fm.get("session_id", "")
         if not sid:

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -882,8 +882,11 @@ def apply(issues, backup_root) -> list[Result]:
             continue
 
         # Capture original stat so we can preserve mtime across the rewrite.
-        # scan() may fall back to mtime for the --days cutoff filter; preserving
-        # mtime prevents the cutoff from silently excluding recently-fixed notes.
+        # scan() uses mtime for the --days cutoff filter. If apply() let the
+        # rewrite bump mtime to now, repaired notes would re-enter the scan
+        # window every run (and could be re-flagged via mtime-fallback signal
+        # if their immutable signals are ever lost). Preserving the original
+        # mtime keeps the rewrite invisible to the cutoff filter.
         try:
             original_stat = os.stat(issue.note_path)
         except OSError as exc:

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -922,7 +922,12 @@ def apply(issues, backup_root) -> list[Result]:
                     backup_path=str(backup_path),
                 )
             )
-        except Exception as exc:  # per-issue isolation; don't abort the loop
+        except (OSError, ValueError, UnicodeDecodeError) as exc:
+            # SF9: narrowed from bare `except Exception` so MemoryError,
+            # RecursionError, and other non-I/O failures propagate instead
+            # of being misreported as ordinary per-issue rewrite failures.
+            # KeyboardInterrupt and SystemExit are BaseException, not Exception,
+            # and were never caught by the original handler.
             results.append(
                 Result(
                     check=NAME,

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -99,33 +99,35 @@ def _parse_iso_ts(ts: str) -> float | None:
         return None
 
 
-def _parse_date_midpoint(date_str: str) -> float | None:
-    """Parse a YYYY-MM-DD date string to the POSIX timestamp at 12:00 UTC.
+def _parse_date_ts(date_str: str, hour: int = 0) -> float | None:
+    """Parse a YYYY-MM-DD date string to a POSIX timestamp at `hour`:00 UTC.
 
-    Day-precision input cannot tell us _when_ during the day a note was
-    captured; using midday makes the JSONL-window matcher symmetric across
-    both ends of a multi-session day.
+    `hour=12` (midday) is used for capture-time matching: day-precision input
+    cannot tell us _when_ during the day a note was captured, so midday makes
+    the JSONL-window matcher symmetric across both ends of a multi-session day.
+
+    `hour=0` (midnight) is used for calendar-day-overlap checks against a
+    JSONL window in Phase 1b.
     """
     if not date_str:
         return None
     try:
         d = datetime.strptime(date_str, "%Y-%m-%d").replace(
-            hour=12, minute=0, second=0, tzinfo=timezone.utc
+            hour=hour, tzinfo=timezone.utc
         )
         return d.timestamp()
     except ValueError:
         return None
 
 
+def _parse_date_midpoint(date_str: str) -> float | None:
+    """Compatibility shim: return the POSIX timestamp at 12:00 UTC of date_str."""
+    return _parse_date_ts(date_str, hour=12)
+
+
 def _parse_date_start(date_str: str) -> float | None:
-    """Parse YYYY-MM-DD to POSIX timestamp at 00:00 UTC of that day, or None."""
-    if not date_str:
-        return None
-    try:
-        d = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
-        return d.timestamp()
-    except ValueError:
-        return None
+    """Compatibility shim: return the POSIX timestamp at 00:00 UTC of date_str."""
+    return _parse_date_ts(date_str, hour=0)
 
 
 # Filename prefix YYYY-MM-DD-...

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -136,12 +136,14 @@ def _parse_iso_ts(ts: str) -> float | None:
 def _parse_date_ts(date_str: str, hour: int = 0) -> float | None:
     """Parse a YYYY-MM-DD date string to a POSIX timestamp at `hour`:00 UTC.
 
-    `hour=12` (midday) is used for capture-time matching: day-precision input
-    cannot tell us _when_ during the day a note was captured, so midday makes
-    the JSONL-window matcher symmetric across both ends of a multi-session day.
+    `hour=12` (midday) is used for the diagnostic reason text (the
+    capture_time printed in Issue.reason) and for created_at-style
+    point-in-window matching as a degraded fallback. It is NOT used by the
+    primary day-overlap matcher — that path calls _parse_date_ts(date, hour=0)
+    directly to compute day_start, and derives day_end as day_start + 86400.
 
     `hour=0` (midnight) is used for calendar-day-overlap checks against a
-    JSONL window in Phase 1b.
+    JSONL window in Phase 1b and in _find_matching_session_by_day_overlap.
     """
     if not date_str:
         return None
@@ -155,12 +157,22 @@ def _parse_date_ts(date_str: str, hour: int = 0) -> float | None:
 
 
 def _parse_date_midpoint(date_str: str) -> float | None:
-    """Compatibility shim: return the POSIX timestamp at 12:00 UTC of date_str."""
+    """Return the POSIX timestamp at 12:00 UTC of a YYYY-MM-DD date_str.
+
+    Used by _capture_time to convert day-precision signals (frontmatter
+    `date`, filename prefix) into a single capture-time anchor for the
+    diagnostic reason field. The day-overlap matcher uses _parse_date_ts
+    directly with hour=0; this helper is for point-anchor consumers.
+    """
     return _parse_date_ts(date_str, hour=12)
 
 
 def _parse_date_start(date_str: str) -> float | None:
-    """Compatibility shim: return the POSIX timestamp at 00:00 UTC of date_str."""
+    """Return the POSIX timestamp at 00:00 UTC of a YYYY-MM-DD date_str.
+
+    Currently unused in the production code path; retained as a
+    symmetric public helper in case future checks need a midnight anchor.
+    """
     return _parse_date_ts(date_str, hour=0)
 
 
@@ -306,6 +318,10 @@ def _find_jsonl_anywhere(sid: str) -> Path | None:
     UUIDs are globally unique, so this is safe even though it ignores the
     project-name index. Returns the first match (deterministic via sorted)
     or None.
+
+    The project segment uses ``*`` so CC's underscore-to-hyphen slug
+    normalization is irrelevant here — there's no need to normalize the
+    input project name (the SID alone is sufficient to disambiguate).
     """
     home = os.environ.get("HOME", os.path.expanduser("~"))
     pattern = os.path.join(home, ".claude", "projects", "*", f"{sid}.jsonl")
@@ -512,7 +528,7 @@ def scan(
             if project and note_project.replace("_", "-") != project.replace("_", "-"):
                 continue
 
-            # Capture-time for JSONL-window matching uses immutable signals (issue #93).
+            # Capture-time for JSONL-window matching uses immutable signals.
             # mtime above is only the --days cutoff, not the matcher input.
             capture_time, capture_conf, capture_signal = _capture_time(note, fm)
             if capture_conf == 0.0:
@@ -542,7 +558,7 @@ def scan(
             else:
                 current_source_display = ""
 
-            # Phase 1b — UUID-first authoritative signal (issue #93):
+            # Phase 1b — UUID-first authoritative signal:
             # if current source's UUID resolves to ANY session note in the
             # vault (cross-project, since worktree-launched skills may write
             # `project:` from main-repo cwd while their source session ran
@@ -726,7 +742,7 @@ def scan(
                 )
             )
 
-    # Convergence guard (issue #93): if multiple flags in a project propose
+    # Convergence guard: if multiple flags in a project propose
     # the same target session, the date-window heuristic has structurally
     # collapsed across a multi-session day. Lower confidence and tag for
     # operator review.

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -521,6 +521,13 @@ def scan(
                         jsonl_path = sess_jsonl_dir / f"{current_sid}.jsonl"
                         if jsonl_path.exists():
                             window = _jsonl_window(str(jsonl_path))
+                    if window is None:
+                        # I4 fix: when project-dir lookup misses (e.g., worktree-
+                        # suffixed project name in the session note), try global
+                        # JSONL search by UUID.
+                        fallback_path = _find_jsonl_anywhere(current_sid)
+                        if fallback_path is not None:
+                            window = _jsonl_window(str(fallback_path))
                     if day_start is not None and window is not None:
                         day_end = day_start + 86400
                         first_ts, last_ts = window

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -249,6 +249,19 @@ def _jsonl_dir_for_project(project: str) -> Path | None:
     return Path(max(viable, key=lambda pair: (pair[1], pair[0]))[0])
 
 
+def _find_jsonl_anywhere(sid: str) -> Path | None:
+    """Locate ~/.claude/projects/*/<sid>.jsonl across all CC project dirs.
+
+    UUIDs are globally unique, so this is safe even though it ignores the
+    project-name index. Returns the first match (deterministic via sorted)
+    or None.
+    """
+    home = os.environ.get("HOME", os.path.expanduser("~"))
+    pattern = os.path.join(home, ".claude", "projects", "*", f"{sid}.jsonl")
+    matches = sorted(glob.glob(pattern))
+    return Path(matches[0]) if matches else None
+
+
 def _list_all_session_notes(sessions_dir: Path) -> dict[str, dict]:
     """Map session_id → {path, basename, date, project} across ALL projects.
 
@@ -499,6 +512,13 @@ def scan(
                                     )
                                 )
                             continue  # UUID is authoritative either way; skip matcher
+                else:
+                    # UUID not in session-note index — but a real JSONL may
+                    # still exist (SessionEnd hook missed; see issue #98).
+                    # In that case, the UUID is authoritative; refuse to
+                    # propose a different-session rewrite.
+                    if _find_jsonl_anywhere(current_sid) is not None:
+                        continue  # trust UUID, skip matcher
 
             match = _find_matching_session(capture_time, jsonl_dir, idx)
             if match is None:

--- a/skills/compress/SKILL.md
+++ b/skills/compress/SKILL.md
@@ -290,6 +290,7 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-insight
 date: YYYY-MM-DD
+created_at: <ISO-8601-UTC>
 source_session: <current-session-id>
 source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
@@ -307,6 +308,11 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<ISO-8601-UTC>` is the current UTC timestamp at second precision. Get it via:
+  ```bash
+  python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="seconds"))'
+  ```
+  Example: `2026-04-24T18:42:11+00:00`
 - `<current-session-id>` and `<session-note-filename>` are derived together. Get session context via the shared helper:
 
   ```bash

--- a/skills/decide/SKILL.md
+++ b/skills/decide/SKILL.md
@@ -102,6 +102,7 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-decision
 date: YYYY-MM-DD
+created_at: <ISO-8601-UTC>
 source_session: <current-session-id>
 source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
@@ -142,6 +143,11 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<ISO-8601-UTC>` is the current UTC timestamp at second precision. Get it via:
+  ```bash
+  python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="seconds"))'
+  ```
+  Example: `2026-04-24T18:42:11+00:00`
 - `<current-session-id>` and `<session-note-filename>` are derived together. Get session context via the shared helper:
 
   ```bash

--- a/skills/error-log/SKILL.md
+++ b/skills/error-log/SKILL.md
@@ -100,6 +100,7 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-error-fix
 date: YYYY-MM-DD
+created_at: <ISO-8601-UTC>
 source_session: <current-session-id>
 source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
@@ -131,6 +132,11 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<ISO-8601-UTC>` is the current UTC timestamp at second precision. Get it via:
+  ```bash
+  python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="seconds"))'
+  ```
+  Example: `2026-04-24T18:42:11+00:00`
 - `<current-session-id>` and `<session-note-filename>` are derived together. Get session context via the shared helper:
 
   ```bash

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -121,6 +121,7 @@ Present the full note to the user including frontmatter:
 ---
 type: claude-retro
 date: YYYY-MM-DD
+created_at: <ISO-8601-UTC>
 source_session: <current-session-id>
 source_session_note: "[[<session-note-filename>]]"
 project: <project-name>
@@ -146,6 +147,11 @@ tags:
 
 Where:
 - `YYYY-MM-DD` is today's date
+- `<ISO-8601-UTC>` is the current UTC timestamp at second precision. Get it via:
+  ```bash
+  python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec="seconds"))'
+  ```
+  Example: `2026-04-24T18:42:11+00:00`
 - `<current-session-id>` and `<session-note-filename>` are derived from Step 5
 - `<project-name>` is derived from the current working directory name (basename of the git repo root or cwd)
 - The `source_session_note` field creates an Obsidian backlink from the retro to its source session

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -86,10 +86,15 @@ Parse the JSON and present a grouped-by-project table.
 For each issue, after the `proposed:` line (when present), render a
 `signal: <capture_signal> (conf <capture_confidence>)` line. The values
 come from the top-level `capture_signal` and `capture_confidence` fields
-in the JSON payload (not from `extra.*`). This makes heuristic-fall cases
-visible to the operator before they decide whether to apply (e.g.,
-`signal=mtime conf=0.3` indicates no immutable signal was available — the
-operator should sample a few flagged notes before running `fix`). For
+in the JSON payload (not from `extra.*`). `capture_confidence` reports
+how reliable the capture-time *signal* is (created_at=1.0, date=0.9,
+filename=0.85, mtime=0.5); the issue's top-level `confidence` field
+reports the *rewrite-proposal* confidence (created_at=0.95, mtime=0.3,
+otherwise 0.6) that gates `--apply --min-confidence`. The two are
+distinct — render `capture_confidence` here so heuristic-fall cases
+are visible (e.g., `signal=mtime conf=0.5` indicates no immutable
+signal was available — the operator should sample a few flagged
+notes before running `fix`). For
 unresolved issues with no `proposed:` line, render `signal:` after `reason:`.
 When `convergence_warning` is `true` in the issue, prefix the issue line
 with `[CONVERGED <N> flags]` where `N` is `convergence_count`.
@@ -105,15 +110,15 @@ vault_doctor report — 3 issue(s) across 1 check(s)
 [FAIL] 2026-04-10-recall-profiling.md
   current:  [[2026-04-09-obsidian-brain-abcd]]
   proposed: [[2026-04-10-obsidian-brain-ef01]]
-  signal:   date (conf 0.6)
-  reason:   note date 2026-04-10 (signal=date, conf=0.6) matches session ef010000 window, not current source abcd0000
+  signal:   date (conf 0.9)
+  reason:   note calendar day 2026-04-10 (signal=date, conf=0.9) overlaps session ef010000 window most, not current source abcd0000
 
 ### Project: tiny-vacation-agent (1 issue)
 [FAIL] 2026-04-11-enrichment-scope.md
   current:  [[2026-04-10-tiny-vacation-agent-aaaa]]
   proposed: [[2026-04-11-tiny-vacation-agent-bbbb]]
-  signal:   created_at (conf 0.95)
-  reason:   note created_at 2026-04-11T09:15 (signal=created_at, conf=0.95) matches session bbbb0000 window, not current source aaaa0000
+  signal:   created_at (conf 1.0)
+  reason:   note capture_time 2026-04-11T09:15:00+00:00 (signal=created_at, conf=1.0) matches session bbbb0000 window, not current source aaaa0000
 ```
 
 Use `[FAIL]` for actionable issues (those with a proposed fix) and `[WARN]` for unresolved ones (those the check could not auto-repair). Always include a one-line summary at the top with the total count.

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -105,15 +105,15 @@ vault_doctor report — 3 issue(s) across 1 check(s)
 [FAIL] 2026-04-10-recall-profiling.md
   current:  [[2026-04-09-obsidian-brain-abcd]]
   proposed: [[2026-04-10-obsidian-brain-ef01]]
-  signal:   date (conf 0.9)
-  reason:   note capture_time 2026-04-10T12:00 (signal=date, conf=0.9) matches session ef010000 window, not current source abcd0000
+  signal:   date (conf 0.6)
+  reason:   note date 2026-04-10 (signal=date, conf=0.6) matches session ef010000 window, not current source abcd0000
 
 ### Project: tiny-vacation-agent (1 issue)
 [FAIL] 2026-04-11-enrichment-scope.md
   current:  [[2026-04-10-tiny-vacation-agent-aaaa]]
   proposed: [[2026-04-11-tiny-vacation-agent-bbbb]]
-  signal:   date (conf 0.9)
-  reason:   note capture_time 2026-04-11T09:15 (signal=date, conf=0.9) matches session bbbb0000 window, not current source aaaa0000
+  signal:   created_at (conf 0.95)
+  reason:   note created_at 2026-04-11T09:15 (signal=created_at, conf=0.95) matches session bbbb0000 window, not current source aaaa0000
 ```
 
 Use `[FAIL]` for actionable issues (those with a proposed fix) and `[WARN]` for unresolved ones (those the check could not auto-repair). Always include a one-line summary at the top with the total count.

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -81,7 +81,18 @@ If exit code is `3`, surface the stderr message directly to the user and stop.
 
 ### Step 3 — Present the report to the user
 
-Parse the JSON and present a grouped-by-project table. Example:
+Parse the JSON and present a grouped-by-project table.
+
+For each issue, after the `proposed:` line (when present), render a
+`signal: <capture_signal> (conf <capture_confidence>)` line. The values
+come from `extra.capture_signal` and `extra.capture_confidence` in the
+JSON payload. This makes heuristic-fall cases visible to the operator
+before they decide whether to apply (e.g., `signal=mtime conf=0.5`
+indicates no immutable signal was available — the operator should
+sample a few flagged notes before running `fix`). For unresolved
+issues with no `proposed:` line, render `signal:` after `reason:`.
+
+Example:
 
 ```
 vault_doctor report — 3 issue(s) across 1 check(s)
@@ -92,13 +103,15 @@ vault_doctor report — 3 issue(s) across 1 check(s)
 [FAIL] 2026-04-10-recall-profiling.md
   current:  [[2026-04-09-obsidian-brain-abcd]]
   proposed: [[2026-04-10-obsidian-brain-ef01]]
-  reason:   note mtime 2026-04-10T14:22 matches session ef010000 window...
+  signal:   date (conf 0.9)
+  reason:   note capture_time 2026-04-10T12:00 (signal=date, conf=0.9) matches session ef010000 window, not current source abcd0000
 
 ### Project: tiny-vacation-agent (1 issue)
 [FAIL] 2026-04-11-enrichment-scope.md
   current:  [[2026-04-10-tiny-vacation-agent-aaaa]]
   proposed: [[2026-04-11-tiny-vacation-agent-bbbb]]
-  reason:   note mtime 2026-04-11T09:15 matches session bbbb0000 window...
+  signal:   date (conf 0.9)
+  reason:   note capture_time 2026-04-11T09:15 (signal=date, conf=0.9) matches session bbbb0000 window, not current source aaaa0000
 ```
 
 Use `[FAIL]` for actionable issues (those with a proposed fix) and `[WARN]` for unresolved ones (those the check could not auto-repair). Always include a one-line summary at the top with the total count.

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -85,12 +85,14 @@ Parse the JSON and present a grouped-by-project table.
 
 For each issue, after the `proposed:` line (when present), render a
 `signal: <capture_signal> (conf <capture_confidence>)` line. The values
-come from `extra.capture_signal` and `extra.capture_confidence` in the
-JSON payload. This makes heuristic-fall cases visible to the operator
-before they decide whether to apply (e.g., `signal=mtime conf=0.5`
-indicates no immutable signal was available — the operator should
-sample a few flagged notes before running `fix`). For unresolved
-issues with no `proposed:` line, render `signal:` after `reason:`.
+come from the top-level `capture_signal` and `capture_confidence` fields
+in the JSON payload (not from `extra.*`). This makes heuristic-fall cases
+visible to the operator before they decide whether to apply (e.g.,
+`signal=mtime conf=0.3` indicates no immutable signal was available — the
+operator should sample a few flagged notes before running `fix`). For
+unresolved issues with no `proposed:` line, render `signal:` after `reason:`.
+When `convergence_warning` is `true` in the issue, prefix the issue line
+with `[CONVERGED <N> flags]` where `N` is `convergence_count`.
 
 Example:
 

--- a/templates/decision.md
+++ b/templates/decision.md
@@ -1,6 +1,7 @@
 ---
 type: claude-decision
 date: {{date}}
+created_at: {{created_at}}
 source_session: {{source_session}}
 source_session_note: "{{source_session_note}}"
 project: {{project}}

--- a/templates/error-fix.md
+++ b/templates/error-fix.md
@@ -1,6 +1,7 @@
 ---
 type: claude-error-fix
 date: {{date}}
+created_at: {{created_at}}
 source_session: {{source_session}}
 source_session_note: "{{source_session_note}}"
 project: {{project}}

--- a/templates/insight.md
+++ b/templates/insight.md
@@ -1,6 +1,7 @@
 ---
 type: claude-insight
 date: {{date}}
+created_at: {{created_at}}
 source_session: {{source_session}}
 source_session_note: "{{source_session_note}}"
 project: {{project}}

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -2158,3 +2158,75 @@ def test_extract_session_metadata_returns_canonical_project(tmp_path):
     # project_path should still be the WORKTREE path, since that's where
     # the session actually ran.
     assert meta["project_path"] == str(worktree)
+
+
+def test_get_session_context_cache_key_isolates_distinct_worktrees(tmp_path, monkeypatch):
+    """T7: get_session_context's cache must isolate distinct worktrees of
+    the same repo so a call from one worktree doesn't return cached state
+    from a sibling worktree.
+
+    Distinct worktrees have distinct CC session_ids (each owns its own
+    JSONL), so the per-session cache file (~/.claude/obsidian-brain/cache-<sid>.json)
+    is naturally partitioned by session. The cache_key within that file
+    includes (vault_path, sessions_folder) — anything else that varies
+    across worktrees (e.g., note basenames in vault_path) would still
+    collide because vault_path is shared across worktrees.
+
+    This test verifies the realistic case: two sessions with different
+    SIDs from two worktrees produce different cache files, so call 2
+    cannot inherit call 1's value. If a future change moves the cache
+    file to be SID-independent without adding a worktree-discriminator
+    to cache_key, this test will fail.
+    """
+    monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(tmp_path / "cache-"))
+
+    repo = tmp_path / "obsidian-brain"
+    repo.mkdir()
+    _init_git_repo(repo)
+    worktree = tmp_path / "obsidian-brain--issue-93"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/issue-93", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+
+    vault = tmp_path / "vault"
+    sessions_dir = vault / "claude-sessions"
+    sessions_dir.mkdir(parents=True)
+
+    # Simulate two distinct CC sessions: SID1 (from main repo) and SID2 (from worktree)
+    sid1 = "11111111-1111-1111-1111-111111111111"
+    sid2 = "22222222-2222-2222-2222-222222222222"
+
+    # Place a session note matching SID1's hash so the basename lookup
+    # produces a non-default value worth caching/comparing.
+    h1 = hashlib.sha256(sid1.encode()).hexdigest()[:4]
+    h2 = hashlib.sha256(sid2.encode()).hexdigest()[:4]
+    (sessions_dir / f"2026-04-25-obsidian-brain-{h1}.md").write_text(
+        "---\nsession_id: " + sid1 + "\n---\n", encoding="utf-8"
+    )
+    (sessions_dir / f"2026-04-25-obsidian-brain-{h2}.md").write_text(
+        "---\nsession_id: " + sid2 + "\n---\n", encoding="utf-8"
+    )
+
+    # Call 1: from main repo with SID1
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid1)
+    ctx1 = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+    assert ctx1["session_id"] == sid1
+    assert ctx1["hash"] == h1
+
+    # Call 2: from worktree with SID2 — must NOT return ctx1's hash
+    monkeypatch.chdir(worktree)
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid2)
+    ctx2 = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+    assert ctx2["session_id"] == sid2, (
+        f"cache leaked across worktrees: expected SID2 ({sid2}), got "
+        f"{ctx2['session_id']}"
+    )
+    assert ctx2["hash"] == h2, (
+        f"cache leaked across worktrees: expected hash {h2}, got {ctx2['hash']}"
+    )
+    # And canonical project naming must agree on both calls
+    assert ctx1["project"] == ctx2["project"] == "obsidian-brain"

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -2109,6 +2109,20 @@ def test_canonical_project_name_normalizes_underscores(tmp_path, monkeypatch):
     assert obsidian_utils.canonical_project_name() == "snake-case-repo"
 
 
+def test_canonical_project_name_handles_deleted_cwd(monkeypatch):
+    """When the current working directory has been deleted (e.g., a worktree
+    removed mid-session via `gh pr merge --delete-branch`), os.getcwd() raises
+    FileNotFoundError. Hooks must exit 0, so canonical_project_name returns
+    'unknown' rather than propagating the exception (review C4)."""
+    def _raise_fnf(*args, **kwargs):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(obsidian_utils.os, "getcwd", _raise_fnf)
+    monkeypatch.setattr(
+        obsidian_utils, "_git_canonical_project_name", lambda cwd=None: None
+    )
+    assert obsidian_utils.canonical_project_name(None) == "unknown"
+
+
 def test_get_session_context_returns_canonical_project(tmp_path, monkeypatch):
     """get_session_context's `project` field uses canonical naming."""
     repo = tmp_path / "obsidian-brain"

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -4,11 +4,19 @@
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import uuid
 from pathlib import Path
 
 import pytest
+
+# Tests that shell out to `git` need it on PATH; skip cleanly otherwise so
+# CI/dev environments without git don't hard-fail (Copilot R5).
+_GIT_AVAILABLE = shutil.which("git") is not None
+_REQUIRES_GIT = pytest.mark.skipif(
+    not _GIT_AVAILABLE, reason="git binary not available on PATH"
+)
 
 import obsidian_utils
 
@@ -2046,8 +2054,13 @@ class TestUpgradeBatch:
 
 
 def _init_git_repo(path: Path) -> None:
-    """Create a minimal git repo at `path` for testing."""
-    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    """Create a minimal git repo at `path` for testing.
+
+    Uses `git init` without `-b <branch>` so the helper works on older git
+    versions that predate that flag (Copilot R5). The default branch name
+    isn't asserted on by any caller — only the repo basename matters.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
     subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
     subprocess.run(["git", "config", "user.name", "test"], cwd=path, check=True)
     (path / "README.md").write_text("init")
@@ -2055,6 +2068,7 @@ def _init_git_repo(path: Path) -> None:
     subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
 
 
+@_REQUIRES_GIT
 def test_canonical_project_name_main_repo(tmp_path, monkeypatch):
     """In the main repo, canonical name = repo basename."""
     repo = tmp_path / "my-project"
@@ -2064,6 +2078,7 @@ def test_canonical_project_name_main_repo(tmp_path, monkeypatch):
     assert obsidian_utils.canonical_project_name() == "my-project"
 
 
+@_REQUIRES_GIT
 def test_canonical_project_name_in_worktree(tmp_path, monkeypatch):
     """In a worktree, canonical name = main repo basename, not worktree basename."""
     repo = tmp_path / "my-project"
@@ -2082,6 +2097,7 @@ def test_canonical_project_name_in_worktree(tmp_path, monkeypatch):
     assert obsidian_utils.canonical_project_name() == "my-project"
 
 
+@_REQUIRES_GIT
 def test_canonical_project_name_falls_back_outside_git(tmp_path, monkeypatch):
     """Outside a git repo, fall back to cwd basename."""
     nongit = tmp_path / "Plain Folder"
@@ -2091,6 +2107,7 @@ def test_canonical_project_name_falls_back_outside_git(tmp_path, monkeypatch):
     assert obsidian_utils.canonical_project_name() == "plain-folder"
 
 
+@_REQUIRES_GIT
 def test_canonical_project_name_explicit_cwd_arg(tmp_path):
     """Explicit cwd= arg used instead of process cwd."""
     repo = tmp_path / "sample-repo"
@@ -2100,6 +2117,7 @@ def test_canonical_project_name_explicit_cwd_arg(tmp_path):
     assert obsidian_utils.canonical_project_name(cwd=str(repo)) == "sample-repo"
 
 
+@_REQUIRES_GIT
 def test_canonical_project_name_normalizes_underscores(tmp_path, monkeypatch):
     """Underscores and spaces normalize to hyphens, lowercase."""
     repo = tmp_path / "Snake_Case_Repo"
@@ -2125,6 +2143,7 @@ def test_canonical_project_name_handles_deleted_cwd(monkeypatch):
     assert obsidian_utils.canonical_project_name(None) == "unknown"
 
 
+@_REQUIRES_GIT
 def test_canonical_project_name_no_warn_when_not_a_repo(tmp_path, monkeypatch, capsys):
     """Copilot R2: the SF7 warning must NOT fire for the normal 'cwd is not
     inside a git repo' case (returncode != 0). That's an expected operating
@@ -2171,6 +2190,7 @@ def test_canonical_project_name_warns_once_when_git_unavailable(monkeypatch, cap
     assert "git-unavailable" in captured.err
 
 
+@_REQUIRES_GIT
 def test_git_canonical_project_name_with_reason_distinguishes_failure_modes(
     tmp_path, monkeypatch
 ):
@@ -2194,6 +2214,7 @@ def test_git_canonical_project_name_with_reason_distinguishes_failure_modes(
     assert reason == "git-unavailable"
 
 
+@_REQUIRES_GIT
 def test_get_session_context_returns_canonical_project(tmp_path, monkeypatch):
     """get_session_context's `project` field uses canonical naming."""
     repo = tmp_path / "obsidian-brain"
@@ -2212,6 +2233,7 @@ def test_get_session_context_returns_canonical_project(tmp_path, monkeypatch):
     assert ctx["project"] == "obsidian-brain"
 
 
+@_REQUIRES_GIT
 def test_extract_session_metadata_returns_canonical_project(tmp_path):
     """extract_session_metadata's `project` field uses canonical naming."""
     repo = tmp_path / "obsidian-brain"
@@ -2231,6 +2253,7 @@ def test_extract_session_metadata_returns_canonical_project(tmp_path):
     assert meta["project_path"] == str(worktree)
 
 
+@_REQUIRES_GIT
 def test_get_session_context_cache_key_isolates_distinct_worktrees(tmp_path, monkeypatch):
     """T7: get_session_context's cache must isolate distinct worktrees of
     the same repo so a call from one worktree doesn't return cached state

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -4,7 +4,9 @@
 import hashlib
 import json
 import os
+import subprocess
 import uuid
+from pathlib import Path
 
 import pytest
 
@@ -2036,3 +2038,109 @@ class TestUpgradeBatch:
         assert "status: summarized" in updated
         assert "## Summary" in updated
         assert "Did a thing." in updated
+
+
+# ===========================================================================
+# Section N: canonical_project_name — worktree-aware project name derivation
+# ===========================================================================
+
+
+def _init_git_repo(path: Path) -> None:
+    """Create a minimal git repo at `path` for testing."""
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=path, check=True)
+    (path / "README.md").write_text("init")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+
+
+def test_canonical_project_name_main_repo(tmp_path, monkeypatch):
+    """In the main repo, canonical name = repo basename."""
+    repo = tmp_path / "my-project"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    assert obsidian_utils.canonical_project_name() == "my-project"
+
+
+def test_canonical_project_name_in_worktree(tmp_path, monkeypatch):
+    """In a worktree, canonical name = main repo basename, not worktree basename."""
+    repo = tmp_path / "my-project"
+    repo.mkdir()
+    _init_git_repo(repo)
+    worktree = tmp_path / "my-project--feature-branch"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/x", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.chdir(worktree)
+    # Despite the worktree's directory basename being "my-project--feature-branch",
+    # canonical_project_name returns the main-repo's basename.
+    assert obsidian_utils.canonical_project_name() == "my-project"
+
+
+def test_canonical_project_name_falls_back_outside_git(tmp_path, monkeypatch):
+    """Outside a git repo, fall back to cwd basename."""
+    nongit = tmp_path / "Plain Folder"
+    nongit.mkdir()
+    monkeypatch.chdir(nongit)
+    # The fallback applies normalization (spaces → hyphens, lowercase).
+    assert obsidian_utils.canonical_project_name() == "plain-folder"
+
+
+def test_canonical_project_name_explicit_cwd_arg(tmp_path):
+    """Explicit cwd= arg used instead of process cwd."""
+    repo = tmp_path / "sample-repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    # Note: NOT chdir-ing — using cwd= arg explicitly.
+    assert obsidian_utils.canonical_project_name(cwd=str(repo)) == "sample-repo"
+
+
+def test_canonical_project_name_normalizes_underscores(tmp_path, monkeypatch):
+    """Underscores and spaces normalize to hyphens, lowercase."""
+    repo = tmp_path / "Snake_Case_Repo"
+    repo.mkdir()
+    _init_git_repo(repo)
+    monkeypatch.chdir(repo)
+    assert obsidian_utils.canonical_project_name() == "snake-case-repo"
+
+
+def test_get_session_context_returns_canonical_project(tmp_path, monkeypatch):
+    """get_session_context's `project` field uses canonical naming."""
+    repo = tmp_path / "obsidian-brain"
+    repo.mkdir()
+    _init_git_repo(repo)
+    worktree = tmp_path / "obsidian-brain--issue-93"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/issue-93", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    monkeypatch.chdir(worktree)
+    # session_id may be 'unknown' in test env — that's fine; we only check project.
+    ctx = obsidian_utils.get_session_context()
+    assert ctx["project"] == "obsidian-brain"
+
+
+def test_extract_session_metadata_returns_canonical_project(tmp_path):
+    """extract_session_metadata's `project` field uses canonical naming."""
+    repo = tmp_path / "obsidian-brain"
+    repo.mkdir()
+    _init_git_repo(repo)
+    worktree = tmp_path / "obsidian-brain--issue-93"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feature/issue-93", str(worktree)],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+    )
+    meta = obsidian_utils.extract_session_metadata([], cwd=str(worktree))
+    assert meta["project"] == "obsidian-brain"
+    # project_path should still be the WORKTREE path, since that's where
+    # the session actually ran.
+    assert meta["project_path"] == str(worktree)

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -2118,9 +2118,80 @@ def test_canonical_project_name_handles_deleted_cwd(monkeypatch):
         raise FileNotFoundError("cwd deleted")
     monkeypatch.setattr(obsidian_utils.os, "getcwd", _raise_fnf)
     monkeypatch.setattr(
-        obsidian_utils, "_git_canonical_project_name", lambda cwd=None: None
+        obsidian_utils,
+        "_git_canonical_project_name_with_reason",
+        lambda cwd=None: (None, "not-a-repo"),
     )
     assert obsidian_utils.canonical_project_name(None) == "unknown"
+
+
+def test_canonical_project_name_no_warn_when_not_a_repo(tmp_path, monkeypatch, capsys):
+    """Copilot R2: the SF7 warning must NOT fire for the normal 'cwd is not
+    inside a git repo' case (returncode != 0). That's an expected operating
+    condition; warning would be noise.
+    """
+    monkeypatch.setattr(obsidian_utils, "_git_fallback_warned", False)
+    nongit = tmp_path / "Plain Folder"
+    nongit.mkdir()
+    monkeypatch.chdir(nongit)
+    capsys.readouterr()  # drain
+    assert obsidian_utils.canonical_project_name() == "plain-folder"
+    captured = capsys.readouterr()
+    assert "[obsidian_utils]" not in captured.err, (
+        f"warning should not fire for not-a-repo case, got stderr: {captured.err!r}"
+    )
+
+
+def test_canonical_project_name_warns_once_when_git_unavailable(monkeypatch, capsys):
+    """Copilot R2: the SF7 warning fires for genuine git errors
+    (git-unavailable / empty-output / resolve-failed) and is one-shot per
+    process. Multiple calls produce exactly one stderr line.
+    """
+    monkeypatch.setattr(obsidian_utils, "_git_fallback_warned", False)
+    monkeypatch.setattr(
+        obsidian_utils,
+        "_git_canonical_project_name_with_reason",
+        lambda cwd=None: (None, "git-unavailable"),
+    )
+    monkeypatch.setattr(obsidian_utils.os, "getcwd", lambda: "/tmp/some-dir")
+    capsys.readouterr()  # drain
+
+    obsidian_utils.canonical_project_name()
+    obsidian_utils.canonical_project_name()
+    obsidian_utils.canonical_project_name()
+
+    captured = capsys.readouterr()
+    occurrences = captured.err.count(
+        "[obsidian_utils] canonical_project_name: git error"
+    )
+    assert occurrences == 1, (
+        f"warning should fire exactly once across 3 calls, got {occurrences} "
+        f"in stderr: {captured.err!r}"
+    )
+    assert "git-unavailable" in captured.err
+
+
+def test_git_canonical_project_name_with_reason_distinguishes_failure_modes(
+    tmp_path, monkeypatch
+):
+    """The new (name, reason) helper distinguishes: ok / not-a-repo /
+    git-unavailable / empty-output / resolve-failed. Used by canonical_project_name
+    to suppress noise for the common 'not-a-repo' case (Copilot R2).
+    """
+    # not-a-repo: real fs, no .git
+    nongit = tmp_path / "no-repo"
+    nongit.mkdir()
+    name, reason = obsidian_utils._git_canonical_project_name_with_reason(str(nongit))
+    assert name is None
+    assert reason == "not-a-repo"
+
+    # git-unavailable: subprocess.run raises OSError
+    def _raise(*args, **kwargs):
+        raise OSError("git binary missing")
+    monkeypatch.setattr(obsidian_utils.subprocess, "run", _raise)
+    name, reason = obsidian_utils._git_canonical_project_name_with_reason(str(nongit))
+    assert name is None
+    assert reason == "git-unavailable"
 
 
 def test_get_session_context_returns_canonical_project(tmp_path, monkeypatch):

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -54,12 +54,14 @@ def test_cli_dry_run_reports_issues(tmp_path):
     claude_home = tmp_path / ".claude" / "projects" / "-x-proj1"
     claude_home.mkdir(parents=True)
 
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
     (claude_home / "sid-b.jsonl").write_text(
-        json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        json.dumps({"type": "user", "timestamp": "2026-04-10T10:00:00Z"}) + "\n",
         encoding="utf-8",
     )
-    os.utime(claude_home / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
+    os.utime(claude_home / "sid-b.jsonl", (b_start + 4 * 3600, b_start + 4 * 3600))
 
     (vault / "claude-sessions" / "2026-04-10-proj1-bbbb.md").write_text(
         "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\nproject: proj1\nstatus: summarized\n---\n# s\n",
@@ -106,12 +108,14 @@ def test_cli_apply_with_yes(tmp_path):
     claude_home = tmp_path / ".claude" / "projects" / "-x-proj1"
     claude_home.mkdir(parents=True)
 
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
     (claude_home / "sid-b.jsonl").write_text(
-        json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        json.dumps({"type": "user", "timestamp": "2026-04-10T10:00:00Z"}) + "\n",
         encoding="utf-8",
     )
-    os.utime(claude_home / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
+    os.utime(claude_home / "sid-b.jsonl", (b_start + 4 * 3600, b_start + 4 * 3600))
 
     (vault / "claude-sessions" / "2026-04-10-proj1-bbbb.md").write_text(
         "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\nproject: proj1\nstatus: summarized\n---\n# s\n",

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -23,7 +23,9 @@ def test_end_to_end_scan_apply_verify(tmp_path):
 
     # Two sessions on different days
     a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
 
     (cc_projects / "sid-a.jsonl").write_text(
         json.dumps({"type": "user", "timestamp": "2026-04-09T10:00:00Z"}) + "\n",
@@ -31,10 +33,10 @@ def test_end_to_end_scan_apply_verify(tmp_path):
     )
     os.utime(cc_projects / "sid-a.jsonl", (a_start + 3600, a_start + 3600))
     (cc_projects / "sid-b.jsonl").write_text(
-        json.dumps({"type": "user", "timestamp": "2026-04-10T14:00:00Z"}) + "\n",
+        json.dumps({"type": "user", "timestamp": "2026-04-10T10:00:00Z"}) + "\n",
         encoding="utf-8",
     )
-    os.utime(cc_projects / "sid-b.jsonl", (b_start + 3600, b_start + 3600))
+    os.utime(cc_projects / "sid-b.jsonl", (b_start + 4 * 3600, b_start + 4 * 3600))
 
     # Session notes
     (vault / "claude-sessions" / "2026-04-09-proj1-aaaa.md").write_text(

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -126,3 +126,103 @@ def test_end_to_end_scan_apply_verify(tmp_path):
     )
     assert r.returncode == 0, f"re-scan exit: expected 0 (clean), got {r.returncode}: {r.stderr}"
     assert json.loads(r.stdout)["total_issues"] == 0
+
+
+def test_json_payload_has_top_level_signal_and_convergence_keys(tmp_path):
+    """Two stale insights converging on a single proposed sid must emit
+    convergence_warning=True and convergence_count>=2 at the top level of
+    each issue dict — alongside capture_signal and capture_confidence
+    (review C1, I6).
+    """
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+
+    home = tmp_path
+    cc_projects = home / ".claude" / "projects" / "-Users-foo-convproj"
+    cc_projects.mkdir(parents=True)
+
+    # Session A: 2026-04-09 10:00 -> 11:00 (referenced by stale insights)
+    a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    a_end = a_start + 3600
+    (cc_projects / "sid-a.jsonl").write_text(
+        json.dumps({"type": "user", "timestamp": "2026-04-09T10:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    os.utime(cc_projects / "sid-a.jsonl", (a_end, a_end))
+
+    # Session B: 2026-04-10 10:00 -> 14:00 (the only candidate the date matcher
+    # can converge onto for both 2026-04-10 insights — they all collapse here)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
+    b_end = b_start + 4 * 3600
+    (cc_projects / "sid-b.jsonl").write_text(
+        json.dumps({"type": "user", "timestamp": "2026-04-10T10:00:00Z"}) + "\n",
+        encoding="utf-8",
+    )
+    os.utime(cc_projects / "sid-b.jsonl", (b_end, b_end))
+
+    (vault / "claude-sessions" / "2026-04-09-convproj-aaaa.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-09\nsession_id: sid-a\n"
+        "project: convproj\nstatus: summarized\n---\n# s\n",
+        encoding="utf-8",
+    )
+    (vault / "claude-sessions" / "2026-04-10-convproj-bbbb.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\n"
+        "project: convproj\nstatus: summarized\n---\n# s\n",
+        encoding="utf-8",
+    )
+
+    # Two stale insights on 2026-04-10 both pointing at sid-a — both will
+    # converge onto sid-b via the date-overlap matcher.
+    for slug in ("conv-one", "conv-two"):
+        insight = vault / "claude-insights" / f"2026-04-10-{slug}.md"
+        insight.write_text(
+            '---\n'
+            'type: claude-insight\n'
+            'date: 2026-04-10\n'
+            'source_session: sid-a\n'
+            'source_session_note: "[[2026-04-09-convproj-aaaa]]"\n'
+            'project: convproj\n'
+            'tags:\n'
+            '  - claude/insight\n'
+            '  - claude/project/convproj\n'
+            '---\n'
+            '\n'
+            '# body\n',
+            encoding="utf-8",
+        )
+        os.utime(insight, (b_start + 1800, b_start + 1800))
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["OBSIDIAN_BRAIN_VAULT"] = str(vault)
+    env["OBSIDIAN_BRAIN_SESSIONS_FOLDER"] = "claude-sessions"
+    env["OBSIDIAN_BRAIN_INSIGHTS_FOLDER"] = "claude-insights"
+
+    script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
+    r = subprocess.run(
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
+         "--project", "convproj", "--json"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 1, f"expected 1 (issues found), got {r.returncode}: {r.stderr}"
+    payload = json.loads(r.stdout)
+    issues = payload["issues"]
+    assert len(issues) >= 2, f"expected >=2 issues, got {len(issues)}: {issues}"
+
+    # Every issue must have all four keys at the TOP level (not under extra).
+    for issue in issues:
+        assert "capture_signal" in issue, f"missing capture_signal: {issue}"
+        assert "capture_confidence" in issue, f"missing capture_confidence: {issue}"
+        assert "convergence_warning" in issue, f"missing convergence_warning: {issue}"
+        assert "convergence_count" in issue, f"missing convergence_count: {issue}"
+
+    converged = [i for i in issues if i["convergence_warning"] is True]
+    assert len(converged) >= 2, (
+        f"expected >=2 issues with convergence_warning=True, got {len(converged)}: "
+        f"{[(i['note_path'], i['convergence_warning']) for i in issues]}"
+    )
+    for issue in converged:
+        assert issue["convergence_count"] >= 2, (
+            f"convergence_count must be >=2 when warned: {issue}"
+        )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -382,6 +382,24 @@ def test_parse_date_midpoint_malformed_returns_none():
     assert ss._parse_date_midpoint("2026-13-99") is None
 
 
+@pytest.mark.parametrize(
+    "bad_date",
+    [
+        "2025-02-29",  # not a leap year
+        "2026-13-01",  # invalid month
+        "2026-04-31",  # April has 30 days
+        "",            # empty
+        "not-a-date",  # garbage
+        "2026/04/21",  # wrong separator
+        "20260421",    # no separators
+    ],
+)
+def test_parse_date_midpoint_negative_edges_return_none(bad_date):
+    """T5: invalid date strings must return None so capture-time signal
+    falls back to the next preference rather than fabricating a timestamp."""
+    assert ss._parse_date_midpoint(bad_date) is None
+
+
 def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
     """When two session windows both contain capture_time, latest first_ts wins."""
     import vault_doctor_checks.source_sessions as check
@@ -1187,9 +1205,11 @@ def test_scan_caps_date_signal_confidence(doctor_vault, monkeypatch):
     assert flagged[0].confidence <= 0.6
 
 
-def test_scan_convergence_guard_lowers_confidence(doctor_vault, monkeypatch):
-    """When 2+ flags in a project converge on the same proposed session,
-    confidence drops to <= 0.4 and convergence_warning is set."""
+@pytest.mark.parametrize("n_flags", [2, 3, 5])
+def test_scan_convergence_guard_lowers_confidence(doctor_vault, monkeypatch, n_flags):
+    """When N>=2 flags in a project converge on the same proposed session,
+    confidence drops to <= 0.4 and convergence_warning is set, with
+    convergence_count == N (review T3)."""
     vault = doctor_vault["vault"]
     home = doctor_vault["home"]
     jsonl_dir = doctor_vault["jsonl_dir"]
@@ -1205,11 +1225,12 @@ def test_scan_convergence_guard_lowers_confidence(doctor_vault, monkeypatch):
                  r_last)
     _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_real, "real")
 
-    # Two insights with bogus UUIDs that don't resolve -> matcher proposes sid_real for both
-    for slug, bogus in [
-        ("converge-1", "11111111-1111-1111-1111-111111111199"),
-        ("converge-2", "22222222-2222-2222-2222-222222222299"),
-    ]:
+    # N insights with bogus UUIDs that don't resolve -> matcher proposes sid_real for all
+    for n in range(n_flags):
+        slug = f"converge-{n+1}"
+        # Distinct bogus UUIDs ensure the global SID index doesn't resolve them,
+        # which forces the day-overlap matcher to propose sid_real for each.
+        bogus = f"{n+1:08d}-1111-1111-1111-{n+1:012d}"
         _write_insight(
             vault / "claude-insights",
             date="2026-04-22",
@@ -1228,12 +1249,12 @@ def test_scan_convergence_guard_lowers_confidence(doctor_vault, monkeypatch):
         project=project,
     )
     flagged = [i for i in issues if "converge" in i.note_path and i.extra.get("proposed_sid") == sid_real]
-    assert len(flagged) == 2, f"expected 2 convergence flags, got {len(flagged)}"
+    assert len(flagged) == n_flags, f"expected {n_flags} convergence flags, got {len(flagged)}"
     for i in flagged:
         assert i.extra.get("convergence_warning") is True, (
             f"expected convergence_warning on {i.note_path}"
         )
-        assert i.extra.get("convergence_count") == 2
+        assert i.extra.get("convergence_count") == n_flags
         assert i.confidence <= 0.4
 
 
@@ -1732,3 +1753,37 @@ def test_phase_1b_fallback_via_find_jsonl_anywhere(tmp_path, monkeypatch):
         f"despite sid_correct having a real JSONL. Flagged: "
         f"{[(i.proposed_source, i.extra) for i in flagged_stale]}"
     )
+
+
+def test_find_jsonl_anywhere_returns_first_lexicographic_match(tmp_path, monkeypatch):
+    """T1: _find_jsonl_anywhere globs across all CC project dirs and returns
+    the first match by sorted order. UUIDs are globally unique, but if the
+    same SID file appears under two project dirs (e.g., a worktree that was
+    later moved or test fixtures), the result must be deterministic across
+    runs — sorted() ensures identical-input → identical-output."""
+    proj_a = tmp_path / ".claude" / "projects" / "-Users-foo-projA"
+    proj_b = tmp_path / ".claude" / "projects" / "-Users-foo-projB"
+    proj_a.mkdir(parents=True)
+    proj_b.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    sid = "11111111-1111-1111-1111-111111111111"
+    (proj_a / f"{sid}.jsonl").write_text("{}\n", encoding="utf-8")
+    (proj_b / f"{sid}.jsonl").write_text("{}\n", encoding="utf-8")
+
+    found = ss._find_jsonl_anywhere(sid)
+    assert found is not None
+    # sorted() returns lexicographically-first match — projA before projB
+    assert "projA" in str(found), f"expected projA winner, got {found}"
+
+    # Stability across repeated calls: sorted() is a total order on str
+    found2 = ss._find_jsonl_anywhere(sid)
+    assert found == found2
+
+
+def test_find_jsonl_anywhere_returns_none_when_missing(tmp_path, monkeypatch):
+    """T1: _find_jsonl_anywhere returns None when no project dir contains
+    a JSONL with the given SID."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / ".claude" / "projects" / "-Users-foo-projX").mkdir(parents=True)
+    assert ss._find_jsonl_anywhere("99999999-9999-9999-9999-999999999999") is None

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1557,3 +1557,55 @@ def test_scan_caps_mtime_signal_confidence_below_convergence_floor(doctor_vault,
     assert flagged[0].confidence <= 0.3, (
         f"mtime-signal confidence must be <=0.3, got {flagged[0].confidence}"
     )
+
+
+def test_scan_emits_unresolved_when_jsonl_exists_but_session_note_missing(
+    doctor_vault, monkeypatch
+):
+    """When source_session UUID has a real JSONL but no vault session note,
+    emit an unresolved diagnostic Issue surfacing the coverage gap. UUID
+    remains authoritative — never propose a different-session rewrite
+    (review C3)."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_orphan = "55555555-5555-5555-5555-555555555555"
+    o_first = datetime(2026, 4, 22, 11, 0, tzinfo=timezone.utc).timestamp()
+    o_last = datetime(2026, 4, 22, 22, 0, tzinfo=timezone.utc).timestamp()
+    orphan_jsonl = jsonl_dir / f"{sid_orphan}.jsonl"
+    _write_jsonl(
+        orphan_jsonl,
+        datetime.fromtimestamp(o_first, tz=timezone.utc).isoformat(),
+        o_last,
+    )
+    # NOTE: deliberately NO session note for sid_orphan — coverage gap.
+
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="orphan-uuid-c3",
+        project=project,
+        src_sid=sid_orphan,
+        src_note_basename="2026-04-22-proj1-orph",
+        mtime=o_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight)]
+    assert len(flagged) == 1, (
+        f"expected exactly 1 issue for orphan-UUID insight, got {len(flagged)}"
+    )
+    issue = flagged[0]
+    assert issue.extra.get("unresolved") is True
+    assert issue.extra.get("missing_session_note") is True
+    assert issue.extra.get("jsonl_path") == str(orphan_jsonl)
+    assert issue.confidence == 0.0

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1628,3 +1628,107 @@ def test_list_all_session_notes_warns_on_malformed_frontmatter(tmp_path, capsys)
     assert out == {}, f"expected empty dict for malformed-only dir, got {out}"
     assert "[vault_doctor] malformed frontmatter, skipped:" in captured.err
     assert "2026-04-22-malformed.md" in captured.err
+
+
+def test_phase_1b_fallback_via_find_jsonl_anywhere(tmp_path, monkeypatch):
+    """Phase 1b's session-window lookup must fall back to _find_jsonl_anywhere
+    when the session-note's worktree-suffixed `project:` does not resolve via
+    `_jsonl_dir_for_project`. Without the fix, the date matcher proposes a
+    different (canonical-project) session as a stale rewrite (review I4)."""
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+
+    # Single canonical project dir under HOME=tmp_path. Both JSONLs live here
+    # (worktrees share parent-repo CC project dir), but the session-NOTE for
+    # sid_correct claims a worktree-suffixed `project:` value that won't
+    # resolve via _jsonl_dir_for_project.
+    canonical_dir = tmp_path / ".claude" / "projects" / "-Users-foo-obsidian-brain"
+    canonical_dir.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    # Day used for note + sessions
+    day_start = calendar.timegm(time.strptime("2026-04-20 00:00", "%Y-%m-%d %H:%M"))
+
+    # sid_correct: window covers most of the day; session note claims
+    # worktree-suffixed project name
+    sid_correct = "11111111-1111-1111-1111-111111111111"
+    correct_first = day_start + 9 * 3600
+    correct_last = day_start + 18 * 3600
+    _write_jsonl(
+        canonical_dir / f"{sid_correct}.jsonl",
+        datetime.fromtimestamp(correct_first, tz=timezone.utc).isoformat(),
+        correct_last,
+    )
+    correct_note = vault / "claude-sessions" / "2026-04-20-obsidian-brain-corr.md"
+    correct_note.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-20\n"
+        f"session_id: {sid_correct}\n"
+        # Worktree-suffixed project — _jsonl_dir_for_project misses this.
+        "project: obsidian-brain--issue-81-slug\n"
+        "status: summarized\n"
+        "---\n# s\n",
+        encoding="utf-8",
+    )
+
+    # sid_wrong: also on 2026-04-20; session note claims canonical project.
+    # Without the fix, the date matcher (operating in canonical project's idx)
+    # picks this as the "correct" target, producing a stale-flag false positive.
+    sid_wrong = "22222222-2222-2222-2222-222222222222"
+    wrong_first = day_start + 8 * 3600
+    wrong_last = day_start + 19 * 3600
+    _write_jsonl(
+        canonical_dir / f"{sid_wrong}.jsonl",
+        datetime.fromtimestamp(wrong_first, tz=timezone.utc).isoformat(),
+        wrong_last,
+    )
+    (vault / "claude-sessions" / "2026-04-20-obsidian-brain-wrng.md").write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-20\n"
+        f"session_id: {sid_wrong}\n"
+        "project: obsidian-brain\n"
+        "status: summarized\n"
+        "---\n# s\n",
+        encoding="utf-8",
+    )
+
+    # Insight: project=obsidian-brain (canonical), source_session=sid_correct,
+    # source_session_note=basename of sid_correct's note.
+    insight = vault / "claude-insights" / "2026-04-20-i4-fallback.md"
+    insight.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "date: 2026-04-20\n"
+        f"source_session: {sid_correct}\n"
+        'source_session_note: "[[2026-04-20-obsidian-brain-corr]]"\n'
+        "project: obsidian-brain\n"
+        "tags:\n"
+        "  - claude/insight\n"
+        "  - claude/project/obsidian-brain\n"
+        "---\n# body\n",
+        encoding="utf-8",
+    )
+    insight_mtime = day_start + 12 * 3600
+    os.utime(insight, (insight_mtime, insight_mtime))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project="obsidian-brain",
+    )
+    flagged_stale = [
+        i for i in issues
+        if i.note_path == str(insight)
+        and not i.extra.get("unresolved")
+        and not i.extra.get("basename_only")
+    ]
+    assert flagged_stale == [], (
+        f"Phase 1b fallback failed: matcher proposed a wrong-session rewrite "
+        f"despite sid_correct having a real JSONL. Flagged: "
+        f"{[(i.proposed_source, i.extra) for i in flagged_stale]}"
+    )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -869,3 +869,65 @@ def test_scan_unresolved_reason_uses_capture_time(doctor_vault, monkeypatch):
     assert "mtime" not in iss.reason, f"reason should not mention mtime: {iss.reason!r}"
     assert iss.extra.get("capture_signal") == "date"
     assert iss.extra.get("capture_confidence") == 0.9
+
+
+def test_scan_trusts_current_source_when_same_day(doctor_vault, monkeypatch):
+    """If the existing source_session resolves to a same-day session note in
+    the index, the check must NOT re-match — even when the matcher would
+    otherwise propose a different same-day session."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    day = "2026-04-22"
+    # Two same-day sessions, arranged so capture_time at 12:00 UTC (date midday)
+    # falls only inside Y. Without early-exit the matcher would propose Y;
+    # with early-exit, current source X is trusted.
+    sid_x = "11111111-1111-1111-1111-111111111111"
+    sid_y = "22222222-2222-2222-2222-222222222222"
+
+    # Session X: 2026-04-22 09:00–11:00 (current source — does NOT contain 12:00)
+    x_start = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
+    x_end = datetime(2026, 4, 22, 11, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_x}.jsonl",
+                 datetime.fromtimestamp(x_start, tz=timezone.utc).isoformat(),
+                 x_end)
+
+    # Session Y: 2026-04-22 12:00–18:00 (contains 12:00 — matcher would pick this)
+    y_start = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc).timestamp()
+    y_end = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_y}.jsonl",
+                 datetime.fromtimestamp(y_start, tz=timezone.utc).isoformat(),
+                 y_end)
+
+    sess_x = _write_session_note(vault / "claude-sessions", day, project, sid_x, "xxxx")
+    _write_session_note(vault / "claude-sessions", day, project, sid_y, "yyyy")
+
+    # Insight whose date: is day; source_session points at X (correct). With
+    # capture_time at 12:00 UTC the matcher would otherwise propose Y. mtime
+    # is irrelevant for this test (the new check no longer uses it for
+    # matching) but we set it to a known value for stability.
+    insight = _write_insight(
+        vault / "claude-insights",
+        date=day,
+        slug="trust-x",
+        project=project,
+        src_sid=sid_x,
+        src_note_basename=sess_x.stem,
+        mtime=y_start + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    paths = [i.note_path for i in issues]
+    assert str(insight) not in paths, (
+        "regression: same-day source was second-guessed by the matcher"
+    )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1011,3 +1011,62 @@ def test_scan_created_at_bypasses_early_exit(doctor_vault, monkeypatch):
     assert iss.extra.get("proposed_sid") == sid_y, (
         f"matcher should propose Y (where created_at falls), got {iss.extra.get('proposed_sid')!r}"
     )
+
+
+def test_scan_trusts_cross_midnight_source(doctor_vault, monkeypatch):
+    """Phase 1b extension (issue #93): a session that started the night before
+    note.date and ran into note.date is the legitimate cross-midnight case.
+    The current source must be trusted even though session_note.date != note.date."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    # Cross-midnight session: started 2026-04-20 22:00, ended 2026-04-21 03:00
+    sid_x = "55555555-5555-5555-5555-555555555555"
+    x_first = datetime(2026, 4, 20, 22, 0, tzinfo=timezone.utc).timestamp()
+    x_last = datetime(2026, 4, 21, 3, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_x}.jsonl",
+                 datetime.fromtimestamp(x_first, tz=timezone.utc).isoformat(),
+                 x_last)
+
+    # Another session, same project, fully within 2026-04-21 daytime
+    sid_y = "66666666-6666-6666-6666-666666666666"
+    y_first = datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc).timestamp()
+    y_last = datetime(2026, 4, 21, 14, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_y}.jsonl",
+                 datetime.fromtimestamp(y_first, tz=timezone.utc).isoformat(),
+                 y_last)
+
+    # Session note for X has date 2026-04-20 (its first-entry day)
+    sess_x = _write_session_note(vault / "claude-sessions", "2026-04-20", project, sid_x, "5555")
+    sess_y = _write_session_note(vault / "claude-sessions", "2026-04-21", project, sid_y, "6666")
+
+    # Insight dated 2026-04-21 (calendar day of capture), source_session = X
+    # (the session that crossed midnight). Without the JSONL-overlap extension,
+    # session.date "2026-04-20" != note.date "2026-04-21" → Phase 1b doesn't fire,
+    # matcher proposes Y → false positive.
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-21",
+        slug="cross-midnight-trust",
+        project=project,
+        src_sid=sid_x,
+        src_note_basename=sess_x.stem,
+        mtime=y_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    paths = [i.note_path for i in issues]
+    assert str(insight) not in paths, (
+        "regression: cross-midnight session_note.date=note.date-1 not trusted "
+        "(session window overlaps note's calendar day → should be trusted)"
+    )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -648,3 +648,53 @@ def test_safe_project_slug_sanitizes_dots_and_separators():
     assert check._safe_project_slug("") == "unknown"
     assert check._safe_project_slug("...") == "unknown"
     assert check._safe_project_slug("valid-name_1") == "valid-name_1"
+
+
+def test_capture_time_prefers_created_at(tmp_path):
+    note = tmp_path / "2026-01-01-foo.md"
+    note.write_text("body")
+    fm = {"created_at": "2026-04-21T14:33:02+00:00", "date": "2026-03-15"}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (1.0, "created_at")
+    expected = datetime.fromisoformat("2026-04-21T14:33:02+00:00").timestamp()
+    assert abs(ts - expected) < 0.001
+
+
+def test_capture_time_falls_back_to_date(tmp_path):
+    note = tmp_path / "1999-12-31-foo.md"
+    note.write_text("body")
+    fm = {"date": "2026-04-21"}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (0.9, "date")
+    expected = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    assert abs(ts - expected) < 0.001
+
+
+def test_capture_time_falls_back_to_filename(tmp_path):
+    note = tmp_path / "2026-04-21-foo-bar.md"
+    note.write_text("body")
+    fm = {}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (0.85, "filename")
+    expected = datetime(2026, 4, 21, 12, 0, 0, tzinfo=timezone.utc).timestamp()
+    assert abs(ts - expected) < 0.001
+
+
+def test_capture_time_falls_back_to_mtime(tmp_path):
+    note = tmp_path / "no-date-prefix.md"
+    note.write_text("body")
+    fixed_mtime = 1_700_000_000.0
+    os.utime(note, (fixed_mtime, fixed_mtime))
+    fm = {}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (0.5, "mtime")
+    assert abs(ts - fixed_mtime) < 0.001
+
+
+def test_capture_time_malformed_date_falls_through(tmp_path):
+    """Malformed date in frontmatter must not block the chain."""
+    note = tmp_path / "2026-04-21-foo.md"
+    note.write_text("body")
+    fm = {"date": "garbage"}
+    ts, conf, signal = ss._capture_time(note, fm)
+    assert (conf, signal) == (0.85, "filename")

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1388,6 +1388,65 @@ def test_list_session_notes_filters_out_snapshots(doctor_vault):
     assert idx[sid]["basename"] == "2026-04-21-proj1-2222"
 
 
+def test_list_all_session_notes_warns_and_keeps_first_on_duplicate_sid(
+    tmp_path, capsys
+):
+    """Copilot R5: when two session notes share the same session_id (a known
+    possible vault state — vault-import collision, rename gone wrong, etc.),
+    the helper iterates in sorted order so the winner is deterministic and
+    emits a stderr warning instead of silently overwriting.
+    """
+    sessions = tmp_path / "claude-sessions"
+    sessions.mkdir()
+    sid = "deadbeef-dead-beef-dead-deadbeefdead"
+    # Note A sorts before Note B lexically — A should win.
+    (sessions / "2026-04-26-aaa-proj1-collide.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-26\n"
+        f"session_id: {sid}\nproject: proj1\nstatus: summarized\n---\n# A\n",
+        encoding="utf-8",
+    )
+    (sessions / "2026-04-26-bbb-proj1-collide.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-26\n"
+        f"session_id: {sid}\nproject: proj1\nstatus: summarized\n---\n# B\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()  # drain
+    idx = ss._list_all_session_notes(sessions)
+    assert sid in idx
+    assert idx[sid]["basename"] == "2026-04-26-aaa-proj1-collide", (
+        f"sorted-order winner should be the lexically-first file, got {idx[sid]['basename']}"
+    )
+    captured = capsys.readouterr()
+    assert "duplicate session_id" in captured.err
+    assert "deadbeef" in captured.err  # short SID prefix
+    assert "rename one to disambiguate" in captured.err
+
+
+def test_list_session_notes_warns_and_keeps_first_on_duplicate_sid(
+    tmp_path, capsys
+):
+    """Copilot R5: parity-symmetry — _list_session_notes must also iterate
+    deterministically and warn on duplicate SIDs."""
+    sessions = tmp_path / "claude-sessions"
+    sessions.mkdir()
+    sid = "feedface-feed-face-feed-feedfacefeed"
+    (sessions / "2026-04-26-bbb-projP-collide.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-26\n"
+        f"session_id: {sid}\nproject: projP\nstatus: summarized\n---\n# B\n",
+        encoding="utf-8",
+    )
+    (sessions / "2026-04-26-aaa-projP-collide.md").write_text(
+        "---\ntype: claude-session\ndate: 2026-04-26\n"
+        f"session_id: {sid}\nproject: projP\nstatus: summarized\n---\n# A\n",
+        encoding="utf-8",
+    )
+    capsys.readouterr()
+    idx = ss._list_session_notes(sessions, "projP")
+    assert idx[sid]["basename"] == "2026-04-26-aaa-projP-collide"
+    captured = capsys.readouterr()
+    assert "duplicate session_id" in captured.err
+
+
 # ---------------------------------------------------------------------------
 # T5e Fix 2 — trust UUID when JSONL exists but session note is missing
 # ---------------------------------------------------------------------------

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1488,3 +1488,72 @@ def test_scan_day_overlap_picks_morning_session(doctor_vault, monkeypatch):
             f"day-overlap matcher should prefer morning session ({sid_morning}) "
             f"over noon session ({sid_noon}); got {flagged[0].extra.get('proposed_sid')}"
         )
+
+
+def test_scan_caps_mtime_signal_confidence_below_convergence_floor(doctor_vault, monkeypatch):
+    """When capture_signal falls all the way to mtime (no created_at, no date
+    frontmatter, no YYYY-MM-DD filename prefix), the proposed-rewrite confidence
+    must be capped at <=0.3 — below the convergence floor of 0.4 — so an
+    operator never auto-applies an mtime-only proposal (review C2)."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Two sessions on different days so the date-overlap matcher returns a
+    # different session than the one currently referenced.
+    a_start = calendar.timegm(time.strptime("2026-04-15 10:00", "%Y-%m-%d %H:%M"))
+    a_end = a_start + 3600
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-15T10:00:00Z", a_end)
+    _write_session_note(vault / "claude-sessions", "2026-04-15", project, "sid-a", "aaaa")
+
+    b_start = calendar.timegm(time.strptime("2026-04-16 10:00", "%Y-%m-%d %H:%M"))
+    b_end = b_start + 4 * 3600
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-16T10:00:00Z", b_end)
+    _write_session_note(vault / "claude-sessions", "2026-04-16", project, "sid-b", "bbbb")
+
+    # Insight with NO created_at, NO date frontmatter, NO YYYY-MM-DD filename
+    # prefix → mtime is the only available signal. Filename intentionally
+    # avoids the date prefix.
+    insight = vault / "claude-insights" / "no-date-prefix-mtime-only.md"
+    insight.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        f"source_session: sid-a\n"
+        f'source_session_note: "[[2026-04-15-{project}-aaaa]]"\n'
+        f"project: {project}\n"
+        "tags:\n"
+        "  - claude/insight\n"
+        f"  - claude/project/{project}\n"
+        "---\n"
+        "# body\n",
+        encoding="utf-8",
+    )
+    # Set mtime inside session B's window so the matcher proposes sid-b.
+    insight_mtime = b_start + 1800
+    os.utime(insight, (insight_mtime, insight_mtime))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [
+        i for i in issues
+        if i.note_path == str(insight)
+        and not i.extra.get("unresolved")
+        and not i.extra.get("basename_only")
+    ]
+    assert len(flagged) == 1, (
+        f"expected 1 stale flag for mtime-signal insight, got {len(flagged)}: "
+        f"{[(i.confidence, i.extra) for i in flagged]}"
+    )
+    assert flagged[0].extra.get("capture_signal") == "mtime", (
+        f"test setup error: expected mtime signal, got {flagged[0].extra.get('capture_signal')}"
+    )
+    assert flagged[0].confidence <= 0.3, (
+        f"mtime-signal confidence must be <=0.3, got {flagged[0].confidence}"
+    )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -931,3 +931,83 @@ def test_scan_trusts_current_source_when_same_day(doctor_vault, monkeypatch):
     assert str(insight) not in paths, (
         "regression: same-day source was second-guessed by the matcher"
     )
+
+
+def test_scan_created_at_bypasses_early_exit(doctor_vault, monkeypatch):
+    """Pin test for the capture_signal != 'created_at' carve-out in Phase 1b
+    early-exit (issue #93). A note with created_at AND a same-day current
+    source MUST still be validated by the matcher; the early-exit must NOT
+    short-circuit just because date strings agree.
+
+    If this test goes silent (passes when it shouldn't), the carve-out has
+    been removed and high-precision created_at notes are being trusted on
+    same-day SID match alone — masking actual corruption."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    day = "2026-04-22"
+    sid_x = "33333333-3333-3333-3333-333333333333"
+    sid_y = "44444444-4444-4444-4444-444444444444"
+
+    # Two same-day sessions, NON-overlapping.
+    # Session X: 09:00–11:00 (current source — INCORRECT for the note).
+    # Session Y: 14:00–16:00 (the note's actual created_at falls here).
+    x_start = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
+    x_end = datetime(2026, 4, 22, 11, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_x}.jsonl",
+                 datetime.fromtimestamp(x_start, tz=timezone.utc).isoformat(),
+                 x_end)
+
+    y_start = datetime(2026, 4, 22, 14, 0, tzinfo=timezone.utc).timestamp()
+    y_end = datetime(2026, 4, 22, 16, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_y}.jsonl",
+                 datetime.fromtimestamp(y_start, tz=timezone.utc).isoformat(),
+                 y_end)
+
+    sess_x = _write_session_note(vault / "claude-sessions", day, project, sid_x, "3333")
+    sess_y = _write_session_note(vault / "claude-sessions", day, project, sid_y, "4444")
+
+    # Insight: source_session is X (same day, would satisfy date-equality early-exit
+    # if signal were date/filename), but created_at = 14:30 falls in Y's window.
+    # The matcher MUST be allowed to run and propose Y. Early-exit must NOT fire.
+    insight_path = vault / "claude-insights" / f"{day}-pin-carveout.md"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: {day}\n"
+        f"created_at: 2026-04-22T14:30:00+00:00\n"
+        f"source_session: {sid_x}\n"
+        f'source_session_note: "[[{sess_x.stem}]]"\n'
+        f"project: {project}\n"
+        f"tags:\n"
+        f"  - claude/insight\n"
+        f"  - claude/project/{project}\n"
+        f"---\n"
+        f"# pin\n",
+        encoding="utf-8",
+    )
+    # Set mtime to a known stable value (irrelevant for matching now)
+    import os as _os
+    _os.utime(insight_path, (y_start + 1800, y_start + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert len(flagged) == 1, (
+        "carve-out regression: created_at note with same-day current source "
+        "was not re-validated by matcher (early-exit fired when it should not)"
+    )
+    iss = flagged[0]
+    assert iss.extra.get("capture_signal") == "created_at"
+    assert iss.extra.get("proposed_sid") == sid_y, (
+        f"matcher should propose Y (where created_at falls), got {iss.extra.get('proposed_sid')!r}"
+    )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1503,12 +1503,14 @@ def test_scan_day_overlap_picks_morning_session(doctor_vault, monkeypatch):
         project=project,
     )
     flagged = [i for i in issues if i.note_path == str(insight) and not i.extra.get("unresolved")]
-    if flagged:
-        # Day-overlap matcher should pick the morning session (larger overlap)
-        assert flagged[0].extra.get("proposed_sid") == sid_morning, (
-            f"day-overlap matcher should prefer morning session ({sid_morning}) "
-            f"over noon session ({sid_noon}); got {flagged[0].extra.get('proposed_sid')}"
-        )
+    assert len(flagged) == 1, (
+        f"expected exactly one non-unresolved issue for {insight}, got {len(flagged)}: {flagged}"
+    )
+    # Day-overlap matcher should pick the morning session (larger overlap)
+    assert flagged[0].extra.get("proposed_sid") == sid_morning, (
+        f"day-overlap matcher should prefer morning session ({sid_morning}) "
+        f"over noon session ({sid_noon}); got {flagged[0].extra.get('proposed_sid')}"
+    )
 
 
 def test_scan_caps_mtime_signal_confidence_below_convergence_floor(doctor_vault, monkeypatch):

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -767,3 +767,105 @@ def test_scan_ignores_mtime_when_date_present(doctor_vault, monkeypatch):
     assert str(insight) not in paths, (
         "regression: drifted mtime caused false-positive flag despite date: pointing to session A"
     )
+
+
+def test_scan_emits_capture_signal_and_confidence(doctor_vault, monkeypatch):
+    """Issue.extra must include capture_signal and capture_confidence so the
+    skill report can flag low-confidence matches to the operator."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    day = "2026-04-22"
+    sid_correct = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    sid_wrong = "wwwwwwww-wwww-wwww-wwww-wwwwwwwwwwww"
+
+    ts_start = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    ts_end = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_correct}.jsonl",
+                 datetime.fromtimestamp(ts_start, tz=timezone.utc).isoformat(),
+                 ts_end)
+    # A different session whose window will be the *current* (wrong) source
+    other_start = datetime(2026, 4, 20, 10, 0, tzinfo=timezone.utc).timestamp()
+    other_end = datetime(2026, 4, 20, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_wrong}.jsonl",
+                 datetime.fromtimestamp(other_start, tz=timezone.utc).isoformat(),
+                 other_end)
+
+    sess_correct = _write_session_note(vault / "claude-sessions", day, project, sid_correct, "1234")
+    _write_session_note(vault / "claude-sessions", "2026-04-20", project, sid_wrong, "5678")
+
+    insight = _write_insight(
+        vault / "claude-insights",
+        date=day,
+        slug="signal-test",
+        project=project,
+        src_sid=sid_wrong,
+        src_note_basename=f"2026-04-20-{project}-5678",
+        mtime=ts_start + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight)]
+    assert len(flagged) == 1, "expected the wrong-source note to be flagged"
+    assert flagged[0].extra.get("capture_signal") == "date"
+    assert flagged[0].extra.get("capture_confidence") == 0.9
+    assert flagged[0].extra.get("proposed_sid") == sid_correct
+
+
+def test_scan_unresolved_reason_uses_capture_time(doctor_vault, monkeypatch):
+    """Unresolved-branch reason string must mention capture_time (not mtime)
+    and surface signal/conf in extra. (issue #93)"""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    # One session, but its window is far from any plausible capture-time of the
+    # insight. Insight's source_session does not match any session in the index,
+    # so the unresolved branch fires.
+    sid_only = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+    s_start = datetime(2026, 1, 1, 10, 0, tzinfo=timezone.utc).timestamp()
+    s_end = datetime(2026, 1, 1, 11, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_only}.jsonl",
+                 datetime.fromtimestamp(s_start, tz=timezone.utc).isoformat(),
+                 s_end)
+    _write_session_note(vault / "claude-sessions", "2026-01-01", project, sid_only, "ffff")
+
+    # Note dated far from any session, source_session not in idx
+    insight_mtime = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc).timestamp()
+    _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="unresolved-signal",
+        project=project,
+        src_sid="not-a-real-sid",
+        src_note_basename="2026-04-22-bogus",
+        mtime=insight_mtime,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    unresolved = [i for i in issues if i.extra.get("unresolved") is True]
+    assert len(unresolved) == 1, f"expected 1 unresolved issue, got {len(unresolved)}"
+    iss = unresolved[0]
+    assert "capture_time" in iss.reason, f"reason should mention capture_time: {iss.reason!r}"
+    assert "mtime" not in iss.reason, f"reason should not mention mtime: {iss.reason!r}"
+    assert iss.extra.get("capture_signal") == "date"
+    assert iss.extra.get("capture_confidence") == 0.9

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1417,16 +1417,16 @@ def test_scan_trusts_uuid_when_jsonl_exists_but_note_missing(doctor_vault, monke
         days=10000,
         project=project,
     )
-    flagged_paths = [i.note_path for i in issues if i.note_path == str(insight)]
-    if flagged_paths:
-        # Acceptable behavior: emit unresolved (UUID is real but note is missing).
-        # Unacceptable: propose sid_distractor as a rewrite target.
-        flagged = [i for i in issues if i.note_path == str(insight)][0]
-        if not flagged.extra.get("unresolved"):
-            assert flagged.extra.get("proposed_sid") != sid_distractor, (
-                "regression: matcher proposed a different session when "
-                "source UUID had a real JSONL (just missing session note)"
-            )
+    flagged = [i for i in issues if i.note_path == str(insight)]
+    assert len(flagged) == 1, (
+        f"expected exactly 1 issue for orphan-UUID insight, got {len(flagged)}"
+    )
+    assert flagged[0].extra.get("unresolved") is True
+    assert flagged[0].extra.get("missing_session_note") is True
+    assert flagged[0].extra.get("proposed_sid") != sid_distractor, (
+        "regression: must not propose a different session when source UUID "
+        "had a real JSONL (just missing session note)"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -97,13 +97,14 @@ def test_scan_flags_insight_stamped_to_wrong_session(doctor_vault, monkeypatch):
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_end)
     _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
 
-    # Session B: 2026-04-10 14:00–15:00
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
-    b_end = b_start + 3600
-    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_end)
+    # Session B: 2026-04-10 10:00–14:00 (window must contain midday for the
+    # date-based capture_time match under the fix for issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
+    b_end = b_start + 4 * 3600
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T10:00:00Z", b_end)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
-    # Insight captured 2026-04-10 14:30 but wrongly stamped with sid-a
+    # Insight captured 2026-04-10 10:30 but wrongly stamped with sid-a
     insight_mtime = b_start + 1800
     _write_insight(
         v / "claude-insights",
@@ -225,9 +226,11 @@ def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monke
     monkeypatch.setenv("HOME", str(home))
 
     a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_start + 3600)
-    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_start + 3600)
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T10:00:00Z", b_start + 4 * 3600)
     _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
@@ -392,9 +395,11 @@ def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
     _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_mtime)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
-    # Insight captured at 14:02 — inside BOTH windows
+    # Insight captured at 14:02 — inside BOTH windows.
+    # We inject created_at so _capture_time uses the precise sub-day timestamp
+    # (date: midday = 12:00, which only falls in A; we need 14:02 in both).
     insight_mtime = calendar.timegm(time.strptime("2026-04-10 14:02", "%Y-%m-%d %H:%M"))
-    _write_insight(
+    insight_path = _write_insight(
         v / "claude-insights",
         "2026-04-10",
         "boundary-tie-insight",
@@ -403,6 +408,13 @@ def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
         "2026-04-10-proj1-aaaa",
         insight_mtime,
     )
+    # Inject created_at so _capture_time resolves to 14:02 (inside both windows)
+    # rather than midday-12:00 (which only falls in session A). (issue #93)
+    text = insight_path.read_text(encoding="utf-8")
+    text = text.replace("type: claude-insight\n",
+                        "type: claude-insight\ncreated_at: 2026-04-10T14:02:00Z\n")
+    insight_path.write_text(text, encoding="utf-8")
+    os.utime(insight_path, (insight_mtime, insight_mtime))  # restore mtime after write
 
     issues = check.scan(
         str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
@@ -469,10 +481,9 @@ def test_jsonl_dir_for_project_picks_newest_worktree(tmp_path, monkeypatch):
 def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
     """After apply, the patched note's mtime equals its pre-apply mtime.
 
-    This is load-bearing: scan() uses note mtime as capture_time. If apply
-    updated mtime to 'now', a subsequent scan would match the note's new
-    mtime against the current session's window, not the original capture
-    session — re-flagging every fixed note on every run.
+    scan() uses mtime for the --days cutoff filter. If apply updated mtime
+    to 'now', notes written long ago could accidentally re-enter the scan
+    window after being fixed. Preserving mtime prevents that drift.
     """
     import vault_doctor_checks.source_sessions as check
     import os
@@ -484,13 +495,15 @@ def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
 
     import calendar, time
     a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
-    b_start = calendar.timegm(time.strptime("2026-04-10 14:00", "%Y-%m-%d %H:%M"))
+    # Session B widened to include 2026-04-10 midday (12:00) so the new
+    # date-based capture_time matches it. (issue #93)
+    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_start + 3600)
-    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_start + 3600)
+    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T10:00:00Z", b_start + 4 * 3600)
     _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
-    original_mtime = b_start + 1800  # 2026-04-10 14:30
+    original_mtime = b_start + 1800  # 2026-04-10 10:30
     _write_insight(
         v / "claude-insights",
         "2026-04-10",
@@ -698,3 +711,59 @@ def test_capture_time_malformed_date_falls_through(tmp_path):
     fm = {"date": "garbage"}
     ts, conf, signal = ss._capture_time(note, fm)
     assert (conf, signal) == (0.85, "filename")
+
+
+def test_scan_ignores_mtime_when_date_present(doctor_vault, monkeypatch):
+    """A note whose mtime drifted into a later session's window must NOT be flagged
+    when its frontmatter date and filename prefix point to the original session's day."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+
+    monkeypatch.setenv("HOME", str(home))
+
+    day_a = "2026-04-21"
+    day_b = "2026-04-22"
+    sid_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    sid_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+    # Session A: 2026-04-21, 10:00–18:00 UTC
+    ts_a_start = datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc).timestamp()
+    ts_a_end = datetime(2026, 4, 21, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_a}.jsonl",
+                 datetime.fromtimestamp(ts_a_start, tz=timezone.utc).isoformat(),
+                 ts_a_end)
+
+    # Session B: 2026-04-22, 09:00–17:00 UTC
+    ts_b_start = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
+    ts_b_end = datetime(2026, 4, 22, 17, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_b}.jsonl",
+                 datetime.fromtimestamp(ts_b_start, tz=timezone.utc).isoformat(),
+                 ts_b_end)
+
+    sess_a = _write_session_note(vault / "claude-sessions", day_a, project, sid_a, "1111")
+    sess_b = _write_session_note(vault / "claude-sessions", day_b, project, sid_b, "2222")
+
+    # Insight written on day A but mtime drifted to day B (e.g., /check-items touched it)
+    insight = _write_insight(
+        vault / "claude-insights",
+        day_a,
+        "real-capture-day-a",
+        project,
+        sid_a,
+        sess_a.stem,
+        ts_b_start + 3600,  # mtime fell into session B's window
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,  # large window so test stays valid as wall-clock advances
+        project=project,
+    )
+    paths = [i.note_path for i in issues]
+    assert str(insight) not in paths, (
+        "regression: drifted mtime caused false-positive flag despite date: pointing to session A"
+    )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -5,12 +5,15 @@ import json
 import os
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 _SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import vault_doctor_checks.source_sessions as ss  # noqa: E402 (must follow sys.path setup)
 
 
 @pytest.fixture
@@ -348,6 +351,24 @@ def test_apply_errors_on_missing_proposed_sid(doctor_vault, tmp_path):
     assert results[0].status == "error"
     assert "proposed_sid" in (results[0].error or "")
     assert note.read_text(encoding="utf-8") == original
+
+
+def test_parse_date_midpoint_valid_date_returns_noon_utc():
+    ts = ss._parse_date_midpoint("2026-04-21")
+    assert ts is not None
+    dt = datetime.fromtimestamp(ts, tz=timezone.utc)
+    assert (dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second) == (
+        2026, 4, 21, 12, 0, 0,
+    )
+
+
+def test_parse_date_midpoint_empty_returns_none():
+    assert ss._parse_date_midpoint("") is None
+
+
+def test_parse_date_midpoint_malformed_returns_none():
+    assert ss._parse_date_midpoint("not-a-date") is None
+    assert ss._parse_date_midpoint("2026-13-99") is None
 
 
 def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -183,7 +183,13 @@ def test_scan_honors_days_window(doctor_vault, monkeypatch):
 
 
 def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch):
-    """Insight whose mtime does not fall inside any session window → UNRESOLVED (or not flagged)."""
+    """Insight whose date has no overlapping session window → UNRESOLVED.
+
+    Under day-overlap matching, the matcher finds any session whose JSONL
+    window touches the note's calendar day. To produce an unresolved case we
+    need the only session to be on a *different* calendar day so no overlap
+    exists at all.
+    """
     import vault_doctor_checks.source_sessions as check
 
     v = doctor_vault["vault"]
@@ -191,11 +197,13 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
     jsonl_dir = doctor_vault["jsonl_dir"]
     monkeypatch.setenv("HOME", str(home))
 
-    a_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
-    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-10T10:00:00Z", a_start + 3600)
-    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-a", "aaaa")
+    # Session on 2026-04-09 only — no session on 2026-04-10
+    a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
+    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_start + 3600)
+    _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
 
-    # Insight captured at 20:00 — no session window covers it, and current source 'wrong-sid' isn't a real session
+    # Insight dated 2026-04-10 — day-overlap finds no session whose window
+    # touches 2026-04-10, so the result is unresolved.
     gap_mtime = calendar.timegm(time.strptime("2026-04-10 20:00", "%Y-%m-%d %H:%M"))
     _write_insight(
         v / "claude-insights",

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1609,3 +1609,22 @@ def test_scan_emits_unresolved_when_jsonl_exists_but_session_note_missing(
     assert issue.extra.get("missing_session_note") is True
     assert issue.extra.get("jsonl_path") == str(orphan_jsonl)
     assert issue.confidence == 0.0
+
+
+def test_list_all_session_notes_warns_on_malformed_frontmatter(tmp_path, capsys):
+    """A `.md` file that opens with `---` but whose frontmatter fails to parse
+    should be skipped AND warned about on stderr — operators need a signal
+    that something is wrong with that note (review C5)."""
+    sessions_dir = tmp_path / "claude-sessions"
+    sessions_dir.mkdir()
+    bad = sessions_dir / "2026-04-22-malformed.md"
+    # Frontmatter block opens with --- but has no closing --- on its own line:
+    # _parse_frontmatter regex returns {} (no match), and the file starts with
+    # "---", so the malformed-warning branch fires.
+    bad.write_text("---\nfoo: bar\nno closing block here\n", encoding="utf-8")
+
+    out = ss._list_all_session_notes(sessions_dir)
+    captured = capsys.readouterr()
+    assert out == {}, f"expected empty dict for malformed-only dir, got {out}"
+    assert "[vault_doctor] malformed frontmatter, skipped:" in captured.err
+    assert "2026-04-22-malformed.md" in captured.err

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1903,3 +1903,136 @@ def test_scan_reason_text_branches_by_signal(doctor_vault, monkeypatch):
         f"created_at-signal reason should describe capture_time, got: {ca_issue.reason}"
     )
     assert "matches session" in ca_issue.reason and "window" in ca_issue.reason
+
+
+def test_scan_reason_text_for_mtime_fallback_uses_point_in_window(
+    doctor_vault, monkeypatch
+):
+    """Copilot R4-1: when capture_signal is 'mtime' AND there's no fm.date
+    AND no YYYY-MM-DD filename prefix, scan() falls through to the point-in-
+    window matcher (not day-overlap). Reason text must say 'capture_time
+    matches session window' not 'calendar day overlaps session window'.
+    """
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_target = "55555555-5555-5555-5555-555555555555"
+    t_first = datetime(2026, 4, 24, 10, 0, tzinfo=timezone.utc).timestamp()
+    t_last = datetime(2026, 4, 24, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(
+        jsonl_dir / f"{sid_target}.jsonl",
+        datetime.fromtimestamp(t_first, tz=timezone.utc).isoformat(),
+        t_last,
+    )
+    _write_session_note(
+        vault / "claude-sessions", "2026-04-24", project, sid_target, "tgt5"
+    )
+
+    # Note with NO created_at, NO date frontmatter, NO YYYY-MM-DD filename prefix.
+    # Filename is intentionally non-date-prefixed.
+    note = vault / "claude-insights" / "mtime-only-no-date-no-filename.md"
+    note.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "source_session: 00000000-0000-0000-0000-000000000055\n"
+        'source_session_note: "[[bogus]]"\n'
+        f"project: {project}\n"
+        "tags:\n"
+        f"  - claude/insight\n"
+        "---\n# m\n",
+        encoding="utf-8",
+    )
+    os.utime(note, (t_first + 1800, t_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(note)]
+    assert flagged, "mtime-only note should flag (mtime falls inside window)"
+    issue = flagged[0]
+    assert issue.extra.get("capture_signal") == "mtime"
+    assert "capture_time" in issue.reason, (
+        f"mtime fallback uses point-in-window matcher; reason should say "
+        f"'capture_time' not 'calendar day'. Got: {issue.reason}"
+    )
+    assert "calendar day" not in issue.reason, (
+        f"mtime-fallback reason must not claim calendar-day overlap. Got: {issue.reason}"
+    )
+
+
+def test_convergence_guard_excludes_created_at_signal(doctor_vault, monkeypatch):
+    """Copilot R4-2: created_at signal uses point-in-window matching with
+    sub-day precision. Two legitimate stale insights from the same session
+    sharing a proposal target is normal — not heuristic collapse — so they
+    must NOT be capped to 0.4 by the convergence guard.
+    """
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_target = "66666666-6666-6666-6666-666666666666"
+    t_first = datetime(2026, 4, 25, 9, 0, tzinfo=timezone.utc).timestamp()
+    t_last = datetime(2026, 4, 25, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(
+        jsonl_dir / f"{sid_target}.jsonl",
+        datetime.fromtimestamp(t_first, tz=timezone.utc).isoformat(),
+        t_last,
+    )
+    _write_session_note(
+        vault / "claude-sessions", "2026-04-25", project, sid_target, "tgt6"
+    )
+
+    # Two insights with created_at signal both stale-pointing at a missing UUID.
+    # Both will be matched to sid_target (point-in-window). Without the R4-2
+    # fix, the convergence guard would cap both to 0.4 — a false positive.
+    for slug, ts in (("alpha", "2026-04-25T10:00:00+00:00"),
+                     ("beta", "2026-04-25T11:30:00+00:00")):
+        n = vault / "claude-insights" / f"created-at-conv-{slug}.md"
+        n.write_text(
+            "---\n"
+            "type: claude-insight\n"
+            f"created_at: {ts}\n"
+            "source_session: 00000000-0000-0000-0000-000000000066\n"
+            'source_session_note: "[[bogus]]"\n'
+            f"project: {project}\n"
+            "tags:\n"
+            f"  - claude/insight\n"
+            "---\n# x\n",
+            encoding="utf-8",
+        )
+        os.utime(n, (t_first + 3600, t_first + 3600))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    created_at_flags = [
+        i for i in issues
+        if i.extra.get("capture_signal") == "created_at"
+        and i.extra.get("proposed_sid") == sid_target
+    ]
+    assert len(created_at_flags) == 2, (
+        f"expected exactly 2 created_at flags converging on {sid_target}, "
+        f"got {len(created_at_flags)}"
+    )
+    for issue in created_at_flags:
+        assert issue.confidence == 0.95, (
+            f"created_at-signal flag must keep its 0.95 confidence — "
+            f"convergence guard should not cap created_at. Got: {issue.confidence}"
+        )
+        assert not issue.extra.get("convergence_warning"), (
+            f"convergence_warning must be False for created_at flags. "
+            f"Got: {issue.extra}"
+        )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1286,3 +1286,197 @@ def test_scan_trusts_cross_midnight_source(doctor_vault, monkeypatch):
         "regression: cross-midnight session_note.date=note.date-1 not trusted "
         "(session window overlaps note's calendar day → should be trusted)"
     )
+
+
+# ---------------------------------------------------------------------------
+# T5e Fix 1 — snapshot type filter
+# ---------------------------------------------------------------------------
+
+def test_list_all_session_notes_filters_out_snapshots(doctor_vault):
+    """Snapshot notes share session_id with parents; only sessions get indexed."""
+    vault = doctor_vault["vault"]
+    sessions = vault / "claude-sessions"
+    sid = "11111111-1111-1111-1111-111111111111"
+
+    # Parent session note
+    parent = sessions / "2026-04-21-proj1-1111.md"
+    parent.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-21\n"
+        f"session_id: {sid}\n"
+        "project: proj1\n"
+        "---\n# session\n",
+        encoding="utf-8",
+    )
+    # Snapshot note with the same SID — must NOT clobber parent in idx
+    snap = sessions / "2026-04-21-proj1-1111-snapshot-131103.md"
+    snap.write_text(
+        "---\n"
+        "type: claude-snapshot\n"
+        "date: 2026-04-21\n"
+        f"session_id: {sid}\n"
+        "project: proj1\n"
+        "---\n# snap\n",
+        encoding="utf-8",
+    )
+
+    idx = ss._list_all_session_notes(sessions)
+    assert sid in idx
+    assert idx[sid]["basename"] == "2026-04-21-proj1-1111", (
+        f"snapshot clobbered parent: got {idx[sid]['basename']!r}"
+    )
+
+
+def test_list_session_notes_filters_out_snapshots(doctor_vault):
+    """Project-scoped variant must also skip snapshot type."""
+    vault = doctor_vault["vault"]
+    sessions = vault / "claude-sessions"
+    sid = "22222222-2222-2222-2222-222222222222"
+
+    parent = sessions / "2026-04-21-proj1-2222.md"
+    parent.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-21\n"
+        f"session_id: {sid}\n"
+        "project: proj1\n"
+        "---\n# session\n",
+        encoding="utf-8",
+    )
+    snap = sessions / "2026-04-21-proj1-2222-snapshot-090000.md"
+    snap.write_text(
+        "---\n"
+        "type: claude-snapshot\n"
+        "date: 2026-04-21\n"
+        f"session_id: {sid}\n"
+        "project: proj1\n"
+        "---\n# snap\n",
+        encoding="utf-8",
+    )
+
+    idx = ss._list_session_notes(sessions, "proj1")
+    assert idx[sid]["basename"] == "2026-04-21-proj1-2222"
+
+
+# ---------------------------------------------------------------------------
+# T5e Fix 2 — trust UUID when JSONL exists but session note is missing
+# ---------------------------------------------------------------------------
+
+def test_scan_trusts_uuid_when_jsonl_exists_but_note_missing(doctor_vault, monkeypatch):
+    """When source_session UUID has a real JSONL but no session note, the
+    UUID is still authoritative — refuse to propose a different-session
+    rewrite. (Reference: issue #93 + #98 interaction.)"""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_orphan = "33333333-3333-3333-3333-333333333333"
+    o_first = datetime(2026, 4, 22, 11, 0, tzinfo=timezone.utc).timestamp()
+    o_last = datetime(2026, 4, 22, 22, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_orphan}.jsonl",
+                 datetime.fromtimestamp(o_first, tz=timezone.utc).isoformat(),
+                 o_last)
+    # NOTE: No session note written for sid_orphan — simulates SessionEnd hook miss
+
+    # A different real session whose window also overlaps the day —
+    # without the fix, the matcher would propose this as the "correct" target.
+    sid_distractor = "44444444-4444-4444-4444-444444444444"
+    d_first = datetime(2026, 4, 22, 12, 30, tzinfo=timezone.utc).timestamp()
+    d_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_distractor}.jsonl",
+                 datetime.fromtimestamp(d_first, tz=timezone.utc).isoformat(),
+                 d_last)
+    _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_distractor, "dist")
+
+    # Insight whose source_session is the orphan UUID
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="orphan-uuid-trust",
+        project=project,
+        src_sid=sid_orphan,
+        src_note_basename="2026-04-22-proj1-orph",
+        mtime=o_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged_paths = [i.note_path for i in issues if i.note_path == str(insight)]
+    if flagged_paths:
+        # Acceptable behavior: emit unresolved (UUID is real but note is missing).
+        # Unacceptable: propose sid_distractor as a rewrite target.
+        flagged = [i for i in issues if i.note_path == str(insight)][0]
+        if not flagged.extra.get("unresolved"):
+            assert flagged.extra.get("proposed_sid") != sid_distractor, (
+                "regression: matcher proposed a different session when "
+                "source UUID had a real JSONL (just missing session note)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# T5e Fix 3 — day-overlap matcher for date-precision signals
+# ---------------------------------------------------------------------------
+
+def test_scan_day_overlap_picks_morning_session(doctor_vault, monkeypatch):
+    """Sessions that ended before noon UTC must still be candidates for
+    notes whose date matches the calendar day. Old noon-anchor matcher
+    excluded them; day-overlap matcher includes them by overlap size."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Morning session: 08:00 → 11:05 UTC (ended before noon)
+    sid_morning = "55555555-5555-5555-5555-555555555555"
+    m_first = datetime(2026, 4, 24, 8, 0, tzinfo=timezone.utc).timestamp()
+    m_last = datetime(2026, 4, 24, 11, 5, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_morning}.jsonl",
+                 datetime.fromtimestamp(m_first, tz=timezone.utc).isoformat(),
+                 m_last)
+    sess_m = _write_session_note(vault / "claude-sessions", "2026-04-24", project, sid_morning, "morn")
+
+    # Noon-anchored session: 12:30 → 14:00 — what the old matcher would have picked
+    sid_noon = "66666666-6666-6666-6666-666666666666"
+    n_first = datetime(2026, 4, 24, 12, 30, tzinfo=timezone.utc).timestamp()
+    n_last = datetime(2026, 4, 24, 14, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_noon}.jsonl",
+                 datetime.fromtimestamp(n_first, tz=timezone.utc).isoformat(),
+                 n_last)
+    _write_session_note(vault / "claude-sessions", "2026-04-24", project, sid_noon, "noon")
+
+    # Insight on 2026-04-24 with a non-resolving source_session UUID and no
+    # JSONL anywhere — falls through to the matcher. Morning session has
+    # the larger overlap (185 minutes vs 90 minutes), so day-overlap picks it.
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-24",
+        slug="morning-session",
+        project=project,
+        src_sid="00000000-0000-0000-0000-000000000099",
+        src_note_basename="2026-04-24-bogus",
+        mtime=m_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight) and not i.extra.get("unresolved")]
+    if flagged:
+        # Day-overlap matcher should pick the morning session (larger overlap)
+        assert flagged[0].extra.get("proposed_sid") == sid_morning, (
+            f"day-overlap matcher should prefer morning session ({sid_morning}) "
+            f"over noon session ({sid_noon}); got {flagged[0].extra.get('proposed_sid')}"
+        )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1789,3 +1789,117 @@ def test_find_jsonl_anywhere_returns_none_when_missing(tmp_path, monkeypatch):
     monkeypatch.setenv("HOME", str(tmp_path))
     (tmp_path / ".claude" / "projects" / "-Users-foo-projX").mkdir(parents=True)
     assert ss._find_jsonl_anywhere("99999999-9999-9999-9999-999999999999") is None
+
+
+def test_find_jsonl_anywhere_uses_cache(tmp_path, monkeypatch):
+    """Copilot R3: per-scan cache amortizes glob cost when scan() looks up the
+    same UUID multiple times across notes (or both Phase 1b paths)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    sid = "deadbeef-dead-beef-dead-deadbeefdead"
+    cc = tmp_path / ".claude" / "projects" / "-Users-foo-projC"
+    cc.mkdir(parents=True)
+    (cc / f"{sid}.jsonl").write_text("{}\n")
+
+    cache: dict[str, ss.Path | None] = {}
+    first = ss._find_jsonl_anywhere(sid, cache=cache)
+    assert first is not None
+    assert sid in cache and cache[sid] == first
+
+    # Now break globbing — if cache works, lookup still succeeds.
+    monkeypatch.setattr(ss.glob, "glob", lambda pattern: [])
+    second = ss._find_jsonl_anywhere(sid, cache=cache)
+    assert second == first, "cache hit must short-circuit the glob"
+
+    # Negative cache: a missing SID is also memoized.
+    miss_sid = "11111111-1111-1111-1111-111111111111"
+    missed = ss._find_jsonl_anywhere(miss_sid, cache=cache)
+    assert missed is None
+    assert miss_sid in cache and cache[miss_sid] is None
+
+
+def test_scan_reason_text_branches_by_signal(doctor_vault, monkeypatch):
+    """Copilot R3: day-precision matches (date/filename signal) describe a
+    calendar-day overlap; created_at matches describe a point-in-window match.
+    Reason strings must reflect the actual matcher used.
+    """
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # date-signal: insight has frontmatter `date:` only. Day-overlap matcher fires.
+    sid_date_target = "33333333-3333-3333-3333-333333333333"
+    d_first = datetime(2026, 4, 22, 8, 0, tzinfo=timezone.utc).timestamp()
+    d_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(
+        jsonl_dir / f"{sid_date_target}.jsonl",
+        datetime.fromtimestamp(d_first, tz=timezone.utc).isoformat(),
+        d_last,
+    )
+    _write_session_note(
+        vault / "claude-sessions", "2026-04-22", project, sid_date_target, "dtgt"
+    )
+
+    insight_date = vault / "claude-insights" / "2026-04-22-date-signal.md"
+    insight_date.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "date: 2026-04-22\n"
+        "source_session: 00000000-0000-0000-0000-000000000088\n"
+        'source_session_note: "[[bogus]]"\n'
+        f"project: {project}\n"
+        "tags:\n"
+        f"  - claude/insight\n"
+        "---\n# d\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_date, (d_first + 3600, d_first + 3600))
+
+    # created_at-signal: insight has frontmatter `created_at:`. Point matcher fires.
+    sid_ca_target = "44444444-4444-4444-4444-444444444444"
+    c_first = datetime(2026, 4, 23, 9, 0, tzinfo=timezone.utc).timestamp()
+    c_last = datetime(2026, 4, 23, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(
+        jsonl_dir / f"{sid_ca_target}.jsonl",
+        datetime.fromtimestamp(c_first, tz=timezone.utc).isoformat(),
+        c_last,
+    )
+    _write_session_note(
+        vault / "claude-sessions", "2026-04-23", project, sid_ca_target, "ctgt"
+    )
+
+    insight_ca = vault / "claude-insights" / "2026-04-23-ca-signal.md"
+    insight_ca.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "created_at: 2026-04-23T10:30:00+00:00\n"
+        "source_session: 00000000-0000-0000-0000-000000000077\n"
+        'source_session_note: "[[bogus]]"\n'
+        f"project: {project}\n"
+        "tags:\n"
+        f"  - claude/insight\n"
+        "---\n# c\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_ca, (c_first + 1800, c_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+
+    date_issue = next(i for i in issues if i.note_path == str(insight_date))
+    assert "calendar day" in date_issue.reason, (
+        f"date-signal reason should describe calendar-day overlap, got: {date_issue.reason}"
+    )
+    assert "overlaps session" in date_issue.reason
+
+    ca_issue = next(i for i in issues if i.note_path == str(insight_ca))
+    assert "capture_time" in ca_issue.reason, (
+        f"created_at-signal reason should describe capture_time, got: {ca_issue.reason}"
+    )
+    assert "matches session" in ca_issue.reason and "window" in ca_issue.reason

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1013,6 +1013,222 @@ def test_scan_created_at_bypasses_early_exit(doctor_vault, monkeypatch):
     )
 
 
+def test_scan_uuid_first_lookup_across_projects(doctor_vault, monkeypatch):
+    """Phase 1b looks up source_session UUID across all projects, not just
+    the note's declared project. Insight notes from a worktree-launched skill
+    may have project=A while their actual source session has project=A--worktree-slug.
+    The UUID is globally unique; the cross-project lookup must trust it."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    project = doctor_vault["project"]  # "proj1"
+    monkeypatch.setenv("HOME", str(home))
+
+    # Create a worktree-style adjacent project's JSONL dir
+    worktree_jsonl_dir = home / ".claude" / "projects" / "-Users-foo-proj1--worktree"
+    worktree_jsonl_dir.mkdir(parents=True)
+
+    sid_w = "77777777-7777-7777-7777-777777777777"
+    w_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    w_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(worktree_jsonl_dir / f"{sid_w}.jsonl",
+                 datetime.fromtimestamp(w_first, tz=timezone.utc).isoformat(),
+                 w_last)
+
+    # Session note records project=proj1--worktree (the worktree's name)
+    sess = vault / "claude-sessions" / "2026-04-22-proj1-worktree-7777.md"
+    sess.write_text(
+        "---\n"
+        "type: claude-session\n"
+        "date: 2026-04-22\n"
+        f"session_id: {sid_w}\n"
+        "project: proj1--worktree\n"
+        "status: summarized\n"
+        "---\n"
+        "# Session\n## Summary\nstub\n",
+        encoding="utf-8",
+    )
+
+    # Insight has project=proj1 (declared from main-repo cwd) but its source
+    # session was in a worktree (project=proj1--worktree). Without UUID-first
+    # cross-project lookup, this would be flagged as stale.
+    insight = _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="cross-project-uuid",
+        project=project,  # "proj1"
+        src_sid=sid_w,
+        src_note_basename=sess.stem,
+        mtime=w_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    paths = [i.note_path for i in issues]
+    assert str(insight) not in paths, (
+        "regression: cross-project UUID resolution failed; insight flagged "
+        "despite source UUID resolving to a real session note"
+    )
+
+
+def test_scan_basename_only_repair_when_uuid_resolves(doctor_vault, monkeypatch):
+    """When the source_session UUID resolves correctly but the basename in
+    source_session_note is stale (e.g., un-truncated worktree slug vs
+    truncated actual filename), propose a basename-only repair. UUID stays."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid = "88888888-8888-8888-8888-888888888888"
+    s_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    s_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid}.jsonl",
+                 datetime.fromtimestamp(s_first, tz=timezone.utc).isoformat(),
+                 s_last)
+
+    # Session note exists with truncated basename
+    sess = _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid, "8888")
+
+    # Insight records a STALE (un-truncated) basename in source_session_note
+    insight_path = vault / "claude-insights" / "2026-04-22-basename-repair.md"
+    stale_basename = "2026-04-22-proj1-some-very-long-original-name-that-was-truncated-8888"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-22\n"
+        f"source_session: {sid}\n"
+        f'source_session_note: "[[{stale_basename}]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    import os as _os
+    _os.utime(insight_path, (s_first + 1800, s_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert len(flagged) == 1, "expected basename-mismatch flag"
+    iss = flagged[0]
+    assert iss.extra.get("basename_only") is True
+    assert iss.extra.get("proposed_sid") == sid  # UUID unchanged
+    assert sess.stem in iss.proposed_source  # actual basename in proposal
+    assert iss.confidence >= 0.95
+
+
+def test_scan_caps_date_signal_confidence(doctor_vault, monkeypatch):
+    """Matcher-proposed flags using only date/filename signals must be capped
+    at confidence <= 0.6 -- multi-session days collapse onto noon-UTC and
+    produce uniform-but-wrong proposals."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa11"
+    sid_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb11"
+
+    a_first = datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc).timestamp()
+    a_last = datetime(2026, 4, 21, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_a}.jsonl",
+                 datetime.fromtimestamp(a_first, tz=timezone.utc).isoformat(),
+                 a_last)
+    b_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    b_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_b}.jsonl",
+                 datetime.fromtimestamp(b_first, tz=timezone.utc).isoformat(),
+                 b_last)
+
+    _write_session_note(vault / "claude-sessions", "2026-04-21", project, sid_a, "1111")
+    _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_b, "2222")
+
+    # Insight on day B (sole same-day session) but source_session points to
+    # day-A session whose UUID does NOT resolve (no entry in idx for proj1)
+    bogus_sid = "00000000-0000-0000-0000-000000000000"
+    _write_insight(
+        vault / "claude-insights",
+        date="2026-04-22",
+        slug="conf-cap",
+        project=project,
+        src_sid=bogus_sid,
+        src_note_basename="2026-04-22-bogus",
+        mtime=b_first + 1800,
+    )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if "conf-cap" in i.note_path and not i.extra.get("unresolved")]
+    assert len(flagged) == 1
+    assert flagged[0].confidence <= 0.6
+
+
+def test_scan_convergence_guard_lowers_confidence(doctor_vault, monkeypatch):
+    """When 2+ flags in a project converge on the same proposed session,
+    confidence drops to <= 0.4 and convergence_warning is set."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # One real session whose window contains noon on the day notes claim
+    sid_real = "cccccccc-cccc-cccc-cccc-cccccccccc11"
+    r_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    r_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_real}.jsonl",
+                 datetime.fromtimestamp(r_first, tz=timezone.utc).isoformat(),
+                 r_last)
+    _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_real, "real")
+
+    # Two insights with bogus UUIDs that don't resolve -> matcher proposes sid_real for both
+    for slug, bogus in [
+        ("converge-1", "11111111-1111-1111-1111-111111111199"),
+        ("converge-2", "22222222-2222-2222-2222-222222222299"),
+    ]:
+        _write_insight(
+            vault / "claude-insights",
+            date="2026-04-22",
+            slug=slug,
+            project=project,
+            src_sid=bogus,
+            src_note_basename="2026-04-22-bogus",
+            mtime=r_first + 1800,
+        )
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if "converge" in i.note_path and i.extra.get("proposed_sid") == sid_real]
+    assert len(flagged) == 2, f"expected 2 convergence flags, got {len(flagged)}"
+    for i in flagged:
+        assert i.extra.get("convergence_warning") is True, (
+            f"expected convergence_warning on {i.note_path}"
+        )
+        assert i.extra.get("convergence_count") == 2
+        assert i.confidence <= 0.4
+
+
 def test_scan_trusts_cross_midnight_source(doctor_vault, monkeypatch):
     """Phase 1b extension (issue #93): a session that started the night before
     note.date and ran into note.date is the legitimate cross-midnight case.


### PR DESCRIPTION
## Summary

Closes #93. Replaces `os.path.getmtime()` capture-time in `scripts/vault_doctor_checks/source_sessions.py` with an immutable-signal preference chain (`created_at` → `date` → filename prefix → mtime), plus a Phase 1b early-exit when the current source's JSONL window overlaps the note's calendar day.

Per memory `technical_github_closes_only_default_branch`: `Closes #93` won't auto-link because base is `develop` not the default branch. Issue will be closed manually post-merge.

## Why

The 2026-04-24 dry-run flagged 17 source-sessions issues. Sampling 7 showed 5 had filename and frontmatter `date:` agreeing on the real capture day while mtime had drifted into a later session's window (touched by `/check-items`, `/link`, `/compress`, manual edits, sync). Applying the proposed fix would have rewritten 5+ correct backlinks to wrong sessions — silent corruption.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-04-24-issue-93-source-sessions-capture-time-design.md` on `abhattacherjee/spec-docs` branch `spec/issue-93-source-sessions-capture-time`
- Plan: `docs/superpowers/plans/2026-04-24-issue-93-source-sessions-capture-time.md` on `abhattacherjee/spec-docs` branch `plan/issue-93-source-sessions-capture-time`

## Notable spec deviation

The spec specified Phase 1b as `session_note.date == note.date`. Live verification revealed that session-note `date:` fields drift due to migrations, renames, and sibling vault-doctor checks — making strict equality too narrow. The implementation uses **JSONL window overlap with the note's calendar day** instead. The JSONL window `(first_entry_ts, mtime)` is ground truth for when a session was active. This correctly handles cross-midnight sessions (the original failure mode), early-morning captures from previous-night sessions, and date-drift on session notes. Documented in commit `43c9f4f` and the CHANGELOG entry.

## Changes (13 commits)

- `scripts/vault_doctor_checks/source_sessions.py`:
  - `_parse_date_ts(date_str, hour)` helper + named shims `_parse_date_midpoint` (12:00 UTC) / `_parse_date_start` (00:00 UTC)
  - `_capture_time(note, fm)` 4-rung preference chain returning `(ts, conf, signal_name)`
  - Module-level `_FILENAME_DATE_RE`
  - `scan()` uses `_capture_time(...)` for matcher input; `mtime` retained only as the `--days` cutoff filter
  - Phase 1b early-exit using JSONL window overlap (with `created_at` carve-out)
  - `Issue.extra` includes `capture_signal` and `capture_confidence` in both branches
  - Module docstring updated; reason strings use `capture_time` and surface signal/conf
- `scripts/vault_doctor.py`: pass `capture_signal`/`capture_confidence` through JSON output (caught and fixed by final review)
- `tests/test_vault_doctor_source_sessions.py`: 11 new unit tests; 5 pre-existing fixtures widened
- `tests/test_vault_doctor.py`, `tests/test_vault_doctor_integration.py`: 3 fixtures widened
- `templates/{insight,decision,error-fix}.md`: `created_at: {{created_at}}` line added
- `skills/{error-log,decide,retro,compress}/SKILL.md`: `created_at: <ISO-8601-UTC>` in new-note frontmatter blocks + 'Where:' derivation bullet
- `skills/vault-doctor/SKILL.md`: step 3 renders `signal: <name> (conf <value>)` line
- `CHANGELOG.md`: `[Unreleased]` Fixed + Added entries

## Test plan

- [x] All 718 tests pass (\`pytest\`)
- [x] 11 new unit tests cover: 4 signal rungs, drift-survives-later-edit, current-source-trusted-when-same-day, signal/conf in payload, unresolved reason uses capture_time, created_at carve-out pin, cross-midnight trust
- [x] Live vault verification: all 5 confirmed false positives from the 2026-04-24 dry-run now clear
- [x] JSON output exposes `capture_signal` and `capture_confidence`
- [ ] \`/dev-test install\` + fresh CC session smoke test (per memory feedback_devtest_merge_gate)
- [ ] Copilot review (via pr-review-cli.sh)
- [ ] Operator dry-run review of remaining flags before any \`fix\` invocation

## Follow-ups

- #95 (audit-historic-repairs) unblocks once this lands. The audit will use the same signal-aware logic to classify the 55 backups in `~/.claude/obsidian-brain-doctor-backup/`.
- #99 (project-name-canonicalization vault-doctor check) — backfill existing notes that have worktree-derived project names. Depends on this PR for the `canonical_project_name()` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)