### PR TITLE
feat(telemetry): SessionEnd outcome logging (#100 Phase 1, #123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- SessionEnd hook now logs structured outcome lines to `~/.claude/obsidian-brain-hook.log` for every exit path (success, all skip reasons, write failure, exception). Enables post-hoc diagnosis of dropped sessions. Issue #100 Phase 1 ([#123](https://github.com/abhattacherjee/obsidian-brain/issues/123)).
+
 ## [2.4.2] - 2026-04-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ python3 hooks/obsidian_context_snapshot.py
 
 Sessions are logged with a **write-first pattern**: the raw note (with conversation excerpts, tool usage, metadata) is always saved to the vault immediately. AI summarization is deferred entirely: notes are written in raw form and upgraded by `/recall` on demand.
 
-Structured outcome telemetry is appended to `~/.claude/obsidian-brain-hook.log` for every SessionEnd exit path (success, all skip reasons, write failure, exception) and every SessionStart bootstrap event. The log uses one line per event with grep-friendly `key=value` fields, rotates at 100 KB to `obsidian-brain-hook.log.1`, and is the primary diagnostic surface for sessions that did not produce a vault note. Inspect with `awk '{print $5}' ~/.claude/obsidian-brain-hook.log | sort | uniq -c` for an outcome distribution.
+Structured outcome telemetry is appended to `~/.claude/obsidian-brain-hook.log` for every SessionEnd exit path (success, all skip reasons, write failure, exception) and every SessionStart bootstrap event. The log uses one line per event with grep-friendly `key=value` fields, rotates at 100 KB to `obsidian-brain-hook.log.1`, and is the primary diagnostic surface for sessions that did not produce a vault note. Inspect with `awk '/SessionEnd/ {print $5}' ~/.claude/obsidian-brain-hook.log | sort | uniq -c` for a SessionEnd outcome distribution.
 
 ### Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,9 @@ python3 hooks/obsidian_context_snapshot.py
 
 ### Data flow
 
-Sessions are logged with a **write-first pattern**: the raw note (with conversation excerpts, tool usage, metadata) is always saved to the vault immediately. AI summarization is attempted as a best-effort upgrade. Unsummarized notes get upgraded later when `/recall` is invoked.
+Sessions are logged with a **write-first pattern**: the raw note (with conversation excerpts, tool usage, metadata) is always saved to the vault immediately. AI summarization is deferred entirely: notes are written in raw form and upgraded by `/recall` on demand.
 
-Structured outcome telemetry is appended to `~/.claude/obsidian-brain-hook.log` for every SessionEnd exit path (success, all skip reasons, write failure, exception) and every SessionStart bootstrap event. The log uses one line per event with grep-friendly `key=value` fields, rotates at 100 KB to `obsidian-brain-hook.log.1`, and is the primary diagnostic surface for sessions that did not produce a vault note. Inspect with `awk '{print $4}' ~/.claude/obsidian-brain-hook.log | sort | uniq -c` for an outcome distribution.
+Structured outcome telemetry is appended to `~/.claude/obsidian-brain-hook.log` for every SessionEnd exit path (success, all skip reasons, write failure, exception) and every SessionStart bootstrap event. The log uses one line per event with grep-friendly `key=value` fields, rotates at 100 KB to `obsidian-brain-hook.log.1`, and is the primary diagnostic surface for sessions that did not produce a vault note. Inspect with `awk '{print $5}' ~/.claude/obsidian-brain-hook.log | sort | uniq -c` for an outcome distribution.
 
 ### Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ python3 hooks/obsidian_context_snapshot.py
 ### Key files
 
 - `hooks/obsidian_utils.py` — Shared utility module (~655 lines) used by all three hooks. Contains transcript parsing, metadata extraction, summarization (shells out to `claude -p --model haiku`), and atomic vault writes.
-- `hooks/obsidian_session_log.py` — SessionEnd: writes raw session note immediately, then attempts AI summarization (15s timeout, best-effort).
+- `hooks/obsidian_session_log.py` — SessionEnd: writes raw session note immediately (AI summarization deferred to `/recall`), and appends a structured outcome line to `~/.claude/obsidian-brain-hook.log` for every exit path.
 - `hooks/obsidian_session_hint.py` — SessionStart: injects last-session context hint for the current project.
 - `hooks/obsidian_context_snapshot.py` — PreCompact: saves context snapshot before compression.
 - `templates/` — Markdown templates for each note type (session, insight, decision, error-fix, snapshot, imported-session).
@@ -44,6 +44,8 @@ python3 hooks/obsidian_context_snapshot.py
 ### Data flow
 
 Sessions are logged with a **write-first pattern**: the raw note (with conversation excerpts, tool usage, metadata) is always saved to the vault immediately. AI summarization is attempted as a best-effort upgrade. Unsummarized notes get upgraded later when `/recall` is invoked.
+
+Structured outcome telemetry is appended to `~/.claude/obsidian-brain-hook.log` for every SessionEnd exit path (success, all skip reasons, write failure, exception) and every SessionStart bootstrap event. The log uses one line per event with grep-friendly `key=value` fields, rotates at 100 KB to `obsidian-brain-hook.log.1`, and is the primary diagnostic surface for sessions that did not produce a vault note. Inspect with `awk '{print $4}' ~/.claude/obsidian-brain-hook.log | sort | uniq -c` for an outcome distribution.
 
 ### Configuration
 

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -83,8 +83,9 @@ def _append_hook_log(project: str, session_id: str, bootstrap_updated: bool) -> 
             pass  # no existing log; nothing to rotate
         timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
         short_sid = (session_id or "unknown")[:8]
+        safe_project = (project or "unknown").replace(" ", "_").replace("\n", " ")
         line = (
-            f"{timestamp} SessionStart project={project} sid={short_sid} "
+            f"{timestamp} SessionStart project={safe_project} sid={short_sid} "
             f"bootstrap_updated={'true' if bootstrap_updated else 'false'}\n"
         )
         with open(log_path, "a", encoding="utf-8") as f:

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -22,6 +22,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from obsidian_utils import (  # noqa: E402
     _bootstrap_prefix,
     _ensure_secure_dir,
+    _HOOK_LOG_MAX_BYTES,
+    _HOOK_LOG_NAME,
     find_latest_session,
     get_project_name,
     load_config,
@@ -31,9 +33,6 @@ from obsidian_utils import (  # noqa: E402
 # ---------------------------------------------------------------------------
 # Bootstrap-file + audit-log helpers
 # ---------------------------------------------------------------------------
-
-_HOOK_LOG_NAME = "obsidian-brain-hook.log"
-_HOOK_LOG_MAX_BYTES = 100 * 1024  # 100 KB
 
 
 def _write_bootstrap_atomic(project: str, session_id: str) -> bool:
@@ -79,8 +78,9 @@ def _append_hook_log(project: str, session_id: str, bootstrap_updated: bool) -> 
         try:
             if os.path.getsize(log_path) > _HOOK_LOG_MAX_BYTES:
                 os.replace(log_path, log_path + ".1")
-        except OSError:
+        except FileNotFoundError:
             pass  # no existing log; nothing to rotate
+        # Other OSError (permission, etc.) propagates to outer except → stderr warning
         timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
         short_sid = (session_id or "unknown")[:8]
         safe_project = (project or "unknown").replace(" ", "_").replace("\n", " ")
@@ -90,6 +90,10 @@ def _append_hook_log(project: str, session_id: str, bootstrap_updated: bool) -> 
         )
         with open(log_path, "a", encoding="utf-8") as f:
             f.write(line)
+        try:
+            os.chmod(log_path, 0o600)
+        except OSError:
+            pass  # best-effort; chmod failure is not fatal for telemetry
     except OSError as exc:
         print(f"[obsidian-brain] hook log append failed: {exc}", file=sys.stderr)
 

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -83,7 +83,7 @@ def _append_hook_log(project: str, session_id: str, bootstrap_updated: bool) -> 
             pass  # no existing log; nothing to rotate
         # Other OSError (permission, etc.) propagates to outer except → stderr warning
         timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
-        short_sid = _sanitize_log_field((session_id or "unknown")[:8])
+        short_sid = _sanitize_log_field((session_id or "unknown")[:8]).replace(" ", "_")
         safe_project = _sanitize_log_field(project, "unknown").replace(" ", "_")
         line = (
             f"{timestamp} SessionStart project={safe_project} sid={short_sid} "

--- a/hooks/obsidian_session_hint.py
+++ b/hooks/obsidian_session_hint.py
@@ -24,6 +24,7 @@ from obsidian_utils import (  # noqa: E402
     _ensure_secure_dir,
     _HOOK_LOG_MAX_BYTES,
     _HOOK_LOG_NAME,
+    _sanitize_log_field,
     find_latest_session,
     get_project_name,
     load_config,
@@ -82,8 +83,8 @@ def _append_hook_log(project: str, session_id: str, bootstrap_updated: bool) -> 
             pass  # no existing log; nothing to rotate
         # Other OSError (permission, etc.) propagates to outer except → stderr warning
         timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
-        short_sid = (session_id or "unknown")[:8]
-        safe_project = (project or "unknown").replace(" ", "_").replace("\n", " ")
+        short_sid = _sanitize_log_field((session_id or "unknown")[:8])
+        safe_project = _sanitize_log_field(project, "unknown").replace(" ", "_")
         line = (
             f"{timestamp} SessionStart project={safe_project} sid={short_sid} "
             f"bootstrap_updated={'true' if bootstrap_updated else 'false'}\n"

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -60,6 +60,13 @@ class _Outcome:
     EXCEPTION = "EXCEPTION"
 
 
+# Updated by _run() as soon as hook_input is parsed; read by main()'s
+# exception handler so EXCEPTION telemetry can carry real project/sid
+# context instead of just "unknown".
+_LAST_PROJECT: str = "unknown"
+_LAST_SESSION_ID: str = "unknown"
+
+
 # ---------------------------------------------------------------------------
 # Telemetry helpers
 # ---------------------------------------------------------------------------
@@ -154,11 +161,12 @@ def main() -> None:
         _run()
     except Exception as exc:
         print(f"[obsidian-brain] session-log unexpected error: {exc}", file=sys.stderr)
-        # stdin was already consumed by _run(); use "unknown" placeholders.
+        # _run() may have updated _LAST_PROJECT / _LAST_SESSION_ID before raising;
+        # use those for telemetry context rather than literal "unknown".
         try:
             _append_sessionend_log(
-                project="unknown",
-                session_id="unknown",
+                project=_LAST_PROJECT,
+                session_id=_LAST_SESSION_ID,
                 outcome=_Outcome.EXCEPTION,
                 detail=repr(exc)[:200],
             )
@@ -169,6 +177,12 @@ def main() -> None:
 
 
 def _run() -> None:
+    global _LAST_PROJECT, _LAST_SESSION_ID
+    # Reset so a stale value from a prior invocation in the same process does
+    # not bleed into this run's EXCEPTION telemetry.
+    _LAST_PROJECT = "unknown"
+    _LAST_SESSION_ID = "unknown"
+
     # 1. Read hook input from stdin
     try:
         raw = sys.stdin.read(1_000_000)
@@ -180,6 +194,8 @@ def _run() -> None:
     # Extract session_id up front so the finally block can always clean up,
     # regardless of which early-return path below we take.
     session_id = hook_input.get("session_id", "")
+    if session_id:
+        _LAST_SESSION_ID = session_id
 
     try:
         if not hook_input:
@@ -192,6 +208,8 @@ def _run() -> None:
             return
 
         cwd = hook_input.get("cwd", "")
+        if cwd:
+            _LAST_PROJECT = _project_slug_for_log(cwd)
         transcript_path = hook_input.get("transcript_path", "")
 
         # Validate transcript_path stays inside ~/.claude/projects/

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -154,6 +154,18 @@ def main() -> None:
         _run()
     except Exception as exc:
         print(f"[obsidian-brain] session-log unexpected error: {exc}", file=sys.stderr)
+        # Best-effort: try to extract a project + sid from stdin for the log line.
+        # If stdin was already consumed (it was, by _run), use "unknown" placeholders.
+        try:
+            _append_sessionend_log(
+                project="unknown",
+                session_id="unknown",
+                outcome=_Outcome.EXCEPTION,
+                detail=repr(exc)[:200],
+            )
+        except Exception:
+            # Logging itself failed — nothing else to do; we still exit 0.
+            pass
     sys.exit(0)
 
 

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -374,6 +374,19 @@ def _run() -> None:
             )
             return
         print("[obsidian-brain] raw note written (summarization deferred to /recall)", file=sys.stderr)
+        _append_sessionend_log(
+            project=metadata.get("project") or _project_slug_for_log(cwd),
+            session_id=session_id,
+            outcome=_Outcome.OK_RAW_NOTE_ONLY,
+            msgs=len(user_msgs),
+            dur_min=float(metadata.get("duration_minutes", 0.0)),
+            detail="snapshot-bypass" if (
+                should_skip_session(
+                    user_msgs, metadata.get("duration_minutes", 0.0),
+                    min_messages=min_messages, min_duration=min_duration,
+                ) and snapshots
+            ) else "",
+        )
     finally:
         # Run cache cleanup regardless of how _run() exits so /tmp does not
         # accumulate stale cache files on any SessionEnd outcome — including

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -335,8 +335,11 @@ def _run() -> None:
 
         # Re-check with actual duration — BUT if snapshots exist, bypass
         # thresholds so the session note always anchors the snapshots.
-        if should_skip_session(user_msgs, metadata["duration_minutes"],
-                               min_messages=min_messages, min_duration=min_duration):
+        was_threshold_skipped = should_skip_session(
+            user_msgs, metadata["duration_minutes"],
+            min_messages=min_messages, min_duration=min_duration,
+        )
+        if was_threshold_skipped:
             if not snapshots:
                 print("[obsidian-brain] session below thresholds, skipping", file=sys.stderr)
                 _append_sessionend_log(
@@ -392,12 +395,7 @@ def _run() -> None:
             outcome=_Outcome.OK_RAW_NOTE_ONLY,
             msgs=len(user_msgs),
             dur_min=float(metadata.get("duration_minutes", 0.0)),
-            detail="snapshot-bypass" if (
-                should_skip_session(
-                    user_msgs, metadata.get("duration_minutes", 0.0),
-                    min_messages=min_messages, min_duration=min_duration,
-                ) and snapshots
-            ) else "",
+            detail="snapshot-bypass" if (was_threshold_skipped and snapshots) else "",
         )
     finally:
         # Run cache cleanup regardless of how _run() exits so /tmp does not

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -191,6 +191,12 @@ def _run() -> None:
         print(f"[obsidian-brain] invalid stdin JSON: {exc}", file=sys.stderr)
         hook_input = {}
 
+    # JSON can legally return non-dict (list, string, number); coerce to {}
+    # so downstream .get() calls don't AttributeError. Treated as
+    # SKIPPED_INVALID_INPUT below via the empty-input branch.
+    if not isinstance(hook_input, dict):
+        hook_input = {}
+
     # Extract session_id up front so the finally block can always clean up,
     # regardless of which early-return path below we take.
     session_id = hook_input.get("session_id", "")

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -159,6 +159,12 @@ def _run() -> None:
 
     try:
         if not hook_input:
+            _append_sessionend_log(
+                project="unknown",
+                session_id=session_id,
+                outcome=_Outcome.SKIPPED_INVALID_INPUT,
+                detail="empty or unparseable stdin",
+            )
             return
 
         cwd = hook_input.get("cwd", "")
@@ -169,10 +175,25 @@ def _run() -> None:
             allowed_root = os.path.realpath(os.path.expanduser("~/.claude/projects"))
             if not os.path.realpath(transcript_path).startswith(allowed_root + os.sep):
                 print("[obsidian-brain] transcript_path outside ~/.claude/projects, skipping", file=sys.stderr)
+                _append_sessionend_log(
+                    project=slugify(Path(cwd).name) if cwd else "unknown",
+                    session_id=session_id,
+                    outcome=_Outcome.SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS,
+                    detail=os.path.realpath(transcript_path),
+                )
                 return
 
         if not session_id or not transcript_path:
             print("[obsidian-brain] missing session_id or transcript_path, skipping", file=sys.stderr)
+            _append_sessionend_log(
+                project=slugify(Path(cwd).name) if cwd else "unknown",
+                session_id=session_id,
+                outcome=_Outcome.SKIPPED_INVALID_INPUT,
+                detail=(
+                    "missing session_id" if not session_id
+                    else "missing transcript_path"
+                ),
+            )
             return
 
         # 2. Load config

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -61,6 +61,19 @@ class _Outcome:
 
 
 # ---------------------------------------------------------------------------
+# Telemetry helpers
+# ---------------------------------------------------------------------------
+
+
+def _project_slug_for_log(cwd: str) -> str:
+    """Derive a project slug for telemetry from the hook's cwd field.
+
+    Returns 'unknown' when cwd is empty rather than slugify's default 'session'.
+    """
+    return slugify(Path(cwd).name) if cwd else "unknown"
+
+
+# ---------------------------------------------------------------------------
 # Session cache cleanup
 # ---------------------------------------------------------------------------
 
@@ -176,7 +189,7 @@ def _run() -> None:
             if not os.path.realpath(transcript_path).startswith(allowed_root + os.sep):
                 print("[obsidian-brain] transcript_path outside ~/.claude/projects, skipping", file=sys.stderr)
                 _append_sessionend_log(
-                    project=slugify(Path(cwd).name) if cwd else "unknown",
+                    project=_project_slug_for_log(cwd),
                     session_id=session_id,
                     outcome=_Outcome.SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS,
                     detail=os.path.realpath(transcript_path),
@@ -186,7 +199,7 @@ def _run() -> None:
         if not session_id or not transcript_path:
             print("[obsidian-brain] missing session_id or transcript_path, skipping", file=sys.stderr)
             _append_sessionend_log(
-                project=slugify(Path(cwd).name) if cwd else "unknown",
+                project=_project_slug_for_log(cwd),
                 session_id=session_id,
                 outcome=_Outcome.SKIPPED_INVALID_INPUT,
                 detail=(
@@ -201,7 +214,7 @@ def _run() -> None:
         if not config.get("auto_log_enabled", True):
             print("[obsidian-brain] auto_log_enabled is False, skipping", file=sys.stderr)
             _append_sessionend_log(
-                project=slugify(Path(cwd).name) if cwd else "unknown",
+                project=_project_slug_for_log(cwd),
                 session_id=session_id,
                 outcome=_Outcome.SKIPPED_AUTO_LOG_OFF,
             )
@@ -211,7 +224,7 @@ def _run() -> None:
         if not vault_path:
             print("[obsidian-brain] no vault_path configured, skipping", file=sys.stderr)
             _append_sessionend_log(
-                project=slugify(Path(cwd).name) if cwd else "unknown",
+                project=_project_slug_for_log(cwd),
                 session_id=session_id,
                 outcome=_Outcome.SKIPPED_NO_VAULT,
             )
@@ -226,7 +239,7 @@ def _run() -> None:
         if not messages:
             print("[obsidian-brain] empty transcript, skipping", file=sys.stderr)
             _append_sessionend_log(
-                project=slugify(Path(cwd).name) if cwd else "unknown",
+                project=_project_slug_for_log(cwd),
                 session_id=session_id,
                 outcome=_Outcome.SKIPPED_NO_TRANSCRIPT,
                 detail=transcript_path,

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -364,6 +364,14 @@ def _run() -> None:
         raw_content = _build_note(session_id, metadata, raw_body, resumed=resumed)
         if not write_vault_note(vault_path, sessions_folder, filename, raw_content):
             print("[obsidian-brain] failed to write raw note, aborting", file=sys.stderr)
+            _append_sessionend_log(
+                project=metadata.get("project") or _project_slug_for_log(cwd),
+                session_id=session_id,
+                outcome=_Outcome.WRITE_FAILED,
+                msgs=len(user_msgs),
+                dur_min=float(metadata.get("duration_minutes", 0.0)),
+                detail=f"write_vault_note returned False; target={Path(vault_path) / sessions_folder / filename}",
+            )
             return
         print("[obsidian-brain] raw note written (summarization deferred to /recall)", file=sys.stderr)
     finally:

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -282,6 +282,14 @@ def _run() -> None:
             if not snapshots:
                 print(f"[obsidian-brain] too few user messages ({len(user_msgs)}), skipping",
                       file=sys.stderr)
+                _append_sessionend_log(
+                    project=_project_slug_for_log(cwd),
+                    session_id=session_id,
+                    outcome=_Outcome.SKIPPED_BELOW_THRESHOLD,
+                    msgs=len(user_msgs),
+                    dur_min=0.0,
+                    detail="message-count check",
+                )
                 return
             print(
                 f"[obsidian-brain] below message threshold but {len(snapshots)} snapshot(s) "
@@ -319,6 +327,14 @@ def _run() -> None:
                                min_messages=min_messages, min_duration=min_duration):
             if not snapshots:
                 print("[obsidian-brain] session below thresholds, skipping", file=sys.stderr)
+                _append_sessionend_log(
+                    project=metadata.get("project") or _project_slug_for_log(cwd),
+                    session_id=session_id,
+                    outcome=_Outcome.SKIPPED_BELOW_THRESHOLD,
+                    msgs=len(user_msgs),
+                    dur_min=float(metadata.get("duration_minutes", 0.0)),
+                    detail="duration check",
+                )
                 return
             print(
                 f"[obsidian-brain] below thresholds but {len(snapshots)} snapshot(s) exist — "

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -24,6 +24,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import obsidian_utils  # noqa: E402  — used for _first_seen_date qualified call
 from obsidian_utils import (  # noqa: E402
+    _append_sessionend_log,
     build_raw_fallback,
     extract_assistant_messages,
     extract_session_metadata,
@@ -38,6 +39,25 @@ from obsidian_utils import (  # noqa: E402
     slugify,
     write_vault_note,
 )
+
+
+# ---------------------------------------------------------------------------
+# SessionEnd outcome enum (telemetry — issue #100 Phase 1)
+# ---------------------------------------------------------------------------
+
+
+class _Outcome:
+    """String constants for SessionEnd hook outcomes written to the rotated audit log."""
+    OK = "OK"
+    OK_RAW_NOTE_ONLY = "OK_RAW_NOTE_ONLY"
+    SKIPPED_BELOW_THRESHOLD = "SKIPPED_BELOW_THRESHOLD"
+    SKIPPED_NO_TRANSCRIPT = "SKIPPED_NO_TRANSCRIPT"
+    SKIPPED_NO_VAULT = "SKIPPED_NO_VAULT"
+    SKIPPED_AUTO_LOG_OFF = "SKIPPED_AUTO_LOG_OFF"
+    SKIPPED_INVALID_INPUT = "SKIPPED_INVALID_INPUT"
+    SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS = "SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS"
+    WRITE_FAILED = "WRITE_FAILED"
+    EXCEPTION = "EXCEPTION"
 
 
 # ---------------------------------------------------------------------------

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -48,7 +48,7 @@ from obsidian_utils import (  # noqa: E402
 
 class _Outcome:
     """String constants for SessionEnd hook outcomes written to the rotated audit log."""
-    OK = "OK"
+    OK = "OK"  # Reserved for Phase 2 (#124/#125) — async summarization success path
     OK_RAW_NOTE_ONLY = "OK_RAW_NOTE_ONLY"
     SKIPPED_BELOW_THRESHOLD = "SKIPPED_BELOW_THRESHOLD"
     SKIPPED_NO_TRANSCRIPT = "SKIPPED_NO_TRANSCRIPT"

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -48,7 +48,7 @@ from obsidian_utils import (  # noqa: E402
 
 class _Outcome:
     """String constants for SessionEnd hook outcomes written to the rotated audit log."""
-    OK = "OK"  # Reserved for Phase 2 (#124/#125) — async summarization success path
+    OK = "OK"  # Reserved for Phase 3 (#125) — reaper writes "Reaped OK" for reconstructed sessions
     OK_RAW_NOTE_ONLY = "OK_RAW_NOTE_ONLY"
     SKIPPED_BELOW_THRESHOLD = "SKIPPED_BELOW_THRESHOLD"
     SKIPPED_NO_TRANSCRIPT = "SKIPPED_NO_TRANSCRIPT"
@@ -154,8 +154,7 @@ def main() -> None:
         _run()
     except Exception as exc:
         print(f"[obsidian-brain] session-log unexpected error: {exc}", file=sys.stderr)
-        # Best-effort: try to extract a project + sid from stdin for the log line.
-        # If stdin was already consumed (it was, by _run), use "unknown" placeholders.
+        # stdin was already consumed by _run(); use "unknown" placeholders.
         try:
             _append_sessionend_log(
                 project="unknown",
@@ -335,6 +334,7 @@ def _run() -> None:
 
         # Re-check with actual duration — BUT if snapshots exist, bypass
         # thresholds so the session note always anchors the snapshots.
+        # Cached: also drives detail="snapshot-bypass" on the OK_RAW_NOTE_ONLY log line below.
         was_threshold_skipped = should_skip_session(
             user_msgs, metadata["duration_minutes"],
             min_messages=min_messages, min_duration=min_duration,

--- a/hooks/obsidian_session_log.py
+++ b/hooks/obsidian_session_log.py
@@ -200,11 +200,21 @@ def _run() -> None:
         config = load_config()
         if not config.get("auto_log_enabled", True):
             print("[obsidian-brain] auto_log_enabled is False, skipping", file=sys.stderr)
+            _append_sessionend_log(
+                project=slugify(Path(cwd).name) if cwd else "unknown",
+                session_id=session_id,
+                outcome=_Outcome.SKIPPED_AUTO_LOG_OFF,
+            )
             return
 
         vault_path = config.get("vault_path", "")
         if not vault_path:
             print("[obsidian-brain] no vault_path configured, skipping", file=sys.stderr)
+            _append_sessionend_log(
+                project=slugify(Path(cwd).name) if cwd else "unknown",
+                session_id=session_id,
+                outcome=_Outcome.SKIPPED_NO_VAULT,
+            )
             return
 
         sessions_folder = config.get("sessions_folder", "claude-sessions")
@@ -215,6 +225,12 @@ def _run() -> None:
         messages = read_transcript(transcript_path)
         if not messages:
             print("[obsidian-brain] empty transcript, skipping", file=sys.stderr)
+            _append_sessionend_log(
+                project=slugify(Path(cwd).name) if cwd else "unknown",
+                session_id=session_id,
+                outcome=_Outcome.SKIPPED_NO_TRANSCRIPT,
+                detail=transcript_path,
+            )
             return
 
         # 4. Extract user and assistant messages

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -390,8 +390,8 @@ def _bootstrap_prefix() -> str:
 # SessionEnd telemetry log
 # ---------------------------------------------------------------------------
 
-_SESSIONEND_LOG_NAME = "obsidian-brain-hook.log"
-_SESSIONEND_LOG_MAX_BYTES = 100 * 1024  # 100 KB — same cap as SessionStart log
+_HOOK_LOG_NAME = "obsidian-brain-hook.log"
+_HOOK_LOG_MAX_BYTES = 100 * 1024  # 100 KB — same cap as SessionStart log
 
 
 def _append_sessionend_log(
@@ -408,14 +408,15 @@ def _append_sessionend_log(
     entries. Never raises — failure to log must not block the SessionEnd hook.
     """
     log_dir = os.path.join(os.path.expanduser("~"), ".claude")
-    log_path = os.path.join(log_dir, _SESSIONEND_LOG_NAME)
+    log_path = os.path.join(log_dir, _HOOK_LOG_NAME)
     try:
         os.makedirs(log_dir, exist_ok=True)
         try:
-            if os.path.getsize(log_path) > _SESSIONEND_LOG_MAX_BYTES:
+            if os.path.getsize(log_path) > _HOOK_LOG_MAX_BYTES:
                 os.replace(log_path, log_path + ".1")
-        except OSError:
+        except FileNotFoundError:
             pass  # no existing log; nothing to rotate
+        # Other OSError (permission, etc.) propagates to outer except → stderr warning
         timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
         short_sid = (session_id or "unknown")[:8]
         # Sanitize fields that could contain spaces/newlines — keep one-line-per-event.
@@ -429,6 +430,10 @@ def _append_sessionend_log(
         )
         with open(log_path, "a", encoding="utf-8") as f:
             f.write(line)
+        try:
+            os.chmod(log_path, 0o600)
+        except OSError:
+            pass  # best-effort; chmod failure is not fatal for telemetry
     except OSError as exc:
         print(f"[obsidian-brain] sessionend log append failed: {exc}", file=sys.stderr)
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -420,10 +420,11 @@ def _append_sessionend_log(
         short_sid = (session_id or "unknown")[:8]
         # Sanitize fields that could contain spaces/newlines — keep one-line-per-event.
         safe_project = (project or "unknown").replace(" ", "_").replace("\n", " ")
+        safe_outcome = (outcome or "UNKNOWN").replace(" ", "_").replace("\n", " ")
         safe_detail = (detail or "").replace("\n", " ").replace("\r", " ")
         line = (
             f"{timestamp} SessionEnd project={safe_project} sid={short_sid} "
-            f"outcome={outcome} msgs={int(msgs)} dur={float(dur_min):.1f} "
+            f"outcome={safe_outcome} msgs={int(msgs)} dur={float(dur_min):.1f} "
             f"detail={safe_detail}\n"
         )
         with open(log_path, "a", encoding="utf-8") as f:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -430,7 +430,7 @@ def _append_sessionend_log(
         timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
         # Sanitize all fields — \n, \r, or \t in any field would corrupt the
         # one-line-per-event format.
-        short_sid = _sanitize_log_field((session_id or "unknown")[:8])
+        short_sid = _sanitize_log_field((session_id or "unknown")[:8]).replace(" ", "_")
         safe_project = _sanitize_log_field(project, "unknown").replace(" ", "_")
         safe_outcome = _sanitize_log_field(outcome, "UNKNOWN").replace(" ", "_")
         safe_detail = _sanitize_log_field(detail)

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -394,6 +394,12 @@ _HOOK_LOG_NAME = "obsidian-brain-hook.log"
 _HOOK_LOG_MAX_BYTES = 100 * 1024  # 100 KB — same cap as SessionStart log
 
 
+def _sanitize_log_field(value: str, default: str = "") -> str:
+    """Sanitize a log field: strip \\n, \\r, \\t so each event stays on one line."""
+    s = value if value else default
+    return s.replace("\n", " ").replace("\r", " ").replace("\t", " ")
+
+
 def _append_sessionend_log(
     project: str,
     session_id: str,
@@ -404,8 +410,12 @@ def _append_sessionend_log(
 ) -> None:
     """Append a one-line SessionEnd outcome record; rotate when oversized.
 
-    Writes to ~/.claude/obsidian-brain-hook.log alongside SessionStart and Reaped
-    entries. Never raises — failure to log must not block the SessionEnd hook.
+    Writes to ~/.claude/obsidian-brain-hook.log alongside SessionStart entries
+    and the future Reaped entries (issue #125 reaper).
+
+    Best-effort: catches any exception (OSError from filesystem, TypeError
+    from bad input types, etc.) and prints a stderr warning. Failure to log
+    must not block the SessionEnd hook contract — the hook always exits 0.
     """
     log_dir = os.path.join(os.path.expanduser("~"), ".claude")
     log_path = os.path.join(log_dir, _HOOK_LOG_NAME)
@@ -416,13 +426,14 @@ def _append_sessionend_log(
                 os.replace(log_path, log_path + ".1")
         except FileNotFoundError:
             pass  # no existing log; nothing to rotate
-        # Other OSError (permission, etc.) propagates to outer except → stderr warning
+        # Other errors (permission, etc.) propagate to outer except → stderr warning
         timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
-        short_sid = (session_id or "unknown")[:8]
-        # Sanitize fields that could contain spaces/newlines — keep one-line-per-event.
-        safe_project = (project or "unknown").replace(" ", "_").replace("\n", " ")
-        safe_outcome = (outcome or "UNKNOWN").replace(" ", "_").replace("\n", " ")
-        safe_detail = (detail or "").replace("\n", " ").replace("\r", " ")
+        # Sanitize all fields — \n, \r, or \t in any field would corrupt the
+        # one-line-per-event format.
+        short_sid = _sanitize_log_field((session_id or "unknown")[:8])
+        safe_project = _sanitize_log_field(project, "unknown").replace(" ", "_")
+        safe_outcome = _sanitize_log_field(outcome, "UNKNOWN").replace(" ", "_")
+        safe_detail = _sanitize_log_field(detail)
         line = (
             f"{timestamp} SessionEnd project={safe_project} sid={short_sid} "
             f"outcome={safe_outcome} msgs={int(msgs)} dur={float(dur_min):.1f} "
@@ -434,7 +445,7 @@ def _append_sessionend_log(
             os.chmod(log_path, 0o600)
         except OSError:
             pass  # best-effort; chmod failure is not fatal for telemetry
-    except OSError as exc:
+    except Exception as exc:
         print(f"[obsidian-brain] sessionend log append failed: {exc}", file=sys.stderr)
 
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -386,6 +386,52 @@ def _bootstrap_prefix() -> str:
     return _BOOTSTRAP_PREFIX
 
 
+# ---------------------------------------------------------------------------
+# SessionEnd telemetry log
+# ---------------------------------------------------------------------------
+
+_SESSIONEND_LOG_NAME = "obsidian-brain-hook.log"
+_SESSIONEND_LOG_MAX_BYTES = 100 * 1024  # 100 KB — same cap as SessionStart log
+
+
+def _append_sessionend_log(
+    project: str,
+    session_id: str,
+    outcome: str,
+    msgs: int = 0,
+    dur_min: float = 0.0,
+    detail: str = "",
+) -> None:
+    """Append a one-line SessionEnd outcome record; rotate when oversized.
+
+    Writes to ~/.claude/obsidian-brain-hook.log alongside SessionStart and Reaped
+    entries. Never raises — failure to log must not block the SessionEnd hook.
+    """
+    log_dir = os.path.join(os.path.expanduser("~"), ".claude")
+    log_path = os.path.join(log_dir, _SESSIONEND_LOG_NAME)
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+        try:
+            if os.path.getsize(log_path) > _SESSIONEND_LOG_MAX_BYTES:
+                os.replace(log_path, log_path + ".1")
+        except OSError:
+            pass  # no existing log; nothing to rotate
+        timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+        short_sid = (session_id or "unknown")[:8]
+        # Sanitize fields that could contain spaces/newlines — keep one-line-per-event.
+        safe_project = (project or "unknown").replace(" ", "_").replace("\n", " ")
+        safe_detail = (detail or "").replace("\n", " ").replace("\r", " ")
+        line = (
+            f"{timestamp} SessionEnd project={safe_project} sid={short_sid} "
+            f"outcome={outcome} msgs={int(msgs)} dur={float(dur_min):.1f} "
+            f"detail={safe_detail}\n"
+        )
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError as exc:
+        print(f"[obsidian-brain] sessionend log append failed: {exc}", file=sys.stderr)
+
+
 def _safe_mtime(path: str) -> float:
     """Return file mtime, or -1.0 if the path is missing/unstatable.
 

--- a/scripts/dev-test/test-issue-123-manual.py
+++ b/scripts/dev-test/test-issue-123-manual.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Automated post-/dev-test-install verification for Issue #123 — SessionEnd outcome telemetry.
+
+Run AFTER: /dev-test install (in a sibling CC session, on feature/issue-100-phase1-sessionend-telemetry)
+Usage: python3 scripts/dev-test/test-issue-123-manual.py
+
+Covers Phases 2, 4, and 5 from the dev-test plan:
+- Phase 2: stdin-driven smoke for 8 _Outcome enum values
+- Phase 4: log integrity (rotation, no missing fields, SessionStart unaffected)
+- Phase 5: fixture + config cleanup
+
+NOT covered (require a live CC session):
+- OK / OK_RAW_NOTE_ONLY end-to-end with a real vault note write — covered in Phase 3 of the plan
+- WRITE_FAILED via real chmod 0500 vault — could be scripted, but lives in Phase 3 to avoid touching the real vault dir
+
+Safety:
+- Real ~/.claude/obsidian-brain-config.json is backed up to a sibling .bak file
+  on first mutation and restored at exit (atexit + signal handlers).
+- All test fixtures live under a mktemp dir and ~/.claude/projects/-issue-123-test/.
+- The real vault DB is never touched; SKIPPED_NO_VAULT and EXCEPTION tests use
+  a temp config pointing at a fake vault path.
+"""
+from __future__ import annotations
+import atexit
+import glob
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+# ─── Bootstrap: locate installed hook ────────────────────────────────────
+
+REAL_HOME = Path(os.path.expanduser("~"))
+HOOK_LOG = REAL_HOME / ".claude" / "obsidian-brain-hook.log"
+CONFIG = REAL_HOME / ".claude" / "obsidian-brain-config.json"
+PROJECTS_ROOT = REAL_HOME / ".claude" / "projects"
+TEST_PROJECT = PROJECTS_ROOT / "-issue-123-test"
+CONFIG_BAK = REAL_HOME / ".claude" / "obsidian-brain-config.json.issue-123-bak"
+# Session-scoped config cache lives here. _get_session_id_fast() resolves a sid
+# from cwd → bootstrap → JSONL glob (not from hook stdin), so multiple sequential
+# subprocess calls with the same cwd hit the SAME cache file. We must clear it
+# between any test that mutates the on-disk config, or the hook will read a
+# stale cached config and the mutation will appear to be ignored.
+SECURE_DIR = REAL_HOME / ".claude" / "obsidian-brain"
+
+candidates = sorted(
+    glob.glob(str(REAL_HOME / ".claude/plugins/cache/*/obsidian-brain/*/hooks/obsidian_session_log.py"))
+)
+if not candidates:
+    sys.exit("❌ No installed obsidian-brain hook found. Run /dev-test install first.")
+HOOK_PY = Path(candidates[-1])
+
+# Sanity: confirm the cache has #123 implementation.
+hook_src = HOOK_PY.read_text()
+needed = ["_Outcome", "_append_sessionend_log", "OK_RAW_NOTE_ONLY", "SKIPPED_BELOW_THRESHOLD"]
+missing = [n for n in needed if n not in hook_src]
+if missing:
+    sys.exit(
+        f"❌ Installed hook at {HOOK_PY} is missing #123 markers: {missing}\n"
+        f"   Re-run /dev-test install on the #123 feature branch."
+    )
+
+# ─── Cleanup registration (must run before any mutation) ─────────────────
+
+def _restore_config():
+    """Restore real config from backup if we created one."""
+    if CONFIG_BAK.exists():
+        try:
+            shutil.copy2(CONFIG_BAK, CONFIG)
+            CONFIG_BAK.unlink()
+        except OSError as e:
+            print(f"  ⚠ failed to restore config: {e}", file=sys.stderr)
+
+
+def _cleanup_test_project():
+    if TEST_PROJECT.exists():
+        shutil.rmtree(TEST_PROJECT, ignore_errors=True)
+
+
+atexit.register(_restore_config)
+atexit.register(_cleanup_test_project)
+# Also restore on SIGINT/SIGTERM so Ctrl-C doesn't leave a corrupted config.
+for sig in (signal.SIGINT, signal.SIGTERM):
+    signal.signal(sig, lambda s, f: sys.exit(130))
+
+
+def _backup_config_once():
+    """Idempotent: copy real config to .issue-123-bak if not already done."""
+    if not CONFIG_BAK.exists() and CONFIG.exists():
+        shutil.copy2(CONFIG, CONFIG_BAK)
+
+
+def _clear_config_cache():
+    """Remove all session-scoped config cache files so the hook re-reads
+    obsidian-brain-config.json on its next invocation. Best-effort.
+
+    Necessary because load_config() in obsidian_utils.py caches the parsed
+    config keyed by _get_session_id_fast()'s sid (which depends on cwd, NOT
+    on the hook input's session_id). Sequential test calls with the same
+    TMPDIR-based cwd resolve to the same sid and therefore share a cache.
+    """
+    if not SECURE_DIR.exists():
+        return
+    for cache_file in SECURE_DIR.glob("cache-*.json"):
+        try:
+            cache_file.unlink()
+        except OSError:
+            pass
+
+
+# ─── Test scaffolding ────────────────────────────────────────────────────
+
+PASS = 0
+FAIL = 0
+
+
+def pass_(msg: str) -> None:
+    global PASS
+    print(f"  ✅ {msg}")
+    PASS += 1
+
+
+def fail_(msg: str) -> None:
+    global FAIL
+    print(f"  ❌ {msg}")
+    FAIL += 1
+
+
+def log_size_lines() -> int:
+    """Return current line count of the hook log (0 if absent)."""
+    if not HOOK_LOG.exists():
+        return 0
+    return sum(1 for _ in HOOK_LOG.open(encoding="utf-8", errors="replace"))
+
+
+def run_hook(payload: dict | str) -> tuple[int, str, str]:
+    """Pipe payload (dict→json or raw str) into the installed hook. Returns (rc, stdout, stderr)."""
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    p = subprocess.run(
+        ["python3", str(HOOK_PY)],
+        input=body,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    return p.returncode, p.stdout, p.stderr
+
+
+def find_outcome_for_sid(sid: str) -> str | None:
+    """Scan the hook log for a SessionEnd line with sid=<sid>. Return its outcome=, or None.
+
+    Note: the hook truncates session_id to 8 chars when emitting the log line
+    (see _append_sessionend_log in obsidian_utils.py), so we match against the
+    8-char prefix.
+    """
+    if not HOOK_LOG.exists():
+        return None
+    target = f"sid={sid[:8]}"
+    for line in HOOK_LOG.read_text(encoding="utf-8", errors="replace").splitlines():
+        if "SessionEnd" in line and target in line:
+            for tok in line.split():
+                if tok.startswith("outcome="):
+                    return tok.split("=", 1)[1]
+    return None
+
+
+def fresh_sid(tag: str) -> str:
+    """Build a unique 8-char synthetic session_id with a tag prefix."""
+    return f"tst{tag}{int(time.time()*1000) % 100000:05d}"
+
+
+def make_jsonl(path: Path, n_user: int = 5, dur_min: float = 5.0) -> None:
+    """Write a synthetic JSONL with n_user user messages spread across dur_min minutes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    start = time.time() - dur_min * 60
+    lines = []
+    for i in range(n_user):
+        ts = start + i * (dur_min * 60 / max(n_user, 1))
+        from datetime import datetime, timezone
+        iso = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        lines.append(json.dumps({
+            "type": "user",
+            "message": {"content": f"user msg {i}"},
+            "timestamp": iso,
+        }))
+        lines.append(json.dumps({
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": f"reply {i}"}]},
+            "timestamp": iso,
+        }))
+    path.write_text("\n".join(lines) + "\n")
+
+
+# ─── Phase 2 — outcome smoke tests ──────────────────────────────────────
+
+print("═══════════════════════════════════════════════════════════════")
+print(f"Issue #123 — SessionEnd telemetry smoke ({HOOK_PY})")
+print("═══════════════════════════════════════════════════════════════")
+print()
+print("Phase 2 — outcome enum coverage")
+print()
+
+TEST_PROJECT.mkdir(parents=True, exist_ok=True)
+TMPDIR = Path(tempfile.mkdtemp(prefix="ob-issue-123-"))
+atexit.register(lambda: shutil.rmtree(TMPDIR, ignore_errors=True))
+
+# 2.1 — SKIPPED_INVALID_INPUT (empty stdin)
+print("  2.1  SKIPPED_INVALID_INPUT — empty stdin")
+sid = fresh_sid("a")
+rc, _, _ = run_hook("")
+# Empty stdin can't carry sid; just check that an INVALID_INPUT line was added.
+last_line = HOOK_LOG.read_text(encoding="utf-8", errors="replace").splitlines()[-1] if HOOK_LOG.exists() else ""
+if "outcome=SKIPPED_INVALID_INPUT" in last_line:
+    pass_(f"empty stdin → SKIPPED_INVALID_INPUT (rc={rc})")
+else:
+    fail_(f"empty stdin: expected SKIPPED_INVALID_INPUT, got: {last_line!r}")
+
+# 2.2 — SKIPPED_INVALID_INPUT (missing session_id)
+# Note: transcript_path containment check runs BEFORE the missing-sid check,
+# so we must point at a path inside ~/.claude/projects/ to actually exercise
+# the missing-sid branch.
+print("  2.2  SKIPPED_INVALID_INPUT — missing session_id")
+rc, _, _ = run_hook({"transcript_path": str(TEST_PROJECT / "no-sid.jsonl")})
+last_line = HOOK_LOG.read_text(encoding="utf-8", errors="replace").splitlines()[-1]
+if "outcome=SKIPPED_INVALID_INPUT" in last_line:
+    pass_(f"missing session_id → SKIPPED_INVALID_INPUT")
+else:
+    fail_(f"missing sid: expected SKIPPED_INVALID_INPUT, got: {last_line!r}")
+
+# 2.3 — SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS
+print("  2.3  SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS")
+sid = fresh_sid("c")
+rc, _, _ = run_hook({"session_id": sid, "transcript_path": "/tmp/foreign.jsonl", "cwd": "/tmp"})
+got = find_outcome_for_sid(sid)
+if got == "SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS":
+    pass_(f"foreign transcript_path → {got}")
+else:
+    fail_(f"expected SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS, got {got!r}")
+
+# 2.4 — SKIPPED_AUTO_LOG_OFF
+# Note: the hook reads `auto_log_enabled` (see obsidian_utils.py _DEFAULTS and
+# obsidian_session_log.py line 249); `auto_log_sessions` is not the canonical
+# key and would be silently ignored.
+print("  2.4  SKIPPED_AUTO_LOG_OFF — auto_log_enabled=false")
+_backup_config_once()
+cfg = json.loads(CONFIG.read_text())
+cfg["auto_log_enabled"] = False
+CONFIG.write_text(json.dumps(cfg, indent=2))
+_clear_config_cache()
+sid = fresh_sid("d")
+jsonl = TEST_PROJECT / f"{sid}.jsonl"
+make_jsonl(jsonl, n_user=5, dur_min=5)
+rc, _, _ = run_hook({"session_id": sid, "transcript_path": str(jsonl), "cwd": str(TMPDIR)})
+got = find_outcome_for_sid(sid)
+if got == "SKIPPED_AUTO_LOG_OFF":
+    pass_(f"auto_log=false → {got}")
+else:
+    fail_(f"expected SKIPPED_AUTO_LOG_OFF, got {got!r}")
+# Restore auto_log
+cfg["auto_log_enabled"] = True
+CONFIG.write_text(json.dumps(cfg, indent=2))
+_clear_config_cache()
+
+# 2.5 — SKIPPED_NO_VAULT (vault_path empty/unconfigured)
+# Note: the hook only checks `if not vault_path:` (truthy), not directory
+# existence — see obsidian_session_log.py line 258. So we trigger this branch
+# with an empty string, which matches what an unconfigured config produces.
+print("  2.5  SKIPPED_NO_VAULT — vault_path empty")
+_backup_config_once()
+cfg = json.loads(CONFIG.read_text())
+real_vault = cfg.get("vault_path")
+cfg["vault_path"] = ""
+CONFIG.write_text(json.dumps(cfg, indent=2))
+_clear_config_cache()
+sid = fresh_sid("e")
+jsonl = TEST_PROJECT / f"{sid}.jsonl"
+make_jsonl(jsonl, n_user=5, dur_min=5)
+rc, _, _ = run_hook({"session_id": sid, "transcript_path": str(jsonl), "cwd": str(TMPDIR)})
+got = find_outcome_for_sid(sid)
+if got == "SKIPPED_NO_VAULT":
+    pass_(f"empty vault_path → {got}")
+else:
+    fail_(f"expected SKIPPED_NO_VAULT, got {got!r}")
+cfg["vault_path"] = real_vault
+CONFIG.write_text(json.dumps(cfg, indent=2))
+_clear_config_cache()
+
+# 2.6 — SKIPPED_NO_TRANSCRIPT (file missing under ~/.claude/projects/)
+print("  2.6  SKIPPED_NO_TRANSCRIPT — file missing")
+sid = fresh_sid("f")
+missing_path = TEST_PROJECT / f"missing-{sid}.jsonl"
+rc, _, _ = run_hook({"session_id": sid, "transcript_path": str(missing_path), "cwd": str(TMPDIR)})
+got = find_outcome_for_sid(sid)
+if got == "SKIPPED_NO_TRANSCRIPT":
+    pass_(f"missing JSONL → {got}")
+else:
+    fail_(f"expected SKIPPED_NO_TRANSCRIPT, got {got!r}")
+
+# 2.7 — SKIPPED_BELOW_THRESHOLD (small JSONL)
+print("  2.7  SKIPPED_BELOW_THRESHOLD — <3 user messages")
+sid = fresh_sid("g")
+jsonl = TEST_PROJECT / f"{sid}.jsonl"
+make_jsonl(jsonl, n_user=2, dur_min=10)  # 2 user msgs, default min is 3
+rc, _, _ = run_hook({"session_id": sid, "transcript_path": str(jsonl), "cwd": str(TMPDIR)})
+got = find_outcome_for_sid(sid)
+if got == "SKIPPED_BELOW_THRESHOLD":
+    pass_(f"<3 user msgs → {got}")
+else:
+    fail_(f"expected SKIPPED_BELOW_THRESHOLD, got {got!r}")
+
+# 2.8 — EXCEPTION (corrupt config — present-but-invalid JSON)
+print("  2.8  EXCEPTION — corrupt config")
+_backup_config_once()
+CONFIG.write_text("{this is not json")
+_clear_config_cache()
+sid = fresh_sid("h")
+jsonl = TEST_PROJECT / f"{sid}.jsonl"
+make_jsonl(jsonl, n_user=5, dur_min=5)
+rc, _, _ = run_hook({"session_id": sid, "transcript_path": str(jsonl), "cwd": str(TMPDIR)})
+got = find_outcome_for_sid(sid)
+# Implementation may classify corrupt config as EXCEPTION OR SKIPPED_NO_VAULT
+# (load_config catches JSON errors and returns defaults whose vault_path="").
+if got in ("EXCEPTION", "SKIPPED_NO_VAULT"):
+    pass_(f"corrupt config → {got}")
+else:
+    fail_(f"expected EXCEPTION or SKIPPED_NO_VAULT, got {got!r}")
+# Restore from backup
+shutil.copy2(CONFIG_BAK, CONFIG)
+_clear_config_cache()
+
+# 2.9 — OK / OK_RAW_NOTE_ONLY (real success path with synthetic JSONL)
+print("  2.9  OK / OK_RAW_NOTE_ONLY — real success path against TEST vault")
+_backup_config_once()
+test_vault = TMPDIR / "test-vault"
+(test_vault / "claude-sessions").mkdir(parents=True)
+(test_vault / "claude-insights").mkdir(parents=True)
+cfg = json.loads(CONFIG.read_text())
+real_vault = cfg.get("vault_path")
+cfg["vault_path"] = str(test_vault)
+CONFIG.write_text(json.dumps(cfg, indent=2))
+_clear_config_cache()
+sid = fresh_sid("i")
+jsonl = TEST_PROJECT / f"{sid}.jsonl"
+make_jsonl(jsonl, n_user=10, dur_min=20)
+rc, _, _ = run_hook({"session_id": sid, "transcript_path": str(jsonl), "cwd": str(TMPDIR)})
+got = find_outcome_for_sid(sid)
+if got and got.startswith("OK"):
+    notes_written = list((test_vault / "claude-sessions").glob("*.md"))
+    if notes_written:
+        pass_(f"success path → {got} + {len(notes_written)} note(s) written to test vault")
+    else:
+        fail_(f"outcome={got} but no note in test vault — write may have failed silently")
+else:
+    fail_(f"expected OK*, got {got!r}")
+cfg["vault_path"] = real_vault
+CONFIG.write_text(json.dumps(cfg, indent=2))
+_clear_config_cache()
+
+# 2.10 — WRITE_FAILED (test vault chmod 0500)
+print("  2.10 WRITE_FAILED — test vault read-only")
+_backup_config_once()
+ro_vault = TMPDIR / "ro-vault"
+(ro_vault / "claude-sessions").mkdir(parents=True)
+(ro_vault / "claude-insights").mkdir(parents=True)
+cfg = json.loads(CONFIG.read_text())
+cfg["vault_path"] = str(ro_vault)
+CONFIG.write_text(json.dumps(cfg, indent=2))
+_clear_config_cache()
+os.chmod(ro_vault / "claude-sessions", 0o500)
+sid = fresh_sid("j")
+jsonl = TEST_PROJECT / f"{sid}.jsonl"
+make_jsonl(jsonl, n_user=10, dur_min=20)
+rc, _, _ = run_hook({"session_id": sid, "transcript_path": str(jsonl), "cwd": str(TMPDIR)})
+got = find_outcome_for_sid(sid)
+if got == "WRITE_FAILED":
+    pass_(f"read-only vault → {got}")
+else:
+    fail_(f"expected WRITE_FAILED, got {got!r}")
+os.chmod(ro_vault / "claude-sessions", 0o700)  # so cleanup can rm it
+cfg["vault_path"] = real_vault
+CONFIG.write_text(json.dumps(cfg, indent=2))
+_clear_config_cache()
+
+# ─── Phase 4 — log integrity ─────────────────────────────────────────────
+
+print()
+print("Phase 4 — log integrity")
+print()
+
+# 4.1 — every SessionEnd line has outcome=, sid=, project=
+print("  4.1  every SessionEnd line has outcome= sid= project=")
+missing_field = []
+for ln, line in enumerate(HOOK_LOG.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+    if "SessionEnd" not in line:
+        continue
+    for required in ("outcome=", "sid=", "project="):
+        if required not in line:
+            missing_field.append((ln, required, line[:200]))
+            break
+if not missing_field:
+    pass_("all SessionEnd lines have required fields")
+else:
+    fail_(f"{len(missing_field)} SessionEnd line(s) missing required field; first: {missing_field[0]}")
+
+# 4.2 — SessionStart entries unaffected
+print("  4.2  SessionStart entries still emitting")
+ss_count = sum(1 for line in HOOK_LOG.read_text(encoding="utf-8", errors="replace").splitlines()
+               if "SessionStart" in line)
+if ss_count > 0:
+    pass_(f"{ss_count} SessionStart line(s) present (regression guard)")
+else:
+    fail_("no SessionStart lines in hook log — telemetry may have broken existing logger")
+
+# 4.3 — rotation cap (100 KB) preserved structure
+print("  4.3  log size within rotation cap")
+log_bytes = HOOK_LOG.stat().st_size
+if log_bytes <= 100 * 1024 + 4096:  # 100 KB + a small grace for the latest line
+    pass_(f"log is {log_bytes} bytes (under 100 KB rotation cap)")
+else:
+    rotated = HOOK_LOG.with_suffix(".log.1")
+    if rotated.exists():
+        pass_(f"log is {log_bytes} bytes but rotated .log.1 exists")
+    else:
+        fail_(f"log is {log_bytes} bytes and no .log.1 — rotation broken")
+
+# ─── Summary ─────────────────────────────────────────────────────────────
+
+print()
+print("═══════════════════════════════════════════════════════════════")
+print(f"PASS={PASS}  FAIL={FAIL}")
+print("═══════════════════════════════════════════════════════════════")
+print()
+print("Cleanup will run via atexit:")
+print(f"  - restore real config from {CONFIG_BAK.name}")
+print(f"  - rm -rf {TEST_PROJECT}")
+print(f"  - rm -rf {TMPDIR}")
+print()
+print("Live-CC steps NOT covered (run separately, see Phase 3 in the dev-test plan):")
+print("  - real OK in a fresh CC session that produces a vault note")
+print("  - WRITE_FAILED on the REAL vault dir (chmod 0500 ~/obsidian/.../claude-sessions/)")
+print()
+sys.exit(0 if FAIL == 0 else 1)

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -112,3 +112,74 @@ class TestAppendSessionEndLog:
         assert "outcome=EXCEPTION" in content
         assert "msgs=0" in content
         assert "dur=0.0" in content
+
+
+# ---------------------------------------------------------------------------
+# Outcome wrapping — subprocess-driven (drives the real hook entry point)
+# ---------------------------------------------------------------------------
+
+
+def _read_log_lines(tmp_path):
+    """Helper: return the SessionEnd lines from the hook log, or [] if missing."""
+    log_path = tmp_path / ".claude" / "obsidian-brain-hook.log"
+    if not log_path.exists():
+        return []
+    return [
+        ln for ln in log_path.read_text(encoding="utf-8").splitlines()
+        if ln.strip() and "SessionEnd" in ln
+    ]
+
+
+def _run_session_end(tmp_path, payload):
+    """Spawn the SessionEnd hook with HOME redirected to tmp_path."""
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    return subprocess.run(
+        [sys.executable, _hook_script_path()],
+        input=json.dumps(payload) if payload is not None else "",
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+class TestInvalidInputOutcomes:
+    def test_empty_stdin_logs_skipped_invalid_input(self, tmp_path):
+        result = _run_session_end(tmp_path, payload=None)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1, f"expected one SessionEnd line, got {lines!r}"
+        assert "outcome=SKIPPED_INVALID_INPUT" in lines[0]
+
+    def test_missing_session_id_logs_skipped_invalid_input(self, tmp_path):
+        # cwd present, transcript_path present (inside projects dir), no session_id
+        projects_dir = tmp_path / ".claude" / "projects" / "-myproj"
+        projects_dir.mkdir(parents=True, exist_ok=True)
+        fake_transcript = projects_dir / "fake.jsonl"
+        fake_transcript.write_text("{}\n", encoding="utf-8")
+        payload = {
+            "cwd": str(tmp_path),
+            "transcript_path": str(fake_transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1
+        assert "outcome=SKIPPED_INVALID_INPUT" in lines[0]
+
+    def test_transcript_outside_projects_logs_outside_projects_outcome(self, tmp_path):
+        # transcript_path that does NOT live under ~/.claude/projects
+        bogus_transcript = tmp_path / "evil" / "transcript.jsonl"
+        bogus_transcript.parent.mkdir(parents=True, exist_ok=True)
+        bogus_transcript.write_text("{}\n", encoding="utf-8")
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-outside-1234",
+            "transcript_path": str(bogus_transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1, f"expected one SessionEnd line, got {lines!r}"
+        assert "outcome=SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS" in lines[0]

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -1,0 +1,114 @@
+"""Tests for SessionEnd telemetry: _append_sessionend_log helper + _Outcome enum wraps."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make hooks/ importable for in-process tests.
+_HOOKS_DIR = str(Path(__file__).parent.parent / "hooks")
+if _HOOKS_DIR not in sys.path:
+    sys.path.insert(0, _HOOKS_DIR)
+
+
+def _hook_script_path() -> str:
+    return str(Path(__file__).parent.parent / "hooks" / "obsidian_session_log.py")
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestAppendSessionEndLog:
+    @pytest.fixture(autouse=True)
+    def _restore_obsidian_utils(self):
+        """Reload obsidian_utils after each test to undo HOME-monkeypatched module constants."""
+        yield
+        import importlib
+        import obsidian_utils
+        importlib.reload(obsidian_utils)
+
+    def test_appends_one_line_with_expected_fields(self, tmp_path, monkeypatch):
+        """Helper appends exactly one line with timestamp, event tag, project, sid, outcome, msgs, dur, detail."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Re-import obsidian_utils so the HOME-derived log path is picked up if cached.
+        import importlib
+        import obsidian_utils
+        importlib.reload(obsidian_utils)
+
+        obsidian_utils._append_sessionend_log(
+            project="myproj",
+            session_id="sid-deadbeef-1234",
+            outcome="OK_RAW_NOTE_ONLY",
+            msgs=42,
+            dur_min=12.5,
+            detail="",
+        )
+
+        log_path = tmp_path / ".claude" / "obsidian-brain-hook.log"
+        assert log_path.exists(), "telemetry log file was not created"
+        content = log_path.read_text(encoding="utf-8")
+        lines = [ln for ln in content.splitlines() if ln.strip()]
+        assert len(lines) == 1, f"expected 1 line, got {len(lines)}: {content!r}"
+
+        line = lines[0]
+        # Format: "<UTC ISO8601> SessionEnd project=<p> sid=<s8> outcome=<O> msgs=<N> dur=<F> detail=<str>"
+        assert "SessionEnd" in line
+        assert "project=myproj" in line
+        # sid is short-form (8 chars)
+        assert "sid=sid-dead" in line
+        assert "outcome=OK_RAW_NOTE_ONLY" in line
+        assert "msgs=42" in line
+        # dur is formatted with one decimal
+        assert "dur=12.5" in line
+        # detail field is present even when empty
+        assert "detail=" in line
+
+    def test_rotates_when_log_exceeds_cap(self, tmp_path, monkeypatch):
+        """When log exceeds 100KB, helper rotates to .1 and starts a new file."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        import importlib
+        import obsidian_utils
+        importlib.reload(obsidian_utils)
+
+        log_dir = tmp_path / ".claude"
+        log_dir.mkdir()
+        log_path = log_dir / "obsidian-brain-hook.log"
+        # Pre-fill the log past the rotation threshold.
+        log_path.write_text("x" * (150 * 1024), encoding="utf-8")
+
+        obsidian_utils._append_sessionend_log(
+            project="rot", session_id="sid-rotate-aa", outcome="OK_RAW_NOTE_ONLY"
+        )
+
+        rotated = log_dir / "obsidian-brain-hook.log.1"
+        assert rotated.exists(), "rotated file was not created"
+        # New log file contains only the one fresh line.
+        new_content = log_path.read_text(encoding="utf-8")
+        new_lines = [ln for ln in new_content.splitlines() if ln.strip()]
+        assert len(new_lines) == 1, f"new log should have only the single fresh line, got: {new_content!r}"
+        assert "outcome=OK_RAW_NOTE_ONLY" in new_lines[0]
+
+    def test_handles_missing_fields_with_defaults(self, tmp_path, monkeypatch):
+        """Helper accepts only the required args (project, session_id, outcome) and uses safe defaults."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        import importlib
+        import obsidian_utils
+        importlib.reload(obsidian_utils)
+
+        obsidian_utils._append_sessionend_log(
+            project="", session_id="", outcome="EXCEPTION"
+        )
+
+        log_path = tmp_path / ".claude" / "obsidian-brain-hook.log"
+        content = log_path.read_text(encoding="utf-8")
+        # Empty project becomes "unknown"; empty sid becomes "unknown"[:8]
+        assert "project=unknown" in content
+        assert "sid=unknown" in content
+        assert "outcome=EXCEPTION" in content
+        assert "msgs=0" in content
+        assert "dur=0.0" in content

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -370,3 +370,41 @@ class TestWriteFailedOutcome:
         finally:
             # Restore permissions so pytest's tmp_path cleanup can rm it.
             os.chmod(sessions, 0o700)
+
+
+class TestSuccessOutcome:
+    def test_successful_write_logs_ok_raw_note_only(self, tmp_path):
+        """A normal above-threshold session that writes a vault note logs OK_RAW_NOTE_ONLY."""
+        cc_slug = "-myproj"
+        proj = tmp_path / ".claude" / "projects" / cc_slug
+        proj.mkdir(parents=True)
+        transcript = proj / "sid-success-1234.jsonl"
+        _make_jsonl(transcript, n_user_msgs=10, duration_sec=600)
+
+        vault = tmp_path / "vault"
+        (vault / "claude-sessions").mkdir(parents=True)
+
+        cfg = {
+            "vault_path": str(vault),
+            "sessions_folder": "claude-sessions",
+            "auto_log_enabled": True,
+            "min_messages": 3,
+            "min_duration_minutes": 2,
+        }
+        cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-success-1234",
+            "transcript_path": str(transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1, f"expected one line, got {lines!r}"
+        assert "outcome=OK_RAW_NOTE_ONLY" in lines[0]
+        assert "msgs=10" in lines[0]
+        # A vault note was actually written:
+        notes = list((vault / "claude-sessions").glob("*.md"))
+        assert len(notes) == 1, f"expected one vault note, got {[n.name for n in notes]}"

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -326,3 +326,47 @@ class TestThresholdOutcomes:
         assert len(lines) == 1
         assert "outcome=SKIPPED_BELOW_THRESHOLD" in lines[0]
         assert "msgs=5" in lines[0]
+
+
+class TestWriteFailedOutcome:
+    def test_write_failure_logs_write_failed(self, tmp_path):
+        """When the vault sessions folder is unwritable, _run logs WRITE_FAILED."""
+        # Set up a valid above-threshold session
+        cc_slug = "-myproj"
+        proj = tmp_path / ".claude" / "projects" / cc_slug
+        proj.mkdir(parents=True)
+        transcript = proj / "sid-writefail-12.jsonl"
+        TestThresholdOutcomes._make_jsonl(transcript, n_user_msgs=10, duration_sec=600)
+
+        # Vault path points at a directory we can read but cannot write to.
+        vault = tmp_path / "vault"
+        vault.mkdir()
+        sessions = vault / "claude-sessions"
+        sessions.mkdir()
+        # Make the sessions folder read-only so write_vault_note() fails.
+        os.chmod(sessions, 0o500)
+
+        cfg = {
+            "vault_path": str(vault),
+            "sessions_folder": "claude-sessions",
+            "auto_log_enabled": True,
+            "min_messages": 3,
+            "min_duration_minutes": 2,
+        }
+        cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-writefail-12",
+            "transcript_path": str(transcript),
+        }
+        try:
+            result = _run_session_end(tmp_path, payload=payload)
+            assert result.returncode == 0
+            lines = _read_log_lines(tmp_path)
+            assert len(lines) == 1, f"expected one line, got {lines!r}"
+            assert "outcome=WRITE_FAILED" in lines[0]
+        finally:
+            # Restore permissions so pytest's tmp_path cleanup can rm it.
+            os.chmod(sessions, 0o700)

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -408,3 +408,38 @@ class TestSuccessOutcome:
         # A vault note was actually written:
         notes = list((vault / "claude-sessions").glob("*.md"))
         assert len(notes) == 1, f"expected one vault note, got {[n.name for n in notes]}"
+
+
+class TestExceptionOutcome:
+    def test_unexpected_exception_logs_exception(self, tmp_path, monkeypatch):
+        """If _run() raises, main() catches and logs EXCEPTION before exit 0."""
+        # Trigger an exception by passing a transcript_path that resolves under
+        # ~/.claude/projects but causes load_config() to blow up. Easiest path:
+        # write a config file with invalid JSON.
+        cc_slug = "-myproj"
+        proj = tmp_path / ".claude" / "projects" / cc_slug
+        proj.mkdir(parents=True)
+        transcript = proj / "sid-except-12345.jsonl"
+        _make_jsonl(transcript, n_user_msgs=10, duration_sec=600)
+
+        # Corrupt config so load_config() raises a JSONDecodeError that bubbles up.
+        cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
+        cfg_path.write_text("{not-valid-json", encoding="utf-8")
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-except-12345",
+            "transcript_path": str(transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        # Exactly one EXCEPTION line — _run can also log SKIPPED_NO_VAULT etc.
+        # depending on how load_config swallows errors. Allow either as long as
+        # SOMETHING is logged so a future maintainer can see what went wrong.
+        assert len(lines) >= 1, f"expected at least one telemetry line, got {lines!r}"
+        # Must contain either EXCEPTION (raised) or SKIPPED_NO_VAULT (load_config swallowed).
+        assert any(
+            "outcome=EXCEPTION" in ln or "outcome=SKIPPED_NO_VAULT" in ln
+            for ln in lines
+        ), f"expected EXCEPTION or SKIPPED_NO_VAULT in {lines!r}"

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -183,3 +183,83 @@ class TestInvalidInputOutcomes:
         lines = _read_log_lines(tmp_path)
         assert len(lines) == 1, f"expected one SessionEnd line, got {lines!r}"
         assert "outcome=SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS" in lines[0]
+
+
+class TestConfigStateOutcomes:
+    @staticmethod
+    def _projects_dir(tmp_path, project_slug):
+        """Create a fake CC projects dir for a given project so transcript_path passes validation."""
+        # Claude Code's path-encoded slug: leading dash, underscores->hyphens
+        cc_slug = "-" + project_slug.replace("_", "-")
+        d = tmp_path / ".claude" / "projects" / cc_slug
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    @staticmethod
+    def _write_config(tmp_path, **overrides):
+        cfg = {
+            "vault_path": str(tmp_path / "vault"),
+            "sessions_folder": "claude-sessions",
+            "auto_log_enabled": True,
+            "min_messages": 3,
+            "min_duration_minutes": 2,
+        }
+        cfg.update(overrides)
+        cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+        # Make sure the vault exists if vault_path is set so write attempts don't fail elsewhere.
+        if cfg.get("vault_path"):
+            (Path(cfg["vault_path"]) / cfg["sessions_folder"]).mkdir(parents=True, exist_ok=True)
+        return cfg_path
+
+    def test_auto_log_disabled_logs_skipped_auto_log_off(self, tmp_path):
+        proj = self._projects_dir(tmp_path, "myproj")
+        transcript = proj / "sid-auto-off-12345.jsonl"
+        transcript.write_text("{}\n", encoding="utf-8")
+        self._write_config(tmp_path, auto_log_enabled=False)
+
+        payload = {
+            "cwd": str(tmp_path),  # cwd's basename derives the project slug
+            "session_id": "sid-auto-off-12345",
+            "transcript_path": str(transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1
+        assert "outcome=SKIPPED_AUTO_LOG_OFF" in lines[0]
+
+    def test_no_vault_path_logs_skipped_no_vault(self, tmp_path):
+        proj = self._projects_dir(tmp_path, "myproj")
+        transcript = proj / "sid-no-vault-12345.jsonl"
+        transcript.write_text("{}\n", encoding="utf-8")
+        self._write_config(tmp_path, vault_path="")
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-no-vault-12345",
+            "transcript_path": str(transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1
+        assert "outcome=SKIPPED_NO_VAULT" in lines[0]
+
+    def test_empty_transcript_logs_skipped_no_transcript(self, tmp_path):
+        proj = self._projects_dir(tmp_path, "myproj")
+        transcript = proj / "sid-empty-12345678.jsonl"
+        transcript.write_text("", encoding="utf-8")  # truly empty
+        self._write_config(tmp_path)
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-empty-12345678",
+            "transcript_path": str(transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1
+        assert "outcome=SKIPPED_NO_TRANSCRIPT" in lines[0]

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -143,6 +143,33 @@ def _run_session_end(tmp_path, payload):
     )
 
 
+def _projects_dir(tmp_path, project_slug):
+    """Create a fake CC projects dir for a given project so transcript_path passes validation."""
+    # Claude Code's path-encoded slug: leading dash, underscores->hyphens
+    cc_slug = "-" + project_slug.replace("_", "-")
+    d = tmp_path / ".claude" / "projects" / cc_slug
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_config(tmp_path, **overrides):
+    cfg = {
+        "vault_path": str(tmp_path / "vault"),
+        "sessions_folder": "claude-sessions",
+        "auto_log_enabled": True,
+        "min_messages": 3,
+        "min_duration_minutes": 2,
+    }
+    cfg.update(overrides)
+    cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+    # Make sure the vault exists if vault_path is set so write attempts don't fail elsewhere.
+    if cfg.get("vault_path"):
+        (Path(cfg["vault_path"]) / cfg["sessions_folder"]).mkdir(parents=True, exist_ok=True)
+    return cfg_path
+
+
 class TestInvalidInputOutcomes:
     def test_empty_stdin_logs_skipped_invalid_input(self, tmp_path):
         result = _run_session_end(tmp_path, payload=None)
@@ -186,38 +213,11 @@ class TestInvalidInputOutcomes:
 
 
 class TestConfigStateOutcomes:
-    @staticmethod
-    def _projects_dir(tmp_path, project_slug):
-        """Create a fake CC projects dir for a given project so transcript_path passes validation."""
-        # Claude Code's path-encoded slug: leading dash, underscores->hyphens
-        cc_slug = "-" + project_slug.replace("_", "-")
-        d = tmp_path / ".claude" / "projects" / cc_slug
-        d.mkdir(parents=True, exist_ok=True)
-        return d
-
-    @staticmethod
-    def _write_config(tmp_path, **overrides):
-        cfg = {
-            "vault_path": str(tmp_path / "vault"),
-            "sessions_folder": "claude-sessions",
-            "auto_log_enabled": True,
-            "min_messages": 3,
-            "min_duration_minutes": 2,
-        }
-        cfg.update(overrides)
-        cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
-        cfg_path.parent.mkdir(parents=True, exist_ok=True)
-        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
-        # Make sure the vault exists if vault_path is set so write attempts don't fail elsewhere.
-        if cfg.get("vault_path"):
-            (Path(cfg["vault_path"]) / cfg["sessions_folder"]).mkdir(parents=True, exist_ok=True)
-        return cfg_path
-
     def test_auto_log_disabled_logs_skipped_auto_log_off(self, tmp_path):
-        proj = self._projects_dir(tmp_path, "myproj")
+        proj = _projects_dir(tmp_path, "myproj")
         transcript = proj / "sid-auto-off-12345.jsonl"
         transcript.write_text("{}\n", encoding="utf-8")
-        self._write_config(tmp_path, auto_log_enabled=False)
+        _write_config(tmp_path, auto_log_enabled=False)
 
         payload = {
             "cwd": str(tmp_path),  # cwd's basename derives the project slug
@@ -231,10 +231,10 @@ class TestConfigStateOutcomes:
         assert "outcome=SKIPPED_AUTO_LOG_OFF" in lines[0]
 
     def test_no_vault_path_logs_skipped_no_vault(self, tmp_path):
-        proj = self._projects_dir(tmp_path, "myproj")
+        proj = _projects_dir(tmp_path, "myproj")
         transcript = proj / "sid-no-vault-12345.jsonl"
         transcript.write_text("{}\n", encoding="utf-8")
-        self._write_config(tmp_path, vault_path="")
+        _write_config(tmp_path, vault_path="")
 
         payload = {
             "cwd": str(tmp_path),
@@ -248,10 +248,10 @@ class TestConfigStateOutcomes:
         assert "outcome=SKIPPED_NO_VAULT" in lines[0]
 
     def test_empty_transcript_logs_skipped_no_transcript(self, tmp_path):
-        proj = self._projects_dir(tmp_path, "myproj")
+        proj = _projects_dir(tmp_path, "myproj")
         transcript = proj / "sid-empty-12345678.jsonl"
         transcript.write_text("", encoding="utf-8")  # truly empty
-        self._write_config(tmp_path)
+        _write_config(tmp_path)
 
         payload = {
             "cwd": str(tmp_path),

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -443,3 +443,36 @@ class TestExceptionOutcome:
             "outcome=EXCEPTION" in ln or "outcome=SKIPPED_NO_VAULT" in ln
             for ln in lines
         ), f"expected EXCEPTION or SKIPPED_NO_VAULT in {lines!r}"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper edge-cases (improve line coverage)
+# ---------------------------------------------------------------------------
+
+
+class TestProjectSlugForLog:
+    """_project_slug_for_log: empty cwd → 'unknown' (line 73 coverage)."""
+
+    def test_empty_cwd_returns_unknown(self):
+        from obsidian_session_log import _project_slug_for_log
+        assert _project_slug_for_log("") == "unknown"
+
+    def test_nonempty_cwd_returns_slug(self):
+        from obsidian_session_log import _project_slug_for_log
+        assert _project_slug_for_log("/home/user/myproject") == "myproject"
+
+
+class TestCleanupSessionCacheException:
+    """_cleanup_session_cache: exception branch (lines 90-91 coverage)."""
+
+    def test_exception_in_unlink_is_swallowed(self, tmp_path, monkeypatch):
+        """If os.unlink raises, _cleanup_session_cache must not propagate."""
+        import obsidian_session_log
+
+        # Monkeypatch os.path.exists to return True (so unlink is attempted)
+        # and os.unlink to raise an OSError.
+        monkeypatch.setattr("obsidian_session_log.os.path.exists", lambda p: True)
+        monkeypatch.setattr("obsidian_session_log.os.unlink", lambda p: (_ for _ in ()).throw(OSError("simulated")))
+
+        # Must not raise, and must exit cleanly.
+        obsidian_session_log._cleanup_session_cache("any-session-id")

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -113,6 +113,28 @@ class TestAppendSessionEndLog:
         assert "msgs=0" in content
         assert "dur=0.0" in content
 
+    def test_sanitizes_carriage_returns_and_tabs(self, tmp_path, monkeypatch):
+        """Project/outcome/sid/detail with \\r or \\t produce a single line, not a corrupted multi-line entry."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        import importlib
+        import obsidian_utils
+        importlib.reload(obsidian_utils)
+
+        obsidian_utils._append_sessionend_log(
+            project="my\rproj\twith\nbad",
+            session_id="sid\rbad\t12",
+            outcome="OK\rBAD",
+            detail="multi\rline\twith\nstuff",
+        )
+
+        log_path = tmp_path / ".claude" / "obsidian-brain-hook.log"
+        content = log_path.read_text(encoding="utf-8")
+        # Exactly one logical line (one \n at end)
+        assert content.count("\n") == 1, f"expected 1 line, got: {content!r}"
+        # No \r or \t survived
+        assert "\r" not in content
+        assert "\t" not in content
+
 
 # ---------------------------------------------------------------------------
 # Outcome wrapping — subprocess-driven (drives the real hook entry point)
@@ -578,6 +600,56 @@ class TestExceptionOutcome:
             ), f"expected EXCEPTION or SKIPPED_NO_TRANSCRIPT in {lines!r}"
         finally:
             os.chmod(transcript, 0o600)  # let pytest cleanup work
+
+    @pytest.mark.skipif(os.getuid() == 0, reason="root bypasses chmod restrictions")
+    def test_exception_carries_real_project_and_sid(self, tmp_path):
+        """When _run() raises after parsing hook_input, main()'s EXCEPTION log carries
+        the real project/sid (not 'unknown') because _LAST_PROJECT/_LAST_SESSION_ID
+        are updated as soon as hook_input is parsed."""
+        cc_slug = "-realproj"
+        proj = tmp_path / ".claude" / "projects" / cc_slug
+        proj.mkdir(parents=True)
+        sid = "sid-real-12345"
+        transcript = proj / f"{sid}.jsonl"
+        _make_jsonl(transcript, n_user_msgs=10, duration_sec=600)
+        os.chmod(transcript, 0o000)  # force read_transcript to raise
+
+        vault = tmp_path / "vault"
+        (vault / "claude-sessions").mkdir(parents=True)
+        cfg = {
+            "vault_path": str(vault),
+            "sessions_folder": "claude-sessions",
+            "auto_log_enabled": True,
+            "min_messages": 3,
+            "min_duration_minutes": 2,
+        }
+        cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+
+        payload = {
+            "cwd": str(tmp_path),  # cwd basename = tmp dir name
+            "session_id": sid,
+            "transcript_path": str(transcript),
+        }
+        try:
+            result = _run_session_end(tmp_path, payload=payload)
+            assert result.returncode == 0
+            lines = _read_log_lines(tmp_path)
+            # Find the EXCEPTION line (might also have other lines if the hook
+            # took a non-exception path; the EXCEPTION wrap is what we're testing)
+            exc_lines = [ln for ln in lines if "outcome=EXCEPTION" in ln]
+            if exc_lines:
+                # If exception path fired, sid and project must NOT be "unknown"
+                assert "sid=sid-real" in exc_lines[0], (
+                    f"EXCEPTION line should carry real sid, got: {exc_lines[0]!r}"
+                )
+                assert "project=unknown" not in exc_lines[0], (
+                    f"EXCEPTION line should carry real project, got: {exc_lines[0]!r}"
+                )
+            # If the exception path didn't fire (read_transcript swallowed the error),
+            # SKIPPED_NO_TRANSCRIPT will be present — that is the existing test's job.
+        finally:
+            os.chmod(transcript, 0o600)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -263,3 +263,66 @@ class TestConfigStateOutcomes:
         lines = _read_log_lines(tmp_path)
         assert len(lines) == 1
         assert "outcome=SKIPPED_NO_TRANSCRIPT" in lines[0]
+
+
+class TestThresholdOutcomes:
+    @staticmethod
+    def _make_jsonl(path, n_user_msgs, duration_sec):
+        """Create a minimal JSONL with N user messages spanning duration_sec seconds."""
+        import datetime as _dt
+        start = _dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=_dt.timezone.utc)
+        entries = []
+        for i in range(n_user_msgs):
+            ts = start + _dt.timedelta(seconds=i * (duration_sec / max(n_user_msgs, 1)))
+            entries.append({
+                "type": "user",
+                "timestamp": ts.isoformat().replace("+00:00", "Z"),
+                "message": {"role": "user", "content": f"msg {i}"},
+            })
+        # Final assistant message at the end so duration metadata reflects duration_sec.
+        end = start + _dt.timedelta(seconds=duration_sec)
+        entries.append({
+            "type": "assistant",
+            "timestamp": end.isoformat().replace("+00:00", "Z"),
+            "message": {"role": "assistant", "content": "ok"},
+        })
+        path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+    def test_too_few_messages_logs_skipped_below_threshold(self, tmp_path):
+        # min_messages=3 in config; provide only 2 user messages
+        proj = _projects_dir(tmp_path, "myproj")
+        transcript = proj / "sid-fewmsg-12345.jsonl"
+        self._make_jsonl(transcript, n_user_msgs=2, duration_sec=600)
+        _write_config(tmp_path)
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-fewmsg-12345",
+            "transcript_path": str(transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1
+        assert "outcome=SKIPPED_BELOW_THRESHOLD" in lines[0]
+        # Should record actual msg count for diagnosis
+        assert "msgs=2" in lines[0]
+
+    def test_below_duration_logs_skipped_below_threshold(self, tmp_path):
+        # min_duration_minutes=2 in config; provide 5 messages over 10 seconds
+        proj = _projects_dir(tmp_path, "myproj")
+        transcript = proj / "sid-shortdur-1234.jsonl"
+        self._make_jsonl(transcript, n_user_msgs=5, duration_sec=10)
+        _write_config(tmp_path)
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-shortdur-1234",
+            "transcript_path": str(transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1
+        assert "outcome=SKIPPED_BELOW_THRESHOLD" in lines[0]
+        assert "msgs=5" in lines[0]

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -216,6 +216,20 @@ class TestInvalidInputOutcomes:
         assert len(lines) == 1
         assert "outcome=SKIPPED_INVALID_INPUT" in lines[0]
 
+    def test_missing_transcript_path_logs_skipped_invalid_input(self, tmp_path):
+        """session_id present but transcript_path missing: SKIPPED_INVALID_INPUT with detail='missing transcript_path'."""
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-no-tp-1234",
+            # transcript_path absent
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1
+        assert "outcome=SKIPPED_INVALID_INPUT" in lines[0]
+        assert "detail=missing transcript_path" in lines[0]
+
     def test_transcript_outside_projects_logs_outside_projects_outcome(self, tmp_path):
         # transcript_path that does NOT live under ~/.claude/projects
         bogus_transcript = tmp_path / "evil" / "transcript.jsonl"
@@ -329,6 +343,7 @@ class TestThresholdOutcomes:
 
 
 class TestWriteFailedOutcome:
+    @pytest.mark.skipif(os.getuid() == 0, reason="root bypasses chmod restrictions")
     def test_write_failure_logs_write_failed(self, tmp_path):
         """When the vault sessions folder is unwritable, _run logs WRITE_FAILED."""
         # Set up a valid above-threshold session
@@ -343,8 +358,6 @@ class TestWriteFailedOutcome:
         vault.mkdir()
         sessions = vault / "claude-sessions"
         sessions.mkdir()
-        # Make the sessions folder read-only so write_vault_note() fails.
-        os.chmod(sessions, 0o500)
 
         cfg = {
             "vault_path": str(vault),
@@ -362,17 +375,102 @@ class TestWriteFailedOutcome:
             "transcript_path": str(transcript),
         }
         try:
+            # Make the sessions folder read-only INSIDE try so restore always runs.
+            os.chmod(sessions, 0o500)
             result = _run_session_end(tmp_path, payload=payload)
             assert result.returncode == 0
             lines = _read_log_lines(tmp_path)
             assert len(lines) == 1, f"expected one line, got {lines!r}"
             assert "outcome=WRITE_FAILED" in lines[0]
+            # Verify detail= is the LAST field — vault paths with spaces (common
+            # on macOS) would fragment earlier fields if this ordering broke.
+            assert "detail=" in lines[0]
+            assert lines[0].rfind("detail=") > lines[0].rfind("dur=")
         finally:
             # Restore permissions so pytest's tmp_path cleanup can rm it.
             os.chmod(sessions, 0o700)
 
 
 class TestSuccessOutcome:
+    def test_snapshot_bypass_logs_ok_with_snapshot_bypass_detail(self, tmp_path):
+        """Below-threshold session with existing snapshot writes OK_RAW_NOTE_ONLY + detail=snapshot-bypass.
+
+        The hook derives early_project = slugify(Path(cwd).name). The snapshot
+        filename glob is {date}-{slug}-*-snapshot*.md and frontmatter must have
+        matching session_id + project. We construct the fixture dynamically so
+        it survives pytest's generated tmp_path names.
+        """
+        import datetime as _dt
+        import sys as _sys
+        _sys.path.insert(0, str(Path(__file__).parent.parent / "hooks"))
+        from obsidian_utils import slugify as _slugify
+
+        # early_project is derived from cwd basename (tmp_path.name).
+        early_project = _slugify(tmp_path.name)
+        cc_slug = f"-{tmp_path.name.replace('_', '-')}"
+        proj = tmp_path / ".claude" / "projects" / cc_slug
+        proj.mkdir(parents=True)
+        sid = "sid-bypass-12345"
+        transcript = proj / f"{sid}.jsonl"
+        # 2 user messages, 5 minutes — below msg threshold (3) but above duration (2).
+        # The message-count check fires first; snapshot presence bypasses it.
+        _make_jsonl(transcript, n_user_msgs=2, duration_sec=300)
+
+        vault = tmp_path / "vault"
+        sessions_dir = vault / "claude-sessions"
+        sessions_dir.mkdir(parents=True)
+
+        # Build snapshot file matching the glob {date}-{slug}-*-snapshot*.md.
+        today = _dt.date.today().isoformat()
+        snapshot_name = f"{today}-{early_project}-bypass-snapshot-120000.md"
+        snapshot_path = sessions_dir / snapshot_name
+        snapshot_path.write_text(
+            "---\n"
+            "type: claude-snapshot\n"
+            f"date: {today}\n"
+            f"session_id: {sid}\n"
+            f"project: {early_project}\n"
+            "---\n\n"
+            "# Snapshot\n\nbody\n",
+            encoding="utf-8",
+        )
+
+        cfg = {
+            "vault_path": str(vault),
+            "sessions_folder": "claude-sessions",
+            "auto_log_enabled": True,
+            "min_messages": 3,
+            "min_duration_minutes": 2,
+        }
+        cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": sid,
+            "transcript_path": str(transcript),
+        }
+        result = _run_session_end(tmp_path, payload=payload)
+        assert result.returncode == 0
+        lines = _read_log_lines(tmp_path)
+        assert len(lines) == 1, f"expected one line, got {lines!r}"
+        assert "outcome=OK_RAW_NOTE_ONLY" in lines[0], f"unexpected outcome in: {lines[0]!r}"
+        assert "detail=snapshot-bypass" in lines[0], (
+            f"expected snapshot-bypass detail, got: {lines[0]!r}"
+        )
+        # A vault note was written as anchor for the snapshot.
+        # Filter by frontmatter type — the session note has type: claude-session,
+        # the fixture snapshot has type: claude-snapshot.
+        all_notes = list(sessions_dir.glob("*.md"))
+        session_notes = [
+            n for n in all_notes
+            if "claude-session" in n.read_text(encoding="utf-8")
+        ]
+        assert len(session_notes) >= 1, (
+            f"expected at least one claude-session note; got files: "
+            f"{[n.name for n in all_notes]}"
+        )
+
     def test_successful_write_logs_ok_raw_note_only(self, tmp_path):
         """A normal above-threshold session that writes a vault note logs OK_RAW_NOTE_ONLY."""
         cc_slug = "-myproj"
@@ -411,38 +509,75 @@ class TestSuccessOutcome:
 
 
 class TestExceptionOutcome:
-    def test_unexpected_exception_logs_exception(self, tmp_path, monkeypatch):
-        """If _run() raises, main() catches and logs EXCEPTION before exit 0."""
-        # Trigger an exception by passing a transcript_path that resolves under
-        # ~/.claude/projects but causes load_config() to blow up. Easiest path:
-        # write a config file with invalid JSON.
+    def test_corrupt_config_logs_skipped_no_vault(self, tmp_path):
+        """Corrupt config JSON: load_config swallows JSONDecodeError and returns
+        empty defaults, so SessionEnd hits the SKIPPED_NO_VAULT path. Verifies
+        even a broken config produces structured telemetry, not a silent drop."""
         cc_slug = "-myproj"
         proj = tmp_path / ".claude" / "projects" / cc_slug
         proj.mkdir(parents=True)
-        transcript = proj / "sid-except-12345.jsonl"
+        transcript = proj / "sid-noconf-12345.jsonl"
         _make_jsonl(transcript, n_user_msgs=10, duration_sec=600)
 
-        # Corrupt config so load_config() raises a JSONDecodeError that bubbles up.
         cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
         cfg_path.write_text("{not-valid-json", encoding="utf-8")
 
         payload = {
             "cwd": str(tmp_path),
-            "session_id": "sid-except-12345",
+            "session_id": "sid-noconf-12345",
             "transcript_path": str(transcript),
         }
         result = _run_session_end(tmp_path, payload=payload)
         assert result.returncode == 0
         lines = _read_log_lines(tmp_path)
-        # Exactly one EXCEPTION line — _run can also log SKIPPED_NO_VAULT etc.
-        # depending on how load_config swallows errors. Allow either as long as
-        # SOMETHING is logged so a future maintainer can see what went wrong.
-        assert len(lines) >= 1, f"expected at least one telemetry line, got {lines!r}"
-        # Must contain either EXCEPTION (raised) or SKIPPED_NO_VAULT (load_config swallowed).
-        assert any(
-            "outcome=EXCEPTION" in ln or "outcome=SKIPPED_NO_VAULT" in ln
-            for ln in lines
-        ), f"expected EXCEPTION or SKIPPED_NO_VAULT in {lines!r}"
+        assert len(lines) == 1
+        assert "outcome=SKIPPED_NO_VAULT" in lines[0]
+
+    @pytest.mark.skipif(os.getuid() == 0, reason="root bypasses chmod restrictions")
+    def test_unreadable_transcript_logs_telemetry(self, tmp_path):
+        """A transcript file that exists at a valid path but is chmod 0o000
+        triggers an OSError in read_transcript. The outcome may be EXCEPTION
+        (if read_transcript propagates) or SKIPPED_NO_TRANSCRIPT (if it
+        swallows and returns []). Either way: structured telemetry, not a
+        silent drop."""
+        cc_slug = "-myproj"
+        proj = tmp_path / ".claude" / "projects" / cc_slug
+        proj.mkdir(parents=True)
+        transcript = proj / "sid-unreadable-12.jsonl"
+        _make_jsonl(transcript, n_user_msgs=10, duration_sec=600)
+
+        vault = tmp_path / "vault"
+        (vault / "claude-sessions").mkdir(parents=True)
+        cfg = {
+            "vault_path": str(vault),
+            "sessions_folder": "claude-sessions",
+            "auto_log_enabled": True,
+            "min_messages": 3,
+            "min_duration_minutes": 2,
+        }
+        cfg_path = tmp_path / ".claude" / "obsidian-brain-config.json"
+        cfg_path.write_text(json.dumps(cfg), encoding="utf-8")
+
+        payload = {
+            "cwd": str(tmp_path),
+            "session_id": "sid-unreadable-12",
+            "transcript_path": str(transcript),
+        }
+        try:
+            os.chmod(transcript, 0o000)
+            result = _run_session_end(tmp_path, payload=payload)
+            assert result.returncode == 0
+            lines = _read_log_lines(tmp_path)
+            assert len(lines) >= 1, f"expected telemetry, got {lines!r}"
+            # read_transcript may raise (PermissionError → EXCEPTION) or swallow
+            # and return [] (→ SKIPPED_NO_TRANSCRIPT). Both are valid: the goal
+            # is no silent drops.
+            assert any(
+                "outcome=EXCEPTION" in ln or "outcome=SKIPPED_NO_TRANSCRIPT" in ln
+                for ln in lines
+            ), f"expected EXCEPTION or SKIPPED_NO_TRANSCRIPT in {lines!r}"
+        finally:
+            os.chmod(transcript, 0o600)  # let pytest cleanup work
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -170,6 +170,28 @@ def _write_config(tmp_path, **overrides):
     return cfg_path
 
 
+def _make_jsonl(path, n_user_msgs, duration_sec):
+    """Create a minimal JSONL with N user messages spanning duration_sec seconds."""
+    import datetime as _dt
+    start = _dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=_dt.timezone.utc)
+    entries = []
+    for i in range(n_user_msgs):
+        ts = start + _dt.timedelta(seconds=i * (duration_sec / max(n_user_msgs, 1)))
+        entries.append({
+            "type": "user",
+            "timestamp": ts.isoformat().replace("+00:00", "Z"),
+            "message": {"role": "user", "content": f"msg {i}"},
+        })
+    # Final assistant message at the end so duration metadata reflects duration_sec.
+    end = start + _dt.timedelta(seconds=duration_sec)
+    entries.append({
+        "type": "assistant",
+        "timestamp": end.isoformat().replace("+00:00", "Z"),
+        "message": {"role": "assistant", "content": "ok"},
+    })
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+
+
 class TestInvalidInputOutcomes:
     def test_empty_stdin_logs_skipped_invalid_input(self, tmp_path):
         result = _run_session_end(tmp_path, payload=None)
@@ -266,33 +288,11 @@ class TestConfigStateOutcomes:
 
 
 class TestThresholdOutcomes:
-    @staticmethod
-    def _make_jsonl(path, n_user_msgs, duration_sec):
-        """Create a minimal JSONL with N user messages spanning duration_sec seconds."""
-        import datetime as _dt
-        start = _dt.datetime(2026, 1, 1, 0, 0, 0, tzinfo=_dt.timezone.utc)
-        entries = []
-        for i in range(n_user_msgs):
-            ts = start + _dt.timedelta(seconds=i * (duration_sec / max(n_user_msgs, 1)))
-            entries.append({
-                "type": "user",
-                "timestamp": ts.isoformat().replace("+00:00", "Z"),
-                "message": {"role": "user", "content": f"msg {i}"},
-            })
-        # Final assistant message at the end so duration metadata reflects duration_sec.
-        end = start + _dt.timedelta(seconds=duration_sec)
-        entries.append({
-            "type": "assistant",
-            "timestamp": end.isoformat().replace("+00:00", "Z"),
-            "message": {"role": "assistant", "content": "ok"},
-        })
-        path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
-
     def test_too_few_messages_logs_skipped_below_threshold(self, tmp_path):
         # min_messages=3 in config; provide only 2 user messages
         proj = _projects_dir(tmp_path, "myproj")
         transcript = proj / "sid-fewmsg-12345.jsonl"
-        self._make_jsonl(transcript, n_user_msgs=2, duration_sec=600)
+        _make_jsonl(transcript, n_user_msgs=2, duration_sec=600)
         _write_config(tmp_path)
 
         payload = {
@@ -312,7 +312,7 @@ class TestThresholdOutcomes:
         # min_duration_minutes=2 in config; provide 5 messages over 10 seconds
         proj = _projects_dir(tmp_path, "myproj")
         transcript = proj / "sid-shortdur-1234.jsonl"
-        self._make_jsonl(transcript, n_user_msgs=5, duration_sec=10)
+        _make_jsonl(transcript, n_user_msgs=5, duration_sec=10)
         _write_config(tmp_path)
 
         payload = {
@@ -336,7 +336,7 @@ class TestWriteFailedOutcome:
         proj = tmp_path / ".claude" / "projects" / cc_slug
         proj.mkdir(parents=True)
         transcript = proj / "sid-writefail-12.jsonl"
-        TestThresholdOutcomes._make_jsonl(transcript, n_user_msgs=10, duration_sec=600)
+        _make_jsonl(transcript, n_user_msgs=10, duration_sec=600)
 
         # Vault path points at a directory we can read but cannot write to.
         vault = tmp_path / "vault"

--- a/tests/test_session_end_telemetry.py
+++ b/tests/test_session_end_telemetry.py
@@ -651,6 +651,50 @@ class TestExceptionOutcome:
         finally:
             os.chmod(transcript, 0o600)
 
+    def test_main_logs_exception_when_run_raises(self, tmp_path, monkeypatch):
+        """In-process strict test: main() catches _run() exceptions and logs EXCEPTION
+        with project/sid context if _run() updated _LAST_PROJECT/_LAST_SESSION_ID first."""
+        import importlib
+        import obsidian_utils
+        import obsidian_session_log
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Reload obsidian_utils so the HOME-derived log path takes effect
+        importlib.reload(obsidian_utils)
+        # Reload session_log AFTER utils so it picks up the reloaded helper
+        importlib.reload(obsidian_session_log)
+
+        # Pretend _run() got far enough to update _LAST_* before raising
+        obsidian_session_log._LAST_PROJECT = "myproj"
+        obsidian_session_log._LAST_SESSION_ID = "sid-explode-1234"
+
+        # Make _run raise
+        def _boom():
+            raise RuntimeError("simulated mid-run failure")
+        monkeypatch.setattr(obsidian_session_log, "_run", _boom)
+
+        # Avoid sys.exit propagating out of pytest
+        with pytest.raises(SystemExit) as exc_info:
+            obsidian_session_log.main()
+        assert exc_info.value.code == 0  # hook exits 0 even on exception
+
+        log_path = tmp_path / ".claude" / "obsidian-brain-hook.log"
+        assert log_path.exists()
+        content = log_path.read_text(encoding="utf-8")
+        lines = [ln for ln in content.splitlines() if "SessionEnd" in ln]
+        assert len(lines) == 1
+        assert "outcome=EXCEPTION" in lines[0]
+        assert "project=myproj" in lines[0]
+        assert "sid=sid-expl" in lines[0]  # short_sid is first 8
+        # detail should contain the exception repr (truncated to 200 chars)
+        assert "RuntimeError" in lines[0] or "simulated" in lines[0]
+
+        # Restore real HOME so module-level constants in obsidian_utils are
+        # recomputed against the real HOME for subsequent tests in this session.
+        monkeypatch.undo()
+        importlib.reload(obsidian_utils)
+        importlib.reload(obsidian_session_log)
+
 
 # ---------------------------------------------------------------------------
 # Unit tests for helper edge-cases (improve line coverage)


### PR DESCRIPTION
## Summary

Phase 1 of the issue #100 fix: instrument every SessionEnd exit path with a structured outcome line in `~/.claude/obsidian-brain-hook.log`.

Pure observability — zero behavior change. Sets the foundation for Phase 2 (replay tool, #124) and Phase 3 (fixes + reaper, #125).

## What changed

- New helper `_append_sessionend_log(project, sid, outcome, msgs, dur_min, detail)` in `hooks/obsidian_utils.py`. Mirrors the rotation pattern of the existing `_append_hook_log` (same file, same 100 KB cap, same atomic-rename). Best-effort: catches `Exception` and prints stderr — fire-and-forget contract preserved.
- New `_Outcome` string-constant class in `hooks/obsidian_session_log.py` with 10 values.
- 11 exit-path call sites in `_run()` + 1 in `main()` now emit a `SessionEnd` line covering every outcome: `OK_RAW_NOTE_ONLY`, `SKIPPED_BELOW_THRESHOLD` (x2), `SKIPPED_NO_TRANSCRIPT`, `SKIPPED_NO_VAULT`, `SKIPPED_AUTO_LOG_OFF`, `SKIPPED_INVALID_INPUT` (x2), `SKIPPED_TRANSCRIPT_OUTSIDE_PROJECTS`, `WRITE_FAILED`, `EXCEPTION`.
- `_append_hook_log` (SessionStart) hardened with matching `_sanitize_log_field` for cross-event log consistency, plus `0o600` perms on the hook log file.
- Helper `_project_slug_for_log(cwd)` extracted to DRY 5 telemetry call sites.
- Module-level `_LAST_PROJECT` / `_LAST_SESSION_ID` so `main()`'s EXCEPTION wrap carries the real cwd-derived project + parsed sid (when `_run()` got that far) instead of literal `"unknown"`.
- `isinstance(hook_input, dict)` guard after `json.loads` — a non-dict JSON value (list, string, number) now falls into `SKIPPED_INVALID_INPUT` instead of raising `AttributeError` on `.get()`.
- CLAUDE.md updated with audit-log section + accurate `awk '/SessionEnd/ {print $5}'` outcome-distribution one-liner.

## Review history

- **5 internal subagent batches** (per-batch spec + code-quality review) → 5 fixes
- **4 parallel pr-review-toolkit agents** (code, silent-failure, test, comment) → 3 critical doc errors + 7 important findings → 3 commits
- **Copilot R1** (4 inline findings) → 1 commit (`b0b69b8`) + 2 regression tests
- **Copilot R2** (5 fresh inline findings) → 1 commit (`8dc92c1`) + 1 in-process EXCEPTION test
- **Copilot R3** requested (max-3 per skill policy)
- All 9 R1+R2 GitHub threads replied with commit citations and resolved

## Test plan

- [x] `pytest -q` — full suite passes (835 tests; 812 baseline + 23 new)
- [x] `pytest tests/test_session_end_telemetry.py -v` — 23/23 telemetry tests pass
- [x] `pytest tests/test_session_hint_bootstrap.py -v` — 12/12 hint bootstrap tests pass
- [x] `obsidian_session_log.py` line coverage: **100%**
- [x] No regression to existing 812-test baseline
- [ ] Manual smoke (post-merge): `/dev-test install`, run a real session, `tail ~/.claude/obsidian-brain-hook.log` and confirm one `SessionEnd` line appears

## Issue refs

Closes #123. Parent: #100. Sibling: #124, #125.

Note: closes-keyword is silent on squash-merges to non-default branches. Will manually `gh issue close 123` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
