### PR TITLE
fix(obsidian-brain): source-session basename stability (#101, subsumes #86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Source-session basename divergence between `get_session_context()` and SessionEnd that broke insight wikilinks across cross-midnight, worktree, and resumed sessions ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101))
 - Snapshot/session hash collision in the resolver could pick a snapshot when an insight saver intended to link to a session ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101) Fix C)
-- `is_resumed_session` first-match-wins glob now filters by `type: claude-session` and `project_path`, eliminating false positives from cross-project hash collisions ([#86](https://github.com/abhattacherjee/obsidian-brain/issues/86), subsumed by [#101](https://github.com/abhattacherjee/obsidian-brain/issues/101))
+- `is_resumed_session` now returns True only when a session-type note for the current project (matched by `project_path` against `cwd`) exists for this session_id's hash — eliminating false positives from cross-project hash collisions and snapshot-only matches ([#86](https://github.com/abhattacherjee/obsidian-brain/issues/86), subsumed by [#101](https://github.com/abhattacherjee/obsidian-brain/issues/101))
 - **vault-doctor source-sessions silently corrupted backlinks** when a note's
   mtime drifted past the originating session's JSONL window (any later edit
   by `/check-items`, `/link`, `/compress`, sync clients, or another vault-doctor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `decide`, `retro`, and `compress` (new-note flow) for sub-day-precision
   capture-time matching by vault-doctor. Net-additive — older notes continue
   to fall back to `date:` (day precision).
+- `_first_seen_date(sid)` marker (atomic, idempotent JSON at `~/.claude/obsidian-brain/sessions/<sid>.json`) consulted by both `get_session_context()` and SessionEnd to keep insight wikilinks and on-disk filenames in lockstep ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101) Fix A)
+- `_resolve_session_note_by_hash()` shared helper with type+project filter and collision detection ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101) Fix C)
+- `tests/test_get_session_context.py` — 21 tests covering markers, peek helpers, resolver, and the project-slug invariant
 
 ### Fixed
+- Source-session basename divergence between `get_session_context()` and SessionEnd that broke insight wikilinks across cross-midnight, worktree, and resumed sessions ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101))
+- Snapshot/session hash collision in the resolver could pick a snapshot when an insight saver intended to link to a session ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101) Fix C)
+- `is_resumed_session` first-match-wins glob now filters by `type: claude-session` and `project_path`, eliminating false positives from cross-project hash collisions ([#86](https://github.com/abhattacherjee/obsidian-brain/issues/86), subsumed by [#101](https://github.com/abhattacherjee/obsidian-brain/issues/101))
 - **vault-doctor source-sessions silently corrupted backlinks** when a note's
   mtime drifted past the originating session's JSONL window (any later edit
   by `/check-items`, `/link`, `/compress`, sync clients, or another vault-doctor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to fall back to `date:` (day precision).
 - `_first_seen_date(sid)` marker (atomic, idempotent JSON at `~/.claude/obsidian-brain/sessions/<sid>.json`) consulted by both `get_session_context()` and SessionEnd to keep insight wikilinks and on-disk filenames in lockstep ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101) Fix A)
 - `_resolve_session_note_by_hash()` shared helper with type+project filter and collision detection ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101) Fix C)
-- `tests/test_get_session_context.py` — 21 tests covering markers, peek helpers, resolver, and the project-slug invariant
+- `tests/test_get_session_context.py` — comprehensive coverage of markers, peek helpers, resolver, and the project-slug invariant
 
 ### Fixed
 - Source-session basename divergence between `get_session_context()` and SessionEnd that broke insight wikilinks across cross-midnight, worktree, and resumed sessions ([#101](https://github.com/abhattacherjee/obsidian-brain/issues/101))

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -257,7 +257,10 @@ def _run() -> None:
             )
 
         # 7. Detect resumed session
-        resumed = is_resumed_session(vault_path, sessions_folder, session_id)
+        # Pass the authoritative cwd from hook_input so the project_path filter
+        # uses Claude Code's truth-of-record rather than os.getcwd(), which can
+        # drift if anything chdir'd inside the hook process.
+        resumed = is_resumed_session(vault_path, sessions_folder, session_id, cwd=cwd)
         if resumed:
             print(f"[obsidian-brain] resumed session detected", file=sys.stderr)
 

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+import obsidian_utils  # noqa: E402  — used for _first_seen_date qualified call
 from obsidian_utils import (  # noqa: E402
     build_raw_fallback,
     extract_assistant_messages,
@@ -261,7 +262,10 @@ def _run() -> None:
             print(f"[obsidian-brain] resumed session detected", file=sys.stderr)
 
         # 8. Build filename
-        date_str = datetime.date.today().isoformat()
+        # Use _first_seen_date so insights saved during the session and the
+        # session note written here resolve to the same basename even when
+        # the session crosses midnight or is resumed across calendar days.
+        date_str = obsidian_utils._first_seen_date(session_id)
         project_slug = slugify(metadata.get("project", "session"))
         filename = make_filename(date_str, project_slug, session_id)
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -160,6 +160,52 @@ def _peek_frontmatter_project_path(path: Path) -> str | None:
     return _peek_frontmatter_field(path, "project_path")
 
 
+def _resolve_session_note_by_hash(
+    sessions_dir: Path | str,
+    h: str,
+    cwd: str | None = None,
+) -> tuple[str | None, list[str]]:
+    """Resolve ``*-{h}.md`` to a session-type note matching this project.
+
+    Replaces first-match-wins glob discipline with a type+project filter
+    that handles the three known collision modes:
+      1. session_id sharing with snapshot notes (#101 Fix C)
+      2. cross-project 4-char hash collision (#101 Fix C)
+      3. genuine same-session_id duplicates (subsumes #86)
+
+    Returns ``(basename_without_ext, collisions)``:
+      - exactly one session-type match              → (basename, [])
+      - 2+ session matches but exactly one cwd match → (basename, [other names])
+      - 0 session-type matches                       → (None, [])
+      - 2+ matches and ambiguous after cwd filter    → (None, [all session names])
+
+    Caller pattern: warn on non-empty ``collisions`` and fall back to a
+    composed name (via ``make_filename(_first_seen_date(sid), project, sid)``)
+    when ``basename is None``.
+    """
+    sessions_dir = Path(sessions_dir)
+    if not sessions_dir.is_dir():
+        return None, []
+
+    matches = sorted(sessions_dir.glob(f"*-{h}.md"))
+    session_matches = [m for m in matches if _peek_frontmatter_type(m) == "claude-session"]
+    if not session_matches:
+        return None, []
+    if len(session_matches) == 1:
+        return session_matches[0].stem, []
+
+    # 2+ session-type matches — try cwd disambiguation
+    if cwd:
+        cwd_matches = [m for m in session_matches
+                       if _peek_frontmatter_project_path(m) == cwd]
+        if len(cwd_matches) == 1:
+            others = [m.name for m in session_matches if m != cwd_matches[0]]
+            return cwd_matches[0].stem, others
+
+    # Still ambiguous — caller falls back
+    return None, [m.name for m in session_matches]
+
+
 # --- Secure working directory ---
 # All temp/cache files use ~/.claude/obsidian-brain/ (0o700) instead of /tmp.
 # This prevents symlink attacks and cache poisoning on multi-user systems.

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -50,6 +50,10 @@ _RE_RAW_CONVERSATION = re.compile(
     r"^## Conversation \(raw\)\n(.+?)(?=\n^## |\Z)", re.MULTILINE | re.DOTALL
 )
 
+# Session IDs are CC UUIDs (or test fixtures). Restrict to safe filename chars
+# so the marker path never escapes ~/.claude/obsidian-brain/sessions/.
+_SID_FILENAME_SAFE = re.compile(r"\A[A-Za-z0-9._-]{1,128}\Z")
+
 
 def _first_seen_date(sid: str) -> str:
     """Return the canonical first-seen calendar date for a session_id.
@@ -62,9 +66,19 @@ def _first_seen_date(sid: str) -> str:
 
     Marker location: ~/.claude/obsidian-brain/sessions/<sid>.json (0o600).
     """
+    if not _SID_FILENAME_SAFE.fullmatch(sid):
+        print(
+            f"[obsidian-brain] _first_seen_date: refusing unsafe sid shape; "
+            f"falling back to today's date",
+            file=sys.stderr,
+        )
+        return datetime.date.today().isoformat()
+
     marker_dir = Path.home() / ".claude" / "obsidian-brain" / "sessions"
     try:
         marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if marker_dir.stat().st_mode & 0o077:
+            os.chmod(marker_dir, 0o700)
     except OSError as exc:
         print(f"[obsidian-brain] _first_seen_date: cannot create marker dir: {exc}",
               file=sys.stderr)
@@ -81,14 +95,25 @@ def _first_seen_date(sid: str) -> str:
         "first_seen_date": today,
         "first_seen_iso": datetime.datetime.now(datetime.timezone.utc).isoformat(),
     }
-    tmp = marker.with_suffix(".json.tmp")
+    tmp_path = None
     try:
-        tmp.write_text(json.dumps(payload), encoding="utf-8")
-        os.chmod(tmp, 0o600)
-        tmp.replace(marker)  # atomic on POSIX
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=f".{sid}.", suffix=".json.tmp", dir=str(marker_dir)
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f)
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, marker)  # atomic on POSIX
+        tmp_path = None  # rename succeeded; nothing to clean up
     except OSError as exc:
         print(f"[obsidian-brain] _first_seen_date: marker write failed: {exc}",
               file=sys.stderr)
+    finally:
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
     return today
 
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -3171,14 +3171,26 @@ def build_raw_fallback(
 def is_resumed_session(
     vault_path: str, sessions_folder: str, session_id: str
 ) -> bool:
-    """Check if a note with the same session_id hash already exists in the vault."""
+    """Return True iff a session-type note matching this session_id's hash
+    exists for the current project. Snapshot-type notes are intentionally
+    ignored (#101 Fix C), and cross-project hash collisions are skipped via
+    project_path filtering. Subsumes #86.
+    """
     sessions_dir = Path(vault_path) / sessions_folder
     if not sessions_dir.exists():
         return False
     h = hashlib.sha256(session_id.encode()).hexdigest()[:4]
-    for _ in sessions_dir.glob(f"*-{h}.md"):
-        return True
-    return False
+    resolved, collisions = _resolve_session_note_by_hash(
+        sessions_dir, h, cwd=os.getcwd()
+    )
+    if collisions:
+        # Caller contract is bool-only; warn so the operator can investigate.
+        print(
+            f"[obsidian-brain] WARN: is_resumed_session: hash {h} collides "
+            f"across {len(collisions) + (1 if resolved else 0)} session note(s)",
+            file=sys.stderr,
+        )
+    return resolved is not None or bool(collisions)
 
 
 def upgrade_note_with_summary(

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -674,10 +674,12 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
                     session_note_name = fname[:-3]  # strip .md
                     break
 
-    # If not found, construct expected name
+    # If not found, compose the canonical basename. Both _first_seen_date()
+    # and make_filename() are also called by SessionEnd, so insight wikilinks
+    # and session-note filenames stay in lockstep across cross-midnight,
+    # worktree, and resumed-session conditions. (#101 Fix A + Fix B.)
     if not session_note_name:
-        from datetime import date
-        session_note_name = f"{date.today().isoformat()}-{project}-{h}"
+        session_note_name = make_filename(_first_seen_date(sid), project, sid)[:-3]
 
     ctx = {"session_id": sid, "hash": h, "project": project, "session_note_name": session_note_name}
     cache_set(sid, cache_key, ctx)

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -50,6 +50,48 @@ _RE_RAW_CONVERSATION = re.compile(
     r"^## Conversation \(raw\)\n(.+?)(?=\n^## |\Z)", re.MULTILINE | re.DOTALL
 )
 
+
+def _first_seen_date(sid: str) -> str:
+    """Return the canonical first-seen calendar date for a session_id.
+
+    Atomic, idempotent, lazy: marker is written on first call and never
+    modified — every subsequent call (across days, worktrees, processes)
+    returns the same date. Used by get_session_context() and SessionEnd
+    so that source_session_note wikilinks and on-disk filenames stay in
+    lockstep even when sessions cross midnight.
+
+    Marker location: ~/.claude/obsidian-brain/sessions/<sid>.json (0o600).
+    """
+    marker_dir = Path.home() / ".claude" / "obsidian-brain" / "sessions"
+    try:
+        marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    except OSError as exc:
+        print(f"[obsidian-brain] _first_seen_date: cannot create marker dir: {exc}",
+              file=sys.stderr)
+        return datetime.date.today().isoformat()  # graceful fallback
+
+    marker = marker_dir / f"{sid}.json"
+    try:
+        return json.loads(marker.read_text(encoding="utf-8"))["first_seen_date"]
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, OSError):
+        pass  # fall through and (re)write
+
+    today = datetime.date.today().isoformat()
+    payload = {
+        "first_seen_date": today,
+        "first_seen_iso": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    tmp = marker.with_suffix(".json.tmp")
+    try:
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.chmod(tmp, 0o600)
+        tmp.replace(marker)  # atomic on POSIX
+    except OSError as exc:
+        print(f"[obsidian-brain] _first_seen_date: marker write failed: {exc}",
+              file=sys.stderr)
+    return today
+
+
 # --- Secure working directory ---
 # All temp/cache files use ~/.claude/obsidian-brain/ (0o700) instead of /tmp.
 # This prevents symlink attacks and cache poisoning on multi-user systems.

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -756,12 +756,19 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
 
     session_note_name = ""
     if vault_path and sessions_folder:
-        sessions_dir = os.path.join(vault_path, sessions_folder)
-        if os.path.isdir(sessions_dir):
-            for fname in os.listdir(sessions_dir):
-                if fname.endswith(f'-{h}.md'):
-                    session_note_name = fname[:-3]  # strip .md
-                    break
+        sessions_dir = Path(vault_path) / sessions_folder
+        resolved, collisions = _resolve_session_note_by_hash(
+            sessions_dir, h, cwd=os.getcwd()
+        )
+        if collisions:
+            print(
+                f"[obsidian-brain] WARN: hash {h} matches {len(collisions) + (1 if resolved else 0)} "
+                f"session note(s); chose {resolved or '<none — fell back to composed name>'} "
+                f"(others: {collisions})",
+                file=sys.stderr,
+            )
+        if resolved:
+            session_note_name = resolved
 
     # If not found, compose the canonical basename. Both _first_seen_date()
     # and make_filename() are also called by SessionEnd, so insight wikilinks

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -93,7 +93,14 @@ def _first_seen_date(sid: str) -> str:
 
     marker = marker_dir / f"{sid}.json"
     try:
-        return json.loads(marker.read_text(encoding="utf-8"))["first_seen_date"]
+        date = json.loads(marker.read_text(encoding="utf-8"))["first_seen_date"]
+        # Self-heal mode if a previous bug or manual edit left it permissive.
+        try:
+            if marker.stat().st_mode & 0o077:
+                os.chmod(marker, 0o600)
+        except OSError:
+            pass  # mode-tightening is best-effort; readback already succeeded
+        return date
     except (FileNotFoundError, json.JSONDecodeError, KeyError, OSError):
         pass  # fall through and (re)write
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -760,6 +760,8 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
         resolved, collisions = _resolve_session_note_by_hash(
             sessions_dir, h, cwd=os.getcwd()
         )
+        # WARN fires once per process per (vault, folder) — the cache_set
+        # below short-circuits subsequent calls. Don't spam stderr.
         if collisions:
             print(
                 f"[obsidian-brain] WARN: hash {h} matches {len(collisions) + (1 if resolved else 0)} "

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -124,6 +124,8 @@ def _peek_frontmatter_field(path: Path, field: str) -> str | None:
 
     Stops at the closing ``---`` marker. Quote-stripping handles the common
     cases ``"value"`` and ``'value'``; unquoted scalars are returned verbatim.
+    Empty values (``field:`` with no scalar) are normalized to None for clean
+    truthy-checks at call sites.
     """
     try:
         with open(path, "r", encoding="utf-8") as fh:
@@ -144,7 +146,7 @@ def _peek_frontmatter_field(path: Path, field: str) -> str | None:
                     if (value.startswith('"') and value.endswith('"')) or \
                        (value.startswith("'") and value.endswith("'")):
                         value = value[1:-1]
-                    return value
+                    return value or None
     except OSError:
         return None
     return None

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -219,8 +219,22 @@ def _resolve_session_note_by_hash(
         )
         return None, []
 
-    matches = sorted(sessions_dir.glob(f"*-{h}.md"))
-    session_matches = [m for m in matches if _peek_frontmatter_type(m) == "claude-session"]
+    try:
+        matches = sorted(sessions_dir.glob(f"*-{h}.md"))
+    except OSError as exc:
+        # Permission errors / transient I/O on the sessions dir must not crash
+        # SessionEnd. Fall back to (None, []) so callers compose a fresh name.
+        print(
+            f"[obsidian-brain] _resolve_session_note_by_hash: glob failed on "
+            f"{sessions_dir}: {exc}",
+            file=sys.stderr,
+        )
+        return None, []
+    # Treat type=None as claude-session for backward-compat with legacy notes
+    # that pre-date the explicit type frontmatter field — matches the same
+    # convention used by collect_open_items() in hooks/open_item_dedup.py.
+    session_matches = [m for m in matches
+                       if (_peek_frontmatter_type(m) or "claude-session") == "claude-session"]
     if not session_matches:
         return None, []
 
@@ -241,6 +255,19 @@ def _resolve_session_note_by_hash(
     if len(session_matches) == 1:
         return session_matches[0].stem, []
     return None, [m.name for m in session_matches]
+
+
+def _safe_getcwd() -> str:
+    """Return os.getcwd() or empty string if cwd is deleted/unmounted.
+
+    Hook paths must not crash on cwd-gone (issue #105 territory) — callers
+    that pass this to _resolve_session_note_by_hash get the (None, []) /
+    (None, [...]) lenient fallback when cwd resolution fails.
+    """
+    try:
+        return os.getcwd()
+    except (OSError, FileNotFoundError):
+        return ""
 
 
 # --- Secure working directory ---
@@ -795,7 +822,7 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
     if vault_path and sessions_folder:
         sessions_dir = Path(vault_path) / sessions_folder
         resolved, collisions = _resolve_session_note_by_hash(
-            sessions_dir, h, cwd=os.getcwd()
+            sessions_dir, h, cwd=_safe_getcwd()
         )
         # WARN fires once per (session, vault, folder) — cache_set below
         # persists the result to ~/.claude/obsidian-brain/cache-<sid>.json,
@@ -3209,19 +3236,27 @@ def build_raw_fallback(
 
 
 def is_resumed_session(
-    vault_path: str, sessions_folder: str, session_id: str
+    vault_path: str, sessions_folder: str, session_id: str,
+    cwd: str | None = None,
 ) -> bool:
     """Return True iff a session-type note matching this session_id's hash
     exists for the current project. Snapshot-type notes are intentionally
     ignored (#101 Fix C), and cross-project hash collisions are skipped via
     project_path filtering. Subsumes #86.
+
+    ``cwd`` overrides ``os.getcwd()`` for the project_path filter. SessionEnd
+    callers should pass ``hook_input["cwd"]`` (the authoritative project
+    path from Claude Code) so that hook processes that have chdir'd
+    elsewhere still classify the session against the right project.
+    Falls back to ``_safe_getcwd()`` when ``cwd`` is None.
     """
     sessions_dir = Path(vault_path) / sessions_folder
     if not sessions_dir.exists():
         return False
     h = hashlib.sha256(session_id.encode()).hexdigest()[:4]
+    effective_cwd = cwd if cwd is not None else _safe_getcwd()
     resolved, collisions = _resolve_session_note_by_hash(
-        sessions_dir, h, cwd=os.getcwd()
+        sessions_dir, h, cwd=effective_cwd
     )
     if collisions:
         # Caller contract is bool-only; warn so the operator can investigate.

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -117,6 +117,47 @@ def _first_seen_date(sid: str) -> str:
     return today
 
 
+def _peek_frontmatter_field(path: Path, field: str) -> str | None:
+    """Return the unquoted YAML scalar for ``field:`` from a vault note's
+    frontmatter, or None. Reads at most 30 lines to keep the cost negligible
+    even when called on hash-collision (which is rare).
+
+    Stops at the closing ``---`` marker. Quote-stripping handles the common
+    cases ``"value"`` and ``'value'``; unquoted scalars are returned verbatim.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            in_frontmatter = False
+            for i, line in enumerate(fh):
+                if i >= 30:
+                    break
+                stripped = line.strip()
+                if stripped == "---":
+                    if not in_frontmatter:
+                        in_frontmatter = True
+                        continue
+                    break  # closing marker
+                if not in_frontmatter:
+                    continue
+                if stripped.startswith(f"{field}:"):
+                    value = stripped[len(field) + 1:].strip()
+                    if (value.startswith('"') and value.endswith('"')) or \
+                       (value.startswith("'") and value.endswith("'")):
+                        value = value[1:-1]
+                    return value
+    except OSError:
+        return None
+    return None
+
+
+def _peek_frontmatter_type(path: Path) -> str | None:
+    return _peek_frontmatter_field(path, "type")
+
+
+def _peek_frontmatter_project_path(path: Path) -> str | None:
+    return _peek_frontmatter_field(path, "project_path")
+
+
 # --- Secure working directory ---
 # All temp/cache files use ~/.claude/obsidian-brain/ (0o700) instead of /tmp.
 # This prevents symlink attacks and cache poisoning on multi-user systems.

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -679,7 +679,9 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
     # and session-note filenames stay in lockstep across cross-midnight,
     # worktree, and resumed-session conditions. (#101 Fix A + Fix B.)
     if not session_note_name:
-        session_note_name = make_filename(_first_seen_date(sid), project, sid)[:-3]
+        session_note_name = make_filename(
+            _first_seen_date(sid), slugify(project), sid
+        )[:-3]
 
     ctx = {"session_id": sid, "hash": h, "project": project, "session_note_name": session_note_name}
     cache_set(sid, cache_key, ctx)

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -58,9 +58,16 @@ _SID_FILENAME_SAFE = re.compile(r"\A[A-Za-z0-9._-]{1,128}\Z")
 def _first_seen_date(sid: str) -> str:
     """Return the canonical first-seen calendar date for a session_id.
 
-    Atomic, idempotent, lazy: marker is written on first call and never
-    modified — every subsequent call (across days, worktrees, processes)
-    returns the same date. Used by get_session_context() and SessionEnd
+    Atomic, idempotent, lazy: marker is written on first call and read
+    verbatim on subsequent calls — every subsequent call (across days,
+    worktrees, processes) returns the same date. If the marker becomes
+    corrupt or unreadable (e.g., truncated by an external process), the
+    function self-heals by rewriting it with today's date — note that
+    this resets the lockstep guarantee for that session_id.
+
+    Silent-failure paths (all log to stderr): unsafe sid shape, mkdir
+    failure, marker write failure — fall back to today's date and lockstep
+    is voided for that call. Used by get_session_context() and SessionEnd
     so that source_session_note wikilinks and on-disk filenames stay in
     lockstep even when sessions cross midnight.
 
@@ -112,8 +119,12 @@ def _first_seen_date(sid: str) -> str:
         if tmp_path is not None:
             try:
                 os.unlink(tmp_path)
-            except OSError:
-                pass
+            except OSError as cleanup_exc:
+                print(
+                    f"[obsidian-brain] _first_seen_date: failed to clean up temp file "
+                    f"{tmp_path}: {cleanup_exc}",
+                    file=sys.stderr,
+                )
     return today
 
 
@@ -146,8 +157,20 @@ def _peek_frontmatter_field(path: Path, field: str) -> str | None:
                     if (value.startswith('"') and value.endswith('"')) or \
                        (value.startswith("'") and value.endswith("'")):
                         value = value[1:-1]
-                    return value or None
-    except OSError:
+                    if not value:
+                        print(
+                            f"[obsidian-brain] _peek_frontmatter_field: {path.name} has empty "
+                            f"{field!r} field — possible mid-write or corruption",
+                            file=sys.stderr,
+                        )
+                        return None
+                    return value
+    except (OSError, UnicodeDecodeError) as exc:
+        print(
+            f"[obsidian-brain] _peek_frontmatter_field: cannot read {path.name} "
+            f"for field={field!r}: {exc}; this file will be excluded from filtering",
+            file=sys.stderr,
+        )
         return None
     return None
 
@@ -174,6 +197,10 @@ def _resolve_session_note_by_hash(
       3. genuine same-session_id duplicates (subsumes #86)
 
     Returns ``(basename_without_ext, collisions)``:
+      - basename_without_ext: file stem (no ``.md``) when resolved
+      - collisions: list of full filenames *with* ``.md`` so stderr
+        warnings are unambiguous when shown to the operator
+
       - exactly one session-type match              → (basename, [])
       - 2+ session matches but exactly one cwd match → (basename, [other names])
       - 0 session-type matches                       → (None, [])
@@ -185,24 +212,34 @@ def _resolve_session_note_by_hash(
     """
     sessions_dir = Path(sessions_dir)
     if not sessions_dir.is_dir():
+        print(
+            f"[obsidian-brain] _resolve_session_note_by_hash: sessions_dir "
+            f"{sessions_dir} does not exist or is not readable; treating as no-match",
+            file=sys.stderr,
+        )
         return None, []
 
     matches = sorted(sessions_dir.glob(f"*-{h}.md"))
     session_matches = [m for m in matches if _peek_frontmatter_type(m) == "claude-session"]
     if not session_matches:
         return None, []
-    if len(session_matches) == 1:
-        return session_matches[0].stem, []
 
-    # 2+ session-type matches — try cwd disambiguation
+    # Apply cwd filter when provided — covers single-match cross-project collision
     if cwd:
         cwd_matches = [m for m in session_matches
                        if _peek_frontmatter_project_path(m) == cwd]
         if len(cwd_matches) == 1:
             others = [m.name for m in session_matches if m != cwd_matches[0]]
             return cwd_matches[0].stem, others
+        if len(cwd_matches) == 0:
+            # No cwd match — surface ALL the cross-project matches as collisions
+            # so caller can warn, then fall back to composed name.
+            return None, [m.name for m in session_matches]
+        # Multiple cwd matches — fall through to ambiguous return below
 
-    # Still ambiguous — caller falls back
+    # No cwd OR multiple cwd matches — leniently return single-match basename
+    if len(session_matches) == 1:
+        return session_matches[0].stem, []
     return None, [m.name for m in session_matches]
 
 
@@ -760,8 +797,11 @@ def get_session_context(vault_path: str | None = None, sessions_folder: str | No
         resolved, collisions = _resolve_session_note_by_hash(
             sessions_dir, h, cwd=os.getcwd()
         )
-        # WARN fires once per process per (vault, folder) — the cache_set
-        # below short-circuits subsequent calls. Don't spam stderr.
+        # WARN fires once per (session, vault, folder) — cache_set below
+        # persists the result to ~/.claude/obsidian-brain/cache-<sid>.json,
+        # suppressing repeats across this hook process and any subsequent
+        # skill invocations within the same session until SessionEnd cleans
+        # up the cache. Don't spam stderr.
         if collisions:
             print(
                 f"[obsidian-brain] WARN: hash {h} matches {len(collisions) + (1 if resolved else 0)} "
@@ -3190,7 +3230,7 @@ def is_resumed_session(
             f"across {len(collisions) + (1 if resolved else 0)} session note(s)",
             file=sys.stderr,
         )
-    return resolved is not None or bool(collisions)
+    return resolved is not None
 
 
 def upgrade_note_with_summary(

--- a/scripts/dev-test/DEV-TEST-ISSUE-101.md
+++ b/scripts/dev-test/DEV-TEST-ISSUE-101.md
@@ -38,7 +38,18 @@ Walk through the following in a **fresh CC session**. Check each box only
 after visually confirming the described behavior. Notes section at the
 bottom for any deviations.
 
-### Phase 1 — Baseline: marker file appears for the new session
+### Phase 1 — Baseline: marker file is lazily written on first invocation
+
+> **Design note (per spec §Fix A):** the marker is **pure-lazy**. No SessionStart
+> hook calls `_first_seen_date()` directly. The marker file is created on the
+> first invocation of the helper — typically at SessionEnd when the vault note
+> basename is composed, or earlier if a helper that uses `get_session_context()`
+> falls through to its compose fallback (e.g. via /recall, /vault-search,
+> /compress when the session note doesn't already exist in vault).
+>
+> Mid-session, **it is normal for the marker file to be absent** until something
+> triggers the helper. This is by design — the spec calls out that pre-PR
+> sessions also "get markers lazily on first helper call after upgrade."
 
 - [ ] **Capture this session's ID.** In the new CC session, run:
       ```bash
@@ -46,16 +57,25 @@ bottom for any deviations.
       ```
       Note the basename minus `.jsonl` — that's `$SID`.
 
-- [ ] **Marker file exists for $SID.**
+- [ ] **Force the lazy write, then verify the marker.** Trigger any helper
+      that exercises the resolver — `/recall`, `/vault-search anything`, or
+      a direct Bash call — then check:
       ```bash
+      python3 -c '
+      import sys, glob, os
+      sys.path.insert(0, glob.glob(os.path.expanduser("~/.claude/plugins/cache/claude-code-skills/obsidian-brain/2.4.1/hooks"))[0])
+      import obsidian_utils; obsidian_utils._first_seen_date("'"$SID"'")'
+
       ls -la ~/.claude/obsidian-brain/sessions/$SID.json
       cat ~/.claude/obsidian-brain/sessions/$SID.json
       ```
       File should exist with mode `-rw-------` (0o600), and JSON should
       contain `first_seen_date` (today, ISO) and `first_seen_iso` (UTC ISO).
 
-      *If missing:* SessionStart did not run, or `_first_seen_date` was
-      never invoked. Check `~/.claude/obsidian-brain-hook.log`.
+      *If still missing after a forced helper call:* the install didn't pick
+      up the new code, or `_first_seen_date` itself failed. Check
+      `~/.claude/obsidian-brain-hook.log` and `diff -q hooks/obsidian_utils.py
+      ~/.claude/plugins/cache/claude-code-skills/obsidian-brain/2.4.1/hooks/obsidian_utils.py`.
 
 ### Phase 2 — Marker is idempotent under live use
 
@@ -218,7 +238,7 @@ bottom for any deviations.
 
 | Phase | Coverage gap pytest can't fill |
 |-------|-------------------------------|
-| 1, 2  | Marker is written by the *real* SessionStart entry point in the running CC session, not by direct helper call from a unit test |
+| 1, 2  | Lazy marker is created+stable when `_first_seen_date()` is invoked from inside a *real* running CC session against the installed cache, not by direct helper call from a unit test (per spec §Fix A: pure-lazy, no dedicated hook) |
 | 3     | SessionEnd hook integration — full write path under real config + transcript flow, including AI summarization fallback |
 | 4     | SessionStart hint render correctness — `is_resumed_session` plumbed through the user-visible "Last session" line |
 | 5     | A genuine cross-project hash collision against your live vault, not a synthetic 4-char fixture |

--- a/scripts/dev-test/DEV-TEST-ISSUE-101.md
+++ b/scripts/dev-test/DEV-TEST-ISSUE-101.md
@@ -1,0 +1,246 @@
+# Dev-Test: Source-Session Basename Stability (Issue #101 / PR #109)
+
+This is the **live Claude Code smoke test** for the source-session basename
+stability work (closes #101 + #86 + #110). It complements the automated
+script `scripts/dev-test/test-issue-101-manual.sh` which covers everything
+that can be validated via hook simulation against a throwaway fixture vault.
+
+The phases below are the bits that **only a real CC session can hit** —
+SessionStart hook narrative, real on-disk vault, /recall round-trip,
+mid-session resume.
+
+## Prerequisites
+
+1. `feature/issue-101-source-session-basename-stability` checked out, or
+   PR #109 already merged to develop and pulled.
+2. `/dev-test install` executed — installed plugin cache now contains
+   `_first_seen_date`, `_resolve_session_note_by_hash`,
+   `_peek_frontmatter_{type,project_path}`, `_safe_getcwd`, and
+   `is_resumed_session(cwd=...)`.
+3. **A new Claude Code session started** in this repo so the installed
+   SKILL.md content is loaded (skill content is read at session start).
+4. Your real Obsidian vault is configured.
+
+Before doing the live flow, run:
+
+```bash
+bash scripts/dev-test/test-issue-101-manual.sh
+```
+
+All automated checks should pass. Only proceed to the live phases below
+once the script reports `0 failed`.
+
+---
+
+## Live smoke checklist
+
+Walk through the following in a **fresh CC session**. Check each box only
+after visually confirming the described behavior. Notes section at the
+bottom for any deviations.
+
+### Phase 1 — Baseline: marker file appears for the new session
+
+- [ ] **Capture this session's ID.** In the new CC session, run:
+      ```bash
+      ls -t ~/.claude/projects/*obsidian-brain*/*.jsonl | head -1
+      ```
+      Note the basename minus `.jsonl` — that's `$SID`.
+
+- [ ] **Marker file exists for $SID.**
+      ```bash
+      ls -la ~/.claude/obsidian-brain/sessions/$SID.json
+      cat ~/.claude/obsidian-brain/sessions/$SID.json
+      ```
+      File should exist with mode `-rw-------` (0o600), and JSON should
+      contain `first_seen_date` (today, ISO) and `first_seen_iso` (UTC ISO).
+
+      *If missing:* SessionStart did not run, or `_first_seen_date` was
+      never invoked. Check `~/.claude/obsidian-brain-hook.log`.
+
+### Phase 2 — Marker is idempotent under live use
+
+- [ ] **Trigger any /recall, /vault-search, or /compress.** Then re-check
+      the marker:
+      ```bash
+      stat -f '%Sm' ~/.claude/obsidian-brain/sessions/$SID.json   # macOS
+      # or: stat -c '%y' ~/.claude/obsidian-brain/sessions/$SID.json   # linux
+      ```
+      Modification time should match the FIRST write — subsequent calls
+      to `_first_seen_date($SID)` must read the marker, not rewrite it.
+
+- [ ] **Marker JSON contents stable.**
+      ```bash
+      cat ~/.claude/obsidian-brain/sessions/$SID.json
+      ```
+      `first_seen_date` and `first_seen_iso` should be unchanged from
+      Phase 1. If they advanced, the helper is rewriting on every call.
+
+### Phase 3 — SessionEnd basename matches marker date
+
+- [ ] **End the session cleanly.** Either type `Ctrl-D` or `/quit`. SessionEnd
+      hook fires, writes a vault note, attempts AI summarization.
+
+- [ ] **Vault note basename starts with marker date.** From a regular shell:
+      ```bash
+      VAULT=$(jq -r .vault_path ~/.claude/obsidian-brain-config.json)
+      MARKER_DATE=$(jq -r .first_seen_date ~/.claude/obsidian-brain/sessions/$SID.json)
+      ls -t "$VAULT/claude-sessions/" | grep "$SID" | head -3
+      ```
+      The most recent file matching `*-$SID*.md` should start with
+      `$MARKER_DATE-`. If today and marker date differ (cross-midnight run),
+      the file MUST use marker date — that's the whole point of #101.
+
+- [ ] **No drift between filename and frontmatter.** Open the new note
+      in any editor:
+      ```bash
+      head -10 "$VAULT/claude-sessions/$MARKER_DATE-"*"-$SID"*.md
+      ```
+      Frontmatter `session_id` should equal `$SID` and `project_path`
+      should equal this repo's path.
+
+### Phase 4 — Resume same SID → is_resumed_session=True
+
+- [ ] **Restart in this repo with the same session ID.**
+      ```bash
+      claude --resume $SID
+      ```
+
+- [ ] **SessionStart hint reflects resume.** Look at the SessionStart
+      additionalContext output (in the conversation header or hook log).
+      It should mention "Last session for obsidian-brain" — proving
+      `is_resumed_session` returned True via the resolver, not by date
+      heuristic.
+
+      *Verify the underlying check in a Bash cell:*
+      ```bash
+      python3 -c '
+      import sys, glob, os
+      sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks"))))
+      import obsidian_utils
+      v = "/Users/abhishek/path/to/your/vault"  # edit
+      print(obsidian_utils.is_resumed_session(v, "claude-sessions", "'$SID'", cwd=os.getcwd()))
+      ' # → True
+      ```
+
+### Phase 5 — Cross-project hash collision is rejected
+
+- [ ] **Find a hash collision (or fabricate one).** Look for any other
+      project in the same vault whose session note shares the first 4
+      hex chars of the SHA-256 of your `$SID`:
+      ```bash
+      python3 -c "import hashlib; print(hashlib.sha256(b'$SID').hexdigest()[:4])"
+      ```
+      Use that 4-char `$H` to grep the vault:
+      ```bash
+      ls "$VAULT/claude-sessions/" | grep -- "-$H.md" | head
+      ```
+      If a SECOND project's note appears, you have a real collision pair.
+
+      *If no natural collision exists*, fabricate one in a temp project:
+      ```bash
+      cp "$VAULT/claude-sessions/$(ls "$VAULT/claude-sessions/" | grep -- "-$H.md" | head -1)" \
+         "$VAULT/claude-sessions/2026-04-20-fabricated-$H.md"
+      ```
+      Edit the copy's frontmatter to set `project_path: "/totally/different"`.
+
+- [ ] **is_resumed_session returns False from a different cwd.**
+      ```bash
+      cd /tmp && python3 -c '...is_resumed_session(... cwd="/tmp")'
+      ```
+      Should be `False` — cwd-strict resolver rejects the cross-project
+      collision (closes #110). If True, the cwd filter is broken.
+
+      Clean up the fabricated file when done.
+
+### Phase 6 — Snapshot+session pair (PreCompact path)
+
+- [ ] **In a fresh CC session, chat a few turns then `/compact`.**
+      PreCompact writes a snapshot note `*-{H}-snapshot-HHMMSS.md` and
+      then continues the session.
+
+- [ ] **/recall renders snapshot under its parent session.** Run `/recall`
+      in this repo. The session history table should show the parent
+      session row, with the snapshot rendered as a nested `↳ HH:MM:SS`
+      row underneath. If the snapshot appears as its own top-level row,
+      the resolver's type filter is misclassifying it as a session.
+
+### Phase 7 — Backward-compat for legacy notes (type-missing)
+
+- [ ] **Find a legacy session note that lacks the `type:` field.**
+      ```bash
+      grep -L "^type:" "$VAULT/claude-sessions/"*.md | head -5
+      ```
+      Pick one and note its `session_id` value:
+      ```bash
+      grep -m1 "^session_id:" "$VAULT/claude-sessions/<one-of-them>.md"
+      ```
+
+- [ ] **is_resumed_session still recognizes it.** Resume with that legacy
+      sid (or just check from a Python REPL) — the resolver should treat
+      `type=None` as a session (matching the `open_item_dedup` legacy
+      convention) and return True. If it returns False, the type-missing
+      back-compat is broken.
+
+### Phase 8 — Reverse: clean restart on brand-new vault
+
+- [ ] **Move the marker dir aside, clear vault sessions for this project.**
+      ```bash
+      mv ~/.claude/obsidian-brain/sessions ~/.claude/obsidian-brain/sessions.bak
+      ```
+
+- [ ] **Start a fresh CC session.** SessionStart fires.
+
+- [ ] **Marker dir was created with mode 0o700.**
+      ```bash
+      stat -f '%Mp%Lp' ~/.claude/obsidian-brain/sessions   # macOS → 40700
+      # or: stat -c '%a' ~/.claude/obsidian-brain/sessions   # linux → 700
+      ```
+
+- [ ] **Restore.**
+      ```bash
+      rm -rf ~/.claude/obsidian-brain/sessions
+      mv ~/.claude/obsidian-brain/sessions.bak ~/.claude/obsidian-brain/sessions
+      ```
+
+### Phase 9 — Cleanup + confirmation
+
+- [ ] **Run `/dev-test restore`** to put the released plugin cache back.
+- [ ] **Confirm full test suite still passes against repo HEAD.**
+      ```bash
+      python3 -m pytest -q
+      ```
+      793 passed expected (32 in `test_get_session_context.py`, 1 new
+      marker-mode self-heal test on top of the pre-#109 baseline).
+
+---
+
+## What this validates that pytest does NOT
+
+| Phase | Coverage gap pytest can't fill |
+|-------|-------------------------------|
+| 1, 2  | Marker is written by the *real* SessionStart entry point in the running CC session, not by direct helper call from a unit test |
+| 3     | SessionEnd hook integration — full write path under real config + transcript flow, including AI summarization fallback |
+| 4     | SessionStart hint render correctness — `is_resumed_session` plumbed through the user-visible "Last session" line |
+| 5     | A genuine cross-project hash collision against your live vault, not a synthetic 4-char fixture |
+| 6     | PreCompact snapshot type filter — verified through /recall's actual nested-row rendering, not just resolver unit tests |
+| 7     | Legacy notes from before the `type:` convention existed — only your live vault has these |
+| 8     | Marker dir bootstrap on first run after install — covered by chmod-self-heal unit tests but worth a real fresh start |
+
+---
+
+## Notes / deviations
+
+(Record any unexpected behavior, broken assumptions, or test-skip rationales here.)
+
+```
+- Phase X: …
+```
+
+---
+
+## Reference
+
+- Plan: `~/dev/claude_workspace/docs/superpowers/plans/2026-04-25-issue-101-source-session-basename-stability-plan.md`
+- Spec: `~/dev/claude_workspace/docs/superpowers/specs/2026-04-25-issue-101-source-session-basename-stability-design.md`
+- Closes: #101 (write-side ABC), #86 (read-side hash resolver), #110 (cross-project collision)
+- Related issues NOT closed by this PR: #102 (D, render-side defense — depends on #101), #103 (E, vault-doctor --min-confidence flag)

--- a/scripts/dev-test/test-issue-101-manual.sh
+++ b/scripts/dev-test/test-issue-101-manual.sh
@@ -1,0 +1,508 @@
+#!/usr/bin/env bash
+# Manual smoke test for Issue #101 / PR #109 — source-session basename stability
+# Run AFTER: /dev-test install
+# Usage: bash scripts/dev-test/test-issue-101-manual.sh
+#
+# Validates the parts that can be checked without a fresh CC session:
+#   - Plugin cache has #101 helpers (_first_seen_date, _resolve_session_note_by_hash,
+#     _peek_frontmatter_{type,project_path}, _safe_getcwd, is_resumed_session(cwd=))
+#   - _first_seen_date marker write/idempotency/corruption/sid-validation/mode-self-heal
+#   - Resolver: type filter, project filter, type-missing legacy, ambiguous, single match
+#   - is_resumed_session: snapshot-only False, real True, collision False, cross-project False
+#   - get_session_context fallback uses marker date (not date.today)
+#   - SessionEnd integration (hook simulation): basename uses _first_seen_date
+#
+# For the parts that require a fresh CC session (live SessionStart hint, /recall
+# resolves UUID via on-disk note, real cross-midnight), see ./DEV-TEST-ISSUE-101.md.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  ✅ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  ⏭️  $1"; SKIP=$((SKIP + 1)); }
+
+# Locate the currently-installed plugin cache (the `dev-test install` target)
+CACHE_DIR=$(find ~/.claude/plugins/cache -type d -path "*/obsidian-brain/*" \
+    -not -path "*.bak*" 2>/dev/null | sort -V | tail -1 | xargs dirname 2>/dev/null || true)
+if [ -z "$CACHE_DIR" ] || [ ! -d "$CACHE_DIR" ]; then
+    echo "❌ Could not locate obsidian-brain plugin cache."
+    echo "   Run /dev-test install first."
+    exit 1
+fi
+
+HOOK_DIR=$(find "$CACHE_DIR" -maxdepth 2 -type d -name hooks | sort -V | tail -1)
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "Issue #101 / PR #109 — Automated Validation"
+echo "═══════════════════════════════════════════════════════════════"
+echo "Plugin cache: $CACHE_DIR"
+echo "Hooks dir:    $HOOK_DIR"
+echo ""
+
+# Throwaway vault + isolated home for hook simulation
+FIXTURE=$(mktemp -d -t ob-issue-101.XXXXXX)
+trap 'rm -rf "$FIXTURE"' EXIT
+mkdir -p "$FIXTURE/vault/claude-sessions"
+mkdir -p "$FIXTURE/home/.claude/obsidian-brain/sessions"
+chmod 700 "$FIXTURE/home/.claude/obsidian-brain/sessions"
+
+# ─── Test 1: Installed code surface ──────────────────────────────────
+echo "Test 1: Installed code surface"
+
+if grep -q "def _first_seen_date" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_first_seen_date() present"
+else
+    fail "_first_seen_date() missing — did /dev-test install pick up this branch?"
+fi
+
+if grep -q "def _resolve_session_note_by_hash" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_resolve_session_note_by_hash() present"
+else
+    fail "_resolve_session_note_by_hash() missing"
+fi
+
+if grep -q "def _peek_frontmatter_type" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_peek_frontmatter_type() present"
+else
+    fail "_peek_frontmatter_type() missing"
+fi
+
+if grep -q "def _peek_frontmatter_project_path" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_peek_frontmatter_project_path() present"
+else
+    fail "_peek_frontmatter_project_path() missing"
+fi
+
+if grep -q "def _safe_getcwd" "$HOOK_DIR/obsidian_utils.py"; then
+    pass "_safe_getcwd() present"
+else
+    fail "_safe_getcwd() missing"
+fi
+
+if python3 -c "
+import sys, inspect
+sys.path.insert(0, '$HOOK_DIR')
+import obsidian_utils
+sig = inspect.signature(obsidian_utils.is_resumed_session)
+sys.exit(0 if 'cwd' in sig.parameters else 1)
+"; then
+    pass "is_resumed_session(cwd=...) signature accepts cwd kwarg"
+else
+    fail "is_resumed_session signature missing cwd parameter"
+fi
+
+if grep -q '_first_seen_date(session_id)' "$HOOK_DIR/obsidian_session_log.py"; then
+    pass "obsidian_session_log.py wires _first_seen_date(session_id)"
+else
+    fail "SessionEnd not using _first_seen_date — Fix A wire-up missing"
+fi
+
+echo ""
+
+# ─── Test 2: Marker write + idempotency + cross-day stability ────────
+echo "Test 2: _first_seen_date marker write + idempotency + cross-day"
+
+RESULT=$(HOME="$FIXTURE/home" python3 - <<PY
+import sys, os, json, datetime, pathlib
+sys.path.insert(0, "$HOOK_DIR")
+from unittest.mock import patch
+import obsidian_utils
+
+sid = "issue101-test-$(date +%s)"
+d1 = obsidian_utils._first_seen_date(sid)
+d2 = obsidian_utils._first_seen_date(sid)
+print(f"d1={d1} d2={d2}")
+
+m = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions" / f"{sid}.json"
+print(f"marker_exists={m.exists()}")
+print(f"marker_mode={oct(m.stat().st_mode)[-3:]}")
+payload = json.loads(m.read_text())
+print(f"has_first_seen_date={'first_seen_date' in payload}")
+print(f"has_first_seen_iso={'first_seen_iso' in payload}")
+
+# Cross-day: mock date.today() to advance, expect marker date unchanged
+class FakeDate:
+    @staticmethod
+    def today():
+        return datetime.date(2099, 1, 1)
+with patch.object(obsidian_utils.datetime, "date", FakeDate):
+    d3 = obsidian_utils._first_seen_date(sid)
+print(f"cross_day={d3}")
+PY
+)
+
+if echo "$RESULT" | grep -qE "d1=2[0-9]{3}-[0-9]{2}-[0-9]{2}"; then
+    D1=$(echo "$RESULT" | grep -oE "d1=[0-9]{4}-[0-9]{2}-[0-9]{2}" | cut -d= -f2)
+    D2=$(echo "$RESULT" | grep -oE "d2=[0-9]{4}-[0-9]{2}-[0-9]{2}" | cut -d= -f2)
+    if [ "$D1" = "$D2" ]; then
+        pass "_first_seen_date returns same value on second call (idempotent)"
+    else
+        fail "Idempotency broken: d1=$D1 d2=$D2"
+    fi
+else
+    fail "_first_seen_date did not return ISO-8601 date: $RESULT"
+fi
+
+echo "$RESULT" | grep -q "marker_exists=True" && pass "Marker file written" || fail "Marker file not written"
+echo "$RESULT" | grep -q "marker_mode=600" && pass "Marker mode is 0o600" || fail "Marker mode wrong: $(echo "$RESULT" | grep marker_mode)"
+echo "$RESULT" | grep -q "has_first_seen_date=True" && pass "Marker has first_seen_date field" || fail "Marker missing first_seen_date"
+echo "$RESULT" | grep -q "has_first_seen_iso=True" && pass "Marker has first_seen_iso field" || fail "Marker missing first_seen_iso"
+
+CROSS=$(echo "$RESULT" | grep -oE "cross_day=[0-9]{4}-[0-9]{2}-[0-9]{2}" | cut -d= -f2)
+if [ "$CROSS" = "$D1" ] && [ "$CROSS" != "2099-01-01" ]; then
+    pass "Cross-day stability: marker beats date.today() (returns $CROSS, not 2099-01-01)"
+else
+    fail "Cross-day BROKEN: cross_day=$CROSS d1=$D1 (should match d1, must NOT be 2099-01-01)"
+fi
+
+echo ""
+
+# ─── Test 3: Marker corruption self-heal + sid validation ────────────
+echo "Test 3: Marker corruption self-heal + sid validation"
+
+RESULT=$(HOME="$FIXTURE/home" python3 - <<PY
+import sys, datetime, pathlib
+sys.path.insert(0, "$HOOK_DIR")
+import obsidian_utils
+
+# Corrupt marker → self-heal returns today
+sid = "corrupt-test-$(date +%s)"
+m = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions" / f"{sid}.json"
+m.write_text("{not valid json}")
+d = obsidian_utils._first_seen_date(sid)
+expected = datetime.date.today().isoformat()
+print(f"corrupt_recover={d == expected}")
+
+# Path-traversal sid → falls back to today, no marker written
+bad_sid = "../../../etc/passwd"
+d2 = obsidian_utils._first_seen_date(bad_sid)
+print(f"bad_sid_fallback={d2 == expected}")
+m2 = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions" / f"{bad_sid}.json"
+# Resolve to detect any write outside the safe dir
+import os
+print(f"no_traversal_write={not os.path.exists('/etc/passwd.json.tmp')}")
+
+# Loose-mode marker file → self-heals to 0o600 on read
+sid3 = "loose-mode-test-$(date +%s)"
+m3 = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions" / f"{sid3}.json"
+m3.write_text('{"first_seen_date":"2026-04-20","first_seen_iso":"x"}')
+import os
+os.chmod(m3, 0o644)
+obsidian_utils._first_seen_date(sid3)
+print(f"marker_remode={oct(m3.stat().st_mode)[-3:]}")
+
+# Loose-mode dir → self-heals to 0o700
+sessions_dir = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions"
+os.chmod(sessions_dir, 0o755)
+obsidian_utils._first_seen_date("dirtest-$(date +%s)")
+print(f"dir_remode={oct(sessions_dir.stat().st_mode)[-3:]}")
+PY
+2>&1)
+
+echo "$RESULT" | grep -q "corrupt_recover=True" && pass "Corrupt marker → self-heals to today" || fail "Corruption recovery broken"
+echo "$RESULT" | grep -q "bad_sid_fallback=True" && pass "Path-traversal sid → safe today fallback" || fail "Path-traversal handling broken"
+echo "$RESULT" | grep -q "no_traversal_write=True" && pass "No file written outside marker dir" || fail "Path-traversal allowed file write"
+echo "$RESULT" | grep -q "marker_remode=600" && pass "Loose-mode marker file → chmod 0o600 self-heal" || fail "Marker mode self-heal broken: $(echo "$RESULT" | grep marker_remode)"
+echo "$RESULT" | grep -q "dir_remode=700" && pass "Loose-mode marker dir → chmod 0o700 self-heal" || fail "Dir mode self-heal broken: $(echo "$RESULT" | grep dir_remode)"
+
+echo ""
+
+# ─── Test 4: Resolver — type filter, project filter, ambiguous ───────
+echo "Test 4: _resolve_session_note_by_hash branches"
+
+RESULT=$(python3 - <<PY
+import sys, pathlib
+sys.path.insert(0, "$HOOK_DIR")
+import obsidian_utils
+
+def write(p, fields):
+    with open(p, "w") as f:
+        f.write("---\n")
+        for k, v in fields.items():
+            f.write(f"{k}: {v}\n")
+        f.write("---\nbody\n")
+
+sessions = pathlib.Path("$FIXTURE/vault/claude-sessions")
+h = "abcd"
+
+# Branch A: snapshot-only with session-shaped name → (None, [])
+import shutil; shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-snap-{h}.md",
+      {"type": "claude-snapshot", "session_id": "x"})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/anything")
+print(f"snapshot_only={b is None and c == []}")
+
+# Branch B: single session match, cwd matches → (basename, [])
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-foo-{h}.md",
+      {"type": "claude-session", "session_id": "real",
+       "project_path": '"/cwd/foo"'})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/foo")
+print(f"single_match={b == f'2026-04-20-foo-{h}' and c == []}")
+
+# Branch C: cross-project disambiguation by cwd
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-proj-a-{h}.md",
+      {"type": "claude-session", "session_id": "a",
+       "project_path": '"/cwd/a"'})
+write(sessions / f"2026-04-20-proj-b-{h}.md",
+      {"type": "claude-session", "session_id": "b",
+       "project_path": '"/cwd/b"'})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/a")
+print(f"disambiguate={b == f'2026-04-20-proj-a-{h}' and c == [f'2026-04-20-proj-b-{h}.md']}")
+
+# Branch D: type-missing legacy note treated as session
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-legacy-{h}.md",
+      {"session_id": "legacy", "project_path": '"/cwd/legacy"'})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/legacy")
+print(f"legacy_compat={b == f'2026-04-20-legacy-{h}'}")
+
+# Branch E: same-cwd ambiguous → (None, [all])
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+write(sessions / f"2026-04-20-x-{h}.md",
+      {"type": "claude-session", "session_id": "1",
+       "project_path": '"/cwd/x"'})
+write(sessions / f"2026-04-20-y-{h}.md",
+      {"type": "claude-session", "session_id": "2",
+       "project_path": '"/cwd/x"'})
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/x")
+print(f"ambiguous={b is None and len(c) == 2}")
+
+# Branch F: empty sessions dir → (None, [])
+shutil.rmtree(sessions); sessions.mkdir(parents=True)
+b, c = obsidian_utils._resolve_session_note_by_hash(sessions, h, cwd="/cwd/x")
+print(f"no_match={b is None and c == []}")
+PY
+)
+
+echo "$RESULT" | grep -q "snapshot_only=True" && pass "Snapshot-only with session-shaped name → excluded by type filter" || fail "Type filter broken: $(echo "$RESULT" | grep snapshot_only)"
+echo "$RESULT" | grep -q "single_match=True" && pass "Single session match returns clean basename" || fail "Single match broken"
+echo "$RESULT" | grep -q "disambiguate=True" && pass "Cross-project hash collision disambiguated by cwd" || fail "Cross-project disambiguation broken"
+echo "$RESULT" | grep -q "legacy_compat=True" && pass "Type-missing legacy note treated as session (backward-compat)" || fail "Legacy-note backward-compat broken"
+echo "$RESULT" | grep -q "ambiguous=True" && pass "Same-cwd ambiguous → (None, [all collisions])" || fail "Ambiguous resolution broken"
+echo "$RESULT" | grep -q "no_match=True" && pass "Empty sessions dir → (None, [])" || fail "No-match path broken"
+
+echo ""
+
+# ─── Test 5: is_resumed_session — all branches ───────────────────────
+echo "Test 5: is_resumed_session(cwd=) branches"
+
+RESULT=$(python3 - <<PY
+import sys, hashlib, pathlib, shutil
+sys.path.insert(0, "$HOOK_DIR")
+import obsidian_utils
+
+def write(p, fields):
+    with open(p, "w") as f:
+        f.write("---\n")
+        for k, v in fields.items():
+            f.write(f"{k}: {v}\n")
+        f.write("---\nbody\n")
+
+vault = pathlib.Path("$FIXTURE/vault")
+sessions = vault / "claude-sessions"
+
+sid = "test-resume-sid"
+h = hashlib.sha256(sid.encode()).hexdigest()[:4]
+
+# Snapshot-only with session-shaped name → False (type filter)
+shutil.rmtree(sessions); sessions.mkdir()
+write(sessions / f"2026-04-20-foo-{h}.md",
+      {"type": "claude-snapshot", "session_id": "different"})
+r = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid, cwd="/cwd/foo")
+print(f"snapshot_only_false={r is False}")
+
+# Real session, cwd matches → True
+shutil.rmtree(sessions); sessions.mkdir()
+write(sessions / f"2026-04-20-foo-{h}.md",
+      {"type": "claude-session", "session_id": sid,
+       "project_path": '"/cwd/foo"'})
+r = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid, cwd="/cwd/foo")
+print(f"real_session_true={r is True}")
+
+# Cross-project hash collision (cwd mismatch) → False
+shutil.rmtree(sessions); sessions.mkdir()
+write(sessions / f"2026-04-20-other-{h}.md",
+      {"type": "claude-session", "session_id": "other-sid",
+       "project_path": '"/some/other/path"'})
+r = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid, cwd="/cwd/foo")
+print(f"cross_project_false={r is False}")
+
+# Same-project ambiguous collision pair → False (no unambiguous prior session)
+shutil.rmtree(sessions); sessions.mkdir()
+write(sessions / f"2026-04-20-x-{h}.md",
+      {"type": "claude-session", "session_id": "1",
+       "project_path": '"/cwd/foo"'})
+write(sessions / f"2026-04-20-y-{h}.md",
+      {"type": "claude-session", "session_id": "2",
+       "project_path": '"/cwd/foo"'})
+r = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid, cwd="/cwd/foo")
+print(f"ambiguous_false={r is False}")
+PY
+)
+
+echo "$RESULT" | grep -q "snapshot_only_false=True" && pass "Snapshot-only → is_resumed_session=False (subsumes #86)" || fail "Snapshot type filter not blocking is_resumed_session"
+echo "$RESULT" | grep -q "real_session_true=True" && pass "Real session note → is_resumed_session=True" || fail "Real session detection broken"
+echo "$RESULT" | grep -q "cross_project_false=True" && pass "Cross-project hash collision → is_resumed_session=False (cwd-strict)" || fail "Cross-project filter broken (closes #110 concern)"
+echo "$RESULT" | grep -q "ambiguous_false=True" && pass "Ambiguous collision pair → is_resumed_session=False" || fail "Ambiguous handling broken"
+
+echo ""
+
+# ─── Test 6: get_session_context fallback uses marker date ───────────
+echo "Test 6: get_session_context fallback uses _first_seen_date (cross-midnight)"
+
+RESULT=$(HOME="$FIXTURE/home" python3 - <<PY
+import sys, json, pathlib, datetime, shutil
+sys.path.insert(0, "$HOOK_DIR")
+from unittest.mock import patch
+import obsidian_utils
+
+# Pre-seed marker for a session with first_seen=day-N, then mock today=day-N+2
+sid = "cross-midnight-sid-$(date +%s)"
+marker_dir = pathlib.Path("$FIXTURE/home") / ".claude/obsidian-brain/sessions"
+(marker_dir / f"{sid}.json").write_text(
+    json.dumps({"first_seen_date": "2026-04-20", "first_seen_iso": "x"})
+)
+
+class FakeDate:
+    @staticmethod
+    def today():
+        return datetime.date(2026, 4, 22)
+
+# Clean vault for fallback path (no on-disk session note → resolver returns None)
+vault = pathlib.Path("$FIXTURE/vault")
+sessions = vault / "claude-sessions"
+shutil.rmtree(sessions); sessions.mkdir()
+
+# get_session_context resolves sid via _get_session_id_fast and project via
+# canonical_project_name — patch both so the fallback exercises marker date.
+with patch.object(obsidian_utils, "_get_session_id_fast", return_value=sid), \
+     patch.object(obsidian_utils, "canonical_project_name", return_value="test-project"), \
+     patch.object(obsidian_utils, "cache_get", return_value=None), \
+     patch.object(obsidian_utils, "cache_set", return_value=None), \
+     patch.object(obsidian_utils.datetime, "date", FakeDate):
+    ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+
+basename = ctx.get("session_note_name", "")
+print(f"basename={basename}")
+print(f"starts_with_marker_date={basename.startswith('2026-04-20-')}")
+print(f"NOT_today={'2026-04-22' not in basename}")
+PY
+)
+
+echo "$RESULT" | grep -q "starts_with_marker_date=True" && pass "Fallback basename starts with marker date (2026-04-20)" || fail "Fallback ignored marker: $(echo "$RESULT" | grep basename)"
+echo "$RESULT" | grep -q "NOT_today=True" && pass "Fallback basename does NOT use today's date (2026-04-22)" || fail "Fallback used today instead of marker"
+
+echo ""
+
+# ─── Test 7: SessionEnd hook simulation — basename uses marker ───────
+echo "Test 7: SessionEnd hook simulation — full write path"
+
+# Clean vault sessions dir of fixtures from earlier tests so the find
+# at the bottom only sees what THIS hook invocation wrote.
+rm -f "$FIXTURE/vault/claude-sessions/"*.md
+
+# Pre-seed a marker with yesterday-equivalent date
+SIM_SID="sim-sessionend-$(date +%s)"
+MARKER_DIR="$FIXTURE/home/.claude/obsidian-brain/sessions"
+echo '{"first_seen_date":"2026-04-20","first_seen_iso":"2026-04-20T22:00:00Z"}' \
+    > "$MARKER_DIR/$SIM_SID.json"
+chmod 600 "$MARKER_DIR/$SIM_SID.json"
+
+# Synthetic config + transcript
+CFG_DIR="$FIXTURE/home/.claude"
+cat > "$CFG_DIR/obsidian-brain-config.json" <<JSON
+{
+  "vault_path": "$FIXTURE/vault",
+  "sessions_folder": "claude-sessions",
+  "insights_folder": "claude-insights",
+  "min_messages_to_log": 0,
+  "min_session_duration_seconds": 0
+}
+JSON
+
+TRANSCRIPT="$FIXTURE/transcript.jsonl"
+cat > "$TRANSCRIPT" <<EOF
+{"type":"user","message":{"role":"user","content":"hello"},"timestamp":"2026-04-20T22:00:00Z"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"timestamp":"2026-04-20T22:00:05Z"}
+EOF
+
+# Simulate SessionEnd
+HOOK_INPUT=$(cat <<JSON
+{"hook_event_name":"SessionEnd","session_id":"$SIM_SID","cwd":"$FIXTURE","transcript_path":"$TRANSCRIPT"}
+JSON
+)
+
+if HOME="$FIXTURE/home" echo "$HOOK_INPUT" | python3 "$HOOK_DIR/obsidian_session_log.py" >/dev/null 2>&1; then
+    pass "SessionEnd hook ran without error"
+else
+    skip "SessionEnd hook returned non-zero (likely benign — filter thresholds, no anthropic key for summarization)"
+fi
+
+# Whether or not summarization succeeded, the raw note must exist with marker-dated basename
+WROTE=$(find "$FIXTURE/vault/claude-sessions" -name "2026-04-20-*.md" 2>/dev/null | head -1)
+if [ -n "$WROTE" ]; then
+    pass "Vault note written with marker date prefix: $(basename "$WROTE")"
+else
+    BAD=$(find "$FIXTURE/vault/claude-sessions" -name "*.md" 2>/dev/null | head -1)
+    if [ -n "$BAD" ]; then
+        fail "Vault note basename uses wrong date: $(basename "$BAD") — expected 2026-04-20-*"
+    else
+        skip "No vault note written (likely below message threshold, OK)"
+    fi
+fi
+
+echo ""
+
+# ─── Test 8: _safe_getcwd handles cwd-gone ───────────────────────────
+echo "Test 8: _safe_getcwd cwd-gone safety"
+
+RESULT=$(python3 - <<PY
+import sys, os
+sys.path.insert(0, "$HOOK_DIR")
+import obsidian_utils
+
+# Normal case
+cwd1 = obsidian_utils._safe_getcwd()
+print(f"normal_nonempty={bool(cwd1)}")
+
+# Simulate cwd-gone
+def fake_getcwd_raises():
+    raise FileNotFoundError("cwd is gone")
+
+orig = os.getcwd
+os.getcwd = fake_getcwd_raises
+cwd2 = obsidian_utils._safe_getcwd()
+os.getcwd = orig
+print(f"cwd_gone_returns_empty={cwd2 == ''}")
+PY
+)
+
+echo "$RESULT" | grep -q "normal_nonempty=True" && pass "_safe_getcwd returns non-empty when cwd is healthy" || fail "_safe_getcwd broken in normal case"
+echo "$RESULT" | grep -q "cwd_gone_returns_empty=True" && pass "_safe_getcwd returns '' on FileNotFoundError" || fail "_safe_getcwd does not handle cwd-gone"
+
+echo ""
+
+# ─── Summary ────────────────────────────────────────────────────────
+echo "═══════════════════════════════════════════════════════════════"
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+echo "═══════════════════════════════════════════════════════════════"
+
+if [ "$FAIL" -gt 0 ]; then
+    echo ""
+    echo "❌ One or more checks failed. Inspect the log above, fix, and re-run."
+    exit 1
+fi
+
+cat <<'NEXT'
+
+✅ Automated checks passed. Next: run the live Claude Code smoke flow in
+   ./DEV-TEST-ISSUE-101.md (the parts that require an actual fresh CC session
+   to exercise SessionStart hint, real /recall against a non-fixture vault,
+   and end-to-end cross-midnight via real wall-clock advance).
+NEXT

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -92,3 +92,28 @@ def test_first_seen_date_corruption_self_heals(isolated_home):
     # Subsequent call returns the rewritten value, no further mutation
     result2 = obsidian_utils._first_seen_date(sid)
     assert result2 == today
+
+
+def test_first_seen_date_rejects_path_traversal_sid(isolated_home, capsys):
+    """A sid shaped like a path-traversal attempt must NOT escape the
+    marker directory; helper falls back to today's date and warns."""
+    today = datetime.date.today().isoformat()
+    result = obsidian_utils._first_seen_date("../../../etc/passwd")
+    assert result == today
+    # No marker file should have been created anywhere outside sessions/
+    sessions_dir = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    if sessions_dir.exists():
+        assert list(sessions_dir.glob("*passwd*")) == []
+    captured = capsys.readouterr()
+    assert "unsafe sid" in captured.err.lower() or "refusing" in captured.err.lower()
+
+
+def test_first_seen_date_chmods_existing_loose_mode_dir(isolated_home):
+    """mkdir(mode=0o700, exist_ok=True) is a no-op on a pre-existing dir;
+    helper must explicitly chmod 0o700 if mode is too permissive."""
+    sessions = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True)
+    os.chmod(sessions, 0o755)  # simulate a previously-buggy permission
+    sid = _unique_sid()
+    obsidian_utils._first_seen_date(sid)
+    assert oct(sessions.stat().st_mode)[-3:] == "700"

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -272,3 +272,67 @@ def test_peek_frontmatter_field_empty_value_returns_none(tmp_path):
     note = tmp_path / "n.md"
     _write_note(note, {"type": "", "session_id": "abc"})
     assert obsidian_utils._peek_frontmatter_type(note) is None
+
+
+def test_resolve_filters_snapshot_type(tmp_path):
+    sessions_dir = tmp_path
+    h = "abcd"
+    _write_note(sessions_dir / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": "real",
+                 "project_path": '"/cwd/foo"'})
+    _write_note(sessions_dir / f"2026-04-20-foo-{h}-snapshot-101010.md",
+                {"type": "claude-snapshot", "session_id": "real"})
+
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions_dir, h, cwd="/cwd/foo"
+    )
+    assert basename == f"2026-04-20-foo-{h}"
+    assert collisions == []
+
+
+def test_resolve_disambiguates_by_project_path(tmp_path):
+    sessions_dir = tmp_path
+    h = "abcd"
+    _write_note(sessions_dir / f"2026-04-20-proj-a-{h}.md",
+                {"type": "claude-session", "session_id": "a",
+                 "project_path": '"/cwd/a"'})
+    _write_note(sessions_dir / f"2026-04-20-proj-b-{h}.md",
+                {"type": "claude-session", "session_id": "b",
+                 "project_path": '"/cwd/b"'})
+
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions_dir, h, cwd="/cwd/a"
+    )
+    assert basename == f"2026-04-20-proj-a-{h}"
+    assert collisions == [f"2026-04-20-proj-b-{h}.md"]
+
+
+def test_resolve_double_collision_returns_none(tmp_path):
+    """Two session-type notes with same hash AND same project_path → ambiguous,
+    caller falls back to composed name."""
+    sessions_dir = tmp_path
+    h = "abcd"
+    _write_note(sessions_dir / f"2026-04-20-proj-a-{h}.md",
+                {"type": "claude-session", "session_id": "a1",
+                 "project_path": '"/cwd/a"'})
+    _write_note(sessions_dir / f"2026-04-21-proj-a-{h}.md",
+                {"type": "claude-session", "session_id": "a2",
+                 "project_path": '"/cwd/a"'})
+
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions_dir, h, cwd="/cwd/a"
+    )
+    assert basename is None
+    assert sorted(collisions) == sorted([
+        f"2026-04-20-proj-a-{h}.md",
+        f"2026-04-21-proj-a-{h}.md",
+    ])
+
+
+def test_resolve_no_match_returns_empty(tmp_path):
+    """Sanity: empty directory → (None, [])."""
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        tmp_path, "abcd", cwd="/cwd/x"
+    )
+    assert basename is None
+    assert collisions == []

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -161,3 +161,69 @@ def test_get_session_context_fallback_uses_marker_date(isolated_home, tmp_path, 
     # Must be byte-equal to make_filename(marker_date, ...)
     expected = obsidian_utils.make_filename(marker_date, "obsidian-brain", sid)[:-3]
     assert ctx["session_note_name"] == expected
+
+
+def test_helper_and_session_end_produce_byte_identical_basename(isolated_home, monkeypatch):
+    """Project-slug invariant: across many (project, sid) combinations,
+    get_session_context()'s fallback basename and the basename SessionEnd
+    would build via make_filename(_first_seen_date(sid), slugify(project), sid)
+    are byte-for-byte identical. Catches any future regression that
+    reintroduces a hand-composed slug or a different date source."""
+    projects = [
+        "obsidian-brain",
+        "tiny-vacation-agent",
+        "personal-ws",
+        "claude-code-skills",
+        "very-long-project-name-that-might-trip-truncation-logic",
+        "abc",
+        "name with spaces",
+        "name_with_underscores",
+        "obsidian-brain--issue-101-source-session-basename-stability",
+        "Mixed-Case-Project",
+    ]
+    for project in projects:
+        for _ in range(3):
+            sid = _unique_sid()
+            monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda s=sid: s)
+            monkeypatch.setattr(obsidian_utils, "canonical_project_name",
+                                lambda *a, project=project, **kw: project)
+
+            # Helper side
+            ctx = obsidian_utils.get_session_context()
+            helper_basename = ctx["session_note_name"]
+
+            # SessionEnd side — replicate the exact call shape
+            date_str = obsidian_utils._first_seen_date(sid)
+            session_end_filename = obsidian_utils.make_filename(
+                date_str,
+                obsidian_utils.slugify(project),
+                sid,
+            )
+            session_end_basename = session_end_filename[:-3]  # strip .md
+
+            assert helper_basename == session_end_basename, (
+                f"divergence for project={project!r}, sid={sid}:\n"
+                f"  helper:      {helper_basename}\n"
+                f"  session_end: {session_end_basename}"
+            )
+
+
+def test_session_end_filename_uses_marker_date(isolated_home, monkeypatch):
+    """SessionEnd reads _first_seen_date(sid), not date.today()."""
+    sid = _unique_sid()
+    # Pre-write a marker pointing at day-N (yesterday relative to "today")
+    marker_dir = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    (marker_dir / f"{sid}.json").write_text(
+        json.dumps({"first_seen_date": "2026-04-25", "first_seen_iso": "x"}),
+        encoding="utf-8",
+    )
+
+    # Direct exercise of the helper SessionEnd uses
+    date_str = obsidian_utils._first_seen_date(sid)
+    assert date_str == "2026-04-25"
+
+    project_slug = obsidian_utils.slugify("obsidian-brain")
+    filename = obsidian_utils.make_filename(date_str, project_slug, sid)
+    assert filename.startswith("2026-04-25-obsidian-brain-")
+    assert filename.endswith(".md")

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -439,9 +439,10 @@ def test_is_resumed_session_returns_true_for_real_session(tmp_path, monkeypatch)
 
 
 def test_is_resumed_session_handles_collision_pair(tmp_path, monkeypatch, capsys):
-    """Same-project two-session collision (the original #86 scope):
-    function returns True (a session does exist), warns, and does not
-    crash."""
+    """Same-project two-session ambiguity (the original #86 scope):
+    is_resumed_session returns False (no unambiguous prior session for
+    THIS sid in THIS project), warns, and does not crash. Operator should
+    investigate the duplicates manually."""
     sid = "fresh-session-id"
     h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
     vault = tmp_path / "vault"
@@ -458,6 +459,63 @@ def test_is_resumed_session_handles_collision_pair(tmp_path, monkeypatch, capsys
                  "project_path": f'"{cwd}"'})
 
     result = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid)
-    assert result is True
+    assert result is False  # ← changed from True
     captured = capsys.readouterr()
-    assert "WARN" in captured.err or "collision" in captured.err.lower()
+    assert "WARN" in captured.err or "collide" in captured.err.lower()  # 'collide' (singular)
+
+
+def test_peek_frontmatter_field_handles_invalid_utf8(tmp_path, capsys):
+    """A file with invalid UTF-8 bytes returns None and logs to stderr,
+    rather than raising and breaking the resolver chain."""
+    note = tmp_path / "n.md"
+    note.write_bytes(b"---\ntype: claude-session\nbad: \xff\xfe\n---\n")
+    result = obsidian_utils._peek_frontmatter_type(note)
+    assert result is None
+    captured = capsys.readouterr()
+    assert "cannot read" in captured.err.lower() or "decode" in captured.err.lower()
+
+
+def test_peek_frontmatter_field_logs_empty_value(tmp_path, capsys):
+    """Empty-but-present field is logged as a possible corruption signal."""
+    note = tmp_path / "n.md"
+    _write_note(note, {"type": "", "session_id": "abc"})
+    result = obsidian_utils._peek_frontmatter_type(note)
+    assert result is None
+    captured = capsys.readouterr()
+    assert "empty" in captured.err.lower()
+
+
+def test_resolve_logs_when_sessions_dir_missing(tmp_path, capsys):
+    """When sessions_dir doesn't exist, resolver logs to stderr (so a
+    misconfigured vault path is observable), then returns no-match."""
+    missing = tmp_path / "nonexistent"
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        missing, "abcd", cwd="/cwd/x"
+    )
+    assert basename is None
+    assert collisions == []
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err.lower() or "no-match" in captured.err.lower()
+
+
+def test_is_resumed_session_returns_false_on_cross_project_collision(tmp_path, monkeypatch, capsys):
+    """Cross-project hash collision: a session-type note exists with the
+    matching hash but project_path != cwd. Function returns False (this
+    is NOT our resumed session) and warns."""
+    sid = "fresh-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    # Single session-type note belonging to a DIFFERENT project
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": "other-project-sid",
+                 "project_path": '"/some/other/project"'})
+
+    result = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid)
+    assert result is False, (
+        "Cross-project hash collision should NOT mark this session as resumed; "
+        "the colliding note belongs to a different project."
+    )

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -336,3 +336,31 @@ def test_resolve_no_match_returns_empty(tmp_path):
     )
     assert basename is None
     assert collisions == []
+
+
+def test_get_session_context_uses_type_aware_resolver(isolated_home, tmp_path, monkeypatch, capsys):
+    """get_session_context with a snapshot+session sharing the hash returns
+    the session, not the snapshot (#101 Fix C)."""
+    sid = "real-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid)
+    monkeypatch.setattr(obsidian_utils, "canonical_project_name",
+                        lambda *a, **kw: "obsidian-brain")
+
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    cwd = str(tmp_path / "obsidian-brain")
+    (tmp_path / "obsidian-brain").mkdir()
+    monkeypatch.chdir(tmp_path / "obsidian-brain")
+
+    _write_note(sessions / f"2026-04-20-obsidian-brain-{h}.md",
+                {"type": "claude-session", "session_id": sid,
+                 "project_path": f'"{cwd}"'})
+    _write_note(sessions / f"2026-04-20-obsidian-brain-{h}-snapshot-101010.md",
+                {"type": "claude-snapshot", "session_id": sid})
+
+    ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+    assert ctx["session_note_name"] == f"2026-04-20-obsidian-brain-{h}"
+    # Should NOT be the snapshot
+    assert "snapshot" not in ctx["session_note_name"]

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import datetime
 import json
 import os
-import shutil
 import uuid
 from pathlib import Path
 from unittest.mock import patch
@@ -117,6 +116,23 @@ def test_first_seen_date_chmods_existing_loose_mode_dir(isolated_home):
     sid = _unique_sid()
     obsidian_utils._first_seen_date(sid)
     assert oct(sessions.stat().st_mode)[-3:] == "700"
+
+
+def test_first_seen_date_chmods_existing_loose_mode_marker(isolated_home):
+    """If a marker file exists with overly-permissive mode (e.g., from a
+    previous bug or manual edit), the helper must self-heal it to 0o600."""
+    sessions = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    sessions.mkdir(parents=True, exist_ok=True, mode=0o700)
+    sid = _unique_sid()
+    marker = sessions / f"{sid}.json"
+    marker.write_text(
+        json.dumps({"first_seen_date": "2026-04-20", "first_seen_iso": "x"}),
+        encoding="utf-8",
+    )
+    os.chmod(marker, 0o644)  # simulate a previously-buggy permission
+
+    obsidian_utils._first_seen_date(sid)
+    assert oct(marker.stat().st_mode)[-3:] == "600"
 
 
 def test_get_session_context_fallback_uses_marker_date(isolated_home, tmp_path, monkeypatch):
@@ -275,12 +291,16 @@ def test_peek_frontmatter_field_empty_value_returns_none(tmp_path):
 
 
 def test_resolve_filters_snapshot_type(tmp_path):
+    """Defense-in-depth: even if a snapshot ever ends up with a session-shaped
+    filename (matching the resolver glob ``*-{h}.md``), the type filter must
+    exclude it. We deliberately give the snapshot a session-shaped name here
+    so the glob matches and the type filter is the only thing keeping it out."""
     sessions_dir = tmp_path
     h = "abcd"
     _write_note(sessions_dir / f"2026-04-20-foo-{h}.md",
                 {"type": "claude-session", "session_id": "real",
                  "project_path": '"/cwd/foo"'})
-    _write_note(sessions_dir / f"2026-04-20-foo-{h}-snapshot-101010.md",
+    _write_note(sessions_dir / f"2026-04-20-snap-{h}.md",
                 {"type": "claude-snapshot", "session_id": "real"})
 
     basename, collisions = obsidian_utils._resolve_session_note_by_hash(
@@ -407,7 +427,8 @@ def test_get_session_context_disambiguates_cross_project_hash_collision(
 
 def test_is_resumed_session_filters_snapshot_type(tmp_path, monkeypatch):
     """is_resumed_session must NOT return True when only a snapshot
-    exists with this hash (subsumes #86)."""
+    exists with this hash (subsumes #86). Snapshot is given a session-shaped
+    filename so the resolver glob matches and the type filter is exercised."""
     sid = "fresh-session-id"
     h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
     vault = tmp_path / "vault"
@@ -415,8 +436,8 @@ def test_is_resumed_session_filters_snapshot_type(tmp_path, monkeypatch):
     sessions.mkdir(parents=True)
     monkeypatch.chdir(tmp_path)
 
-    # Only a snapshot exists with this hash — not a resumed session
-    _write_note(sessions / f"2026-04-20-foo-{h}-snapshot-101010.md",
+    # Snapshot with a session-shaped filename — only the type filter excludes it
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
                 {"type": "claude-snapshot", "session_id": "different"})
 
     assert obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid) is False

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -28,3 +28,67 @@ def isolated_home(tmp_path, monkeypatch):
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     monkeypatch.setenv("HOME", str(tmp_path))
     yield tmp_path
+
+
+def test_first_seen_date_lazy_writes_and_returns_today(isolated_home):
+    sid = _unique_sid()
+    today = datetime.date.today().isoformat()
+
+    result = obsidian_utils._first_seen_date(sid)
+
+    assert result == today
+    marker = isolated_home / ".claude" / "obsidian-brain" / "sessions" / f"{sid}.json"
+    assert marker.exists()
+    assert oct(marker.stat().st_mode)[-3:] == "600"
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["first_seen_date"] == today
+    assert "first_seen_iso" in payload
+
+
+def test_first_seen_date_idempotent_across_calls(isolated_home):
+    sid = _unique_sid()
+    first = obsidian_utils._first_seen_date(sid)
+    second = obsidian_utils._first_seen_date(sid)
+    third = obsidian_utils._first_seen_date(sid)
+    assert first == second == third
+
+
+def test_first_seen_date_survives_today_advance(isolated_home):
+    """Cross-midnight invariant: once the marker exists, advancing
+    date.today() must not change the returned value."""
+    sid = _unique_sid()
+    day_n = datetime.date(2026, 4, 25)
+    day_n_plus_1 = datetime.date(2026, 4, 26)
+
+    class _FrozenDate:
+        @staticmethod
+        def today():
+            return _FrozenDate._now
+
+    _FrozenDate._now = day_n
+    with patch.object(obsidian_utils.datetime, "date", _FrozenDate):
+        first = obsidian_utils._first_seen_date(sid)
+        assert first == day_n.isoformat()
+
+    _FrozenDate._now = day_n_plus_1
+    with patch.object(obsidian_utils.datetime, "date", _FrozenDate):
+        second = obsidian_utils._first_seen_date(sid)
+        assert second == day_n.isoformat()  # still day-N, not day-N+1
+
+
+def test_first_seen_date_corruption_self_heals(isolated_home):
+    sid = _unique_sid()
+    marker_dir = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    marker = marker_dir / f"{sid}.json"
+    marker.write_text("not valid json {", encoding="utf-8")
+
+    today = datetime.date.today().isoformat()
+    result = obsidian_utils._first_seen_date(sid)
+    assert result == today
+    payload = json.loads(marker.read_text(encoding="utf-8"))
+    assert payload["first_seen_date"] == today
+
+    # Subsequent call returns the rewritten value, no further mutation
+    result2 = obsidian_utils._first_seen_date(sid)
+    assert result2 == today

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -403,3 +403,61 @@ def test_get_session_context_disambiguates_cross_project_hash_collision(
     assert "WARN" in captured.err
     assert f"hash {h}" in captured.err
     assert "other-project" in captured.err  # the OTHER session is named in the warning
+
+
+def test_is_resumed_session_filters_snapshot_type(tmp_path, monkeypatch):
+    """is_resumed_session must NOT return True when only a snapshot
+    exists with this hash (subsumes #86)."""
+    sid = "fresh-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    # Only a snapshot exists with this hash — not a resumed session
+    _write_note(sessions / f"2026-04-20-foo-{h}-snapshot-101010.md",
+                {"type": "claude-snapshot", "session_id": "different"})
+
+    assert obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid) is False
+
+
+def test_is_resumed_session_returns_true_for_real_session(tmp_path, monkeypatch):
+    sid = "fresh-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    cwd = str(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": sid,
+                 "project_path": f'"{cwd}"'})
+
+    assert obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid) is True
+
+
+def test_is_resumed_session_handles_collision_pair(tmp_path, monkeypatch, capsys):
+    """Same-project two-session collision (the original #86 scope):
+    function returns True (a session does exist), warns, and does not
+    crash."""
+    sid = "fresh-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    cwd = str(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": "old",
+                 "project_path": f'"{cwd}"'})
+    _write_note(sessions / f"2026-04-21-foo-{h}.md",
+                {"type": "claude-session", "session_id": "newer",
+                 "project_path": f'"{cwd}"'})
+
+    result = obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid)
+    assert result is True
+    captured = capsys.readouterr()
+    assert "WARN" in captured.err or "collision" in captured.err.lower()

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -519,3 +519,95 @@ def test_is_resumed_session_returns_false_on_cross_project_collision(tmp_path, m
         "Cross-project hash collision should NOT mark this session as resumed; "
         "the colliding note belongs to a different project."
     )
+
+
+def test_safe_getcwd_returns_empty_on_cwd_gone(monkeypatch):
+    """When os.getcwd() raises (cwd deleted/unmounted — issue #105 territory),
+    _safe_getcwd returns empty string so callers fall back gracefully instead
+    of crashing SessionEnd."""
+    def _raise(*a, **kw):
+        raise FileNotFoundError("cwd deleted")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    assert obsidian_utils._safe_getcwd() == ""
+
+
+def test_safe_getcwd_returns_empty_on_oserror(monkeypatch):
+    """OSError (permission, EIO) on os.getcwd() must also degrade gracefully."""
+    def _raise(*a, **kw):
+        raise OSError("EIO on cwd")
+    monkeypatch.setattr(os, "getcwd", _raise)
+    assert obsidian_utils._safe_getcwd() == ""
+
+
+def test_resolver_glob_oserror_returns_none(tmp_path, monkeypatch, capsys):
+    """If glob raises OSError (transient I/O, permission), resolver returns
+    (None, []) and logs to stderr — does not propagate.
+
+    Patches Path.glob globally because the resolver does ``Path(sessions_dir)``
+    internally, which produces a fresh Path object whose `glob` method is
+    bound at call time.
+    """
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+
+    def _raising_glob(self, pattern):
+        raise OSError("simulated I/O error")
+    monkeypatch.setattr(Path, "glob", _raising_glob)
+
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions, "abcd", cwd="/cwd/x"
+    )
+    assert basename is None
+    assert collisions == []
+    captured = capsys.readouterr()
+    assert "glob failed" in captured.err.lower()
+
+
+def test_resolve_treats_type_missing_as_session(tmp_path):
+    """Legacy notes without an explicit `type:` frontmatter field still count
+    as session notes so resumed-session detection doesn't regress on
+    pre-existing vaults — matches the convention used by collect_open_items()
+    in hooks/open_item_dedup.py.
+    """
+    sessions = tmp_path
+    h = "abcd"
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"session_id": "abc", "project_path": '"/cwd/foo"'})  # NO type
+    basename, collisions = obsidian_utils._resolve_session_note_by_hash(
+        sessions, h, cwd="/cwd/foo"
+    )
+    assert basename == f"2026-04-20-foo-{h}"
+    assert collisions == []
+
+
+def test_is_resumed_session_uses_provided_cwd_over_getcwd(tmp_path, monkeypatch):
+    """When ``cwd`` is passed explicitly, is_resumed_session uses it instead
+    of os.getcwd(). SessionEnd passes hook_input["cwd"] (Claude Code's
+    authoritative project path) so a hook process that chdir'd elsewhere
+    still classifies the session against the right project.
+    """
+    sid = "real-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+
+    project_a = tmp_path / "real-project"
+    project_a.mkdir()
+    cwd_a = str(project_a)
+    _write_note(sessions / f"2026-04-20-foo-{h}.md",
+                {"type": "claude-session", "session_id": sid,
+                 "project_path": f'"{cwd_a}"'})
+
+    # Force os.getcwd() into a DIFFERENT directory; the provided cwd must win.
+    other = tmp_path / "other"
+    other.mkdir()
+    monkeypatch.chdir(other)
+
+    # Without cwd param: returns False (os.getcwd() doesn't match note).
+    assert obsidian_utils.is_resumed_session(str(vault), "claude-sessions", sid) is False
+
+    # With cwd param: returns True (provided cwd matches note).
+    assert obsidian_utils.is_resumed_session(
+        str(vault), "claude-sessions", sid, cwd=cwd_a
+    ) is True

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -1,0 +1,30 @@
+# tests/test_get_session_context.py
+"""Tests for first-seen-date marker, hash-resolver, and basename invariants
+introduced for obsidian-brain#101 (subsumes #86)."""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import shutil
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import obsidian_utils
+
+
+def _unique_sid() -> str:
+    return f"test-sid-{uuid.uuid4().hex}"
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Redirect `~/.claude/obsidian-brain/sessions/` into tmp_path so marker
+    writes do not pollute the real user directory across tests."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    yield tmp_path

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -227,3 +227,40 @@ def test_session_end_filename_uses_marker_date(isolated_home, monkeypatch):
     filename = obsidian_utils.make_filename(date_str, project_slug, sid)
     assert filename.startswith("2026-04-25-obsidian-brain-")
     assert filename.endswith(".md")
+
+
+def _write_note(path: Path, frontmatter: dict, body: str = "body\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["---"]
+    for k, v in frontmatter.items():
+        lines.append(f"{k}: {v}")
+    lines.append("---")
+    lines.append(body)
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def test_peek_frontmatter_type_reads_session(tmp_path):
+    note = tmp_path / "n.md"
+    _write_note(note, {"type": "claude-session", "session_id": "abc"})
+    assert obsidian_utils._peek_frontmatter_type(note) == "claude-session"
+
+
+def test_peek_frontmatter_type_reads_snapshot(tmp_path):
+    note = tmp_path / "n.md"
+    _write_note(note, {"type": "claude-snapshot", "session_id": "abc"})
+    assert obsidian_utils._peek_frontmatter_type(note) == "claude-snapshot"
+
+
+def test_peek_frontmatter_type_returns_none_when_missing(tmp_path):
+    note = tmp_path / "n.md"
+    _write_note(note, {"session_id": "abc"})
+    assert obsidian_utils._peek_frontmatter_type(note) is None
+
+
+def test_peek_frontmatter_project_path_strips_quotes(tmp_path):
+    note = tmp_path / "n.md"
+    _write_note(note, {
+        "type": "claude-session",
+        "project_path": '"/Users/a/dev/obsidian-brain"',
+    })
+    assert obsidian_utils._peek_frontmatter_project_path(note) == "/Users/a/dev/obsidian-brain"

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -122,16 +122,21 @@ def test_first_seen_date_chmods_existing_loose_mode_dir(isolated_home):
 def test_get_session_context_fallback_uses_marker_date(isolated_home, tmp_path, monkeypatch):
     """get_session_context() fallback must compose its basename from
     _first_seen_date(sid), not date.today() — so cross-midnight insights
-    and SessionEnd writes agree on the filename."""
+    and SessionEnd writes agree on the filename. Mock date.today() to a
+    different day than the marker so the test actually exercises the
+    divergence the helper prevents."""
     sid = _unique_sid()
     monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid)
     monkeypatch.setattr(obsidian_utils, "canonical_project_name", lambda *a, **kw: "obsidian-brain")
+
+    marker_date = "2026-04-20"  # day-N
+    other_day = datetime.date(2026, 4, 22)  # day-N+2 — different from marker
 
     # Pre-write a marker pointing at day-N
     marker_dir = isolated_home / ".claude" / "obsidian-brain" / "sessions"
     marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     (marker_dir / f"{sid}.json").write_text(
-        json.dumps({"first_seen_date": "2026-04-25", "first_seen_iso": "x"}),
+        json.dumps({"first_seen_date": marker_date, "first_seen_iso": "x"}),
         encoding="utf-8",
     )
 
@@ -139,8 +144,20 @@ def test_get_session_context_fallback_uses_marker_date(isolated_home, tmp_path, 
     sessions = vault / "claude-sessions"
     sessions.mkdir(parents=True)
 
-    ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
-    assert ctx["session_note_name"].startswith("2026-04-25-obsidian-brain-")
-    # Must be byte-equal to make_filename(...)[:-3]
-    expected = obsidian_utils.make_filename("2026-04-25", "obsidian-brain", sid)[:-3]
+    class _FrozenDate:
+        @staticmethod
+        def today():
+            return other_day
+
+    # With date.today() mocked to day-N+2, the fallback must STILL produce
+    # the day-N basename via the marker. If the fallback ignored the marker
+    # and used date.today(), the basename would start with 2026-04-22.
+    with patch.object(obsidian_utils.datetime, "date", _FrozenDate):
+        ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+
+    assert ctx["session_note_name"].startswith(f"{marker_date}-obsidian-brain-"), (
+        f"expected basename pinned to marker date {marker_date}, got {ctx['session_note_name']}"
+    )
+    # Must be byte-equal to make_filename(marker_date, ...)
+    expected = obsidian_utils.make_filename(marker_date, "obsidian-brain", sid)[:-3]
     assert ctx["session_note_name"] == expected

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -117,3 +117,30 @@ def test_first_seen_date_chmods_existing_loose_mode_dir(isolated_home):
     sid = _unique_sid()
     obsidian_utils._first_seen_date(sid)
     assert oct(sessions.stat().st_mode)[-3:] == "700"
+
+
+def test_get_session_context_fallback_uses_marker_date(isolated_home, tmp_path, monkeypatch):
+    """get_session_context() fallback must compose its basename from
+    _first_seen_date(sid), not date.today() — so cross-midnight insights
+    and SessionEnd writes agree on the filename."""
+    sid = _unique_sid()
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid)
+    monkeypatch.setattr(obsidian_utils, "canonical_project_name", lambda *a, **kw: "obsidian-brain")
+
+    # Pre-write a marker pointing at day-N
+    marker_dir = isolated_home / ".claude" / "obsidian-brain" / "sessions"
+    marker_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    (marker_dir / f"{sid}.json").write_text(
+        json.dumps({"first_seen_date": "2026-04-25", "first_seen_iso": "x"}),
+        encoding="utf-8",
+    )
+
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+
+    ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+    assert ctx["session_note_name"].startswith("2026-04-25-obsidian-brain-")
+    # Must be byte-equal to make_filename(...)[:-3]
+    expected = obsidian_utils.make_filename("2026-04-25", "obsidian-brain", sid)[:-3]
+    assert ctx["session_note_name"] == expected

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -364,3 +364,42 @@ def test_get_session_context_uses_type_aware_resolver(isolated_home, tmp_path, m
     assert ctx["session_note_name"] == f"2026-04-20-obsidian-brain-{h}"
     # Should NOT be the snapshot
     assert "snapshot" not in ctx["session_note_name"]
+
+
+def test_get_session_context_disambiguates_cross_project_hash_collision(
+    isolated_home, tmp_path, monkeypatch, capsys
+):
+    """When two session-type notes share the 4-char hash across projects,
+    get_session_context returns the cwd-matching one and emits a WARN
+    listing the other (#101 Fix C)."""
+    sid = "real-session-id"
+    h = obsidian_utils.hashlib.sha256(sid.encode()).hexdigest()[:4]
+    monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: sid)
+    monkeypatch.setattr(obsidian_utils, "canonical_project_name",
+                        lambda *a, **kw: "obsidian-brain")
+
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+
+    cwd_a = str(tmp_path / "obsidian-brain")
+    (tmp_path / "obsidian-brain").mkdir()
+    monkeypatch.chdir(tmp_path / "obsidian-brain")
+
+    # Two session-type notes with the SAME hash but DIFFERENT project_path —
+    # this is the cross-project hash collision the resolver disambiguates.
+    _write_note(sessions / f"2026-04-20-obsidian-brain-{h}.md",
+                {"type": "claude-session", "session_id": "sid-a",
+                 "project_path": f'"{cwd_a}"'})
+    _write_note(sessions / f"2026-04-21-other-project-{h}.md",
+                {"type": "claude-session", "session_id": "sid-b",
+                 "project_path": '"/some/other/project"'})
+
+    ctx = obsidian_utils.get_session_context(str(vault), "claude-sessions")
+    assert ctx["session_note_name"] == f"2026-04-20-obsidian-brain-{h}", (
+        f"expected cwd-matching basename, got {ctx['session_note_name']}"
+    )
+    captured = capsys.readouterr()
+    assert "WARN" in captured.err
+    assert f"hash {h}" in captured.err
+    assert "other-project" in captured.err  # the OTHER session is named in the warning

--- a/tests/test_get_session_context.py
+++ b/tests/test_get_session_context.py
@@ -264,3 +264,11 @@ def test_peek_frontmatter_project_path_strips_quotes(tmp_path):
         "project_path": '"/Users/a/dev/obsidian-brain"',
     })
     assert obsidian_utils._peek_frontmatter_project_path(note) == "/Users/a/dev/obsidian-brain"
+
+
+def test_peek_frontmatter_field_empty_value_returns_none(tmp_path):
+    """An empty scalar (`field:` with no value) returns None, not ''.
+    Lets resolver call sites use truthy checks safely."""
+    note = tmp_path / "n.md"
+    _write_note(note, {"type": "", "session_id": "abc"})
+    assert obsidian_utils._peek_frontmatter_type(note) is None

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -2298,10 +2298,10 @@ def test_get_session_context_cache_key_isolates_distinct_worktrees(tmp_path, mon
     h1 = hashlib.sha256(sid1.encode()).hexdigest()[:4]
     h2 = hashlib.sha256(sid2.encode()).hexdigest()[:4]
     (sessions_dir / f"2026-04-25-obsidian-brain-{h1}.md").write_text(
-        "---\nsession_id: " + sid1 + "\n---\n", encoding="utf-8"
+        "---\ntype: claude-session\nsession_id: " + sid1 + "\n---\n", encoding="utf-8"
     )
     (sessions_dir / f"2026-04-25-obsidian-brain-{h2}.md").write_text(
-        "---\nsession_id: " + sid2 + "\n---\n", encoding="utf-8"
+        "---\ntype: claude-session\nsession_id: " + sid2 + "\n---\n", encoding="utf-8"
     )
 
     # Call 1: from main repo with SID1


### PR DESCRIPTION
## Summary

Implements [issue #101](https://github.com/abhattacherjee/obsidian-brain/issues/101)'s A+B+C bundle for write-side prevention of source_session_note basename divergence:

- **Fix A** — Pure-lazy `_first_seen_date(sid)` marker pinned at first call; `get_session_context()` and SessionEnd both consult it so cross-midnight insights and session-note filenames agree.
- **Fix B** — Helper fallback routed through `make_filename(_first_seen_date(sid), slugify(project), sid)[:-3]` for byte-symmetric slug normalization with SessionEnd. Locked in by a 30-combination invariant test.
- **Fix C** — Shared `_resolve_session_note_by_hash()` helper at both glob sites (`get_session_context` and `is_resumed_session`) materializes matches, filters by `type: claude-session` and `project_path` (cwd-strict), warns on collisions. Subsumes [#86](https://github.com/abhattacherjee/obsidian-brain/issues/86).

13 TDD commits + 1 review-fix commit. Full suite: **787 passed**, no regressions.

## Comprehensive review applied

After initial Task 8 PR creation, ran 4-agent comprehensive review (`/pr-review-toolkit:review-pr`):
- code-reviewer
- silent-failure-hunter
- pr-test-analyzer
- comment-analyzer

Surfaced 3 Critical findings (silent-failure-hunter elevated #110 from "deferred follow-up" to Critical: cross-project hash collision produces silently-wrong `resumed: true` frontmatter, not just cosmetic) plus 4 Important findings. All addressed in fixup commit `9fe2402`:

- `is_resumed_session` returns `resolved is not None` (drops `bool(collisions)` disjunct) — eliminates silently-wrong frontmatter
- `_resolve_session_note_by_hash` cwd-strict on single-match path (subsumes #110)
- `_peek_frontmatter_field` catches `UnicodeDecodeError` + logs empty-but-present values (corruption signal)
- `_resolve_session_note_by_hash` logs when sessions_dir is missing (no longer conflates "no vault" with "no matches")
- `_first_seen_date` temp cleanup OSError now logs (no empty `except: pass`)
- Docstring fixes (corruption-self-heal, return-shape asymmetry, WARN scope clarification)
- 4 new tests covering invalid UTF-8, empty values, missing dirs, cross-project collisions

## Test plan

- [x] `tests/test_get_session_context.py` — 27 tests
- [x] Project-slug invariant test parametrized over 30 (project, sid) combinations
- [x] Full suite: 787 passed
- [x] Manual smoke test: `_first_seen_date` writes marker with mode 0o600 in fresh shell

## Closes

- Closes #101 (cluster Phase 1 foundation)
- Closes #86 (sister glob site discipline)
- Closes #110 (cross-project hash collision — subsumed by review-fix commit `9fe2402`)

## Out of scope (separate issues, queued)

- #102 render-side defense (basename → UUID resolution)
- #103 `--min-confidence` drain — repairs the existing 9 dead-link insights
- #106 UUID-first detection in vault-doctor source-sessions check
- #100 SessionEnd silently drops above-threshold notes

## Spec + plan

- Spec: `docs/superpowers/specs/2026-04-25-issue-101-source-session-basename-stability-design.md` @ `8909254` (branch `spec/issue-101-source-session-basename-stability`)
- Plan: `docs/superpowers/plans/2026-04-25-issue-101-source-session-basename-stability-plan.md` @ `80c6109` (branch `plan/issue-101-source-session-basename-stability`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)