### PR TITLE
feat(vault-doctor): UUID-first detection (issue #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `vault-doctor source-sessions`: removed the `capture_signal != "created_at"` carve-out around Phase 1b — UUID-first now runs uniformly.
 - `vault-doctor source-sessions`: removed the convergence guard (multiple-flag confidence cap). Made moot by UUID-first.
 - `vault-doctor source-sessions`: removed the mtime SID-rewrite path (`proposed_conf=0.3`). Mtime emits as unresolved.
-- `vault-doctor source-sessions`: removed the `created_at` SID-rewrite path (`proposed_conf=0.95`). Made moot by UUID-first.
+- `vault-doctor source-sessions`: removed the dedicated `created_at` SID-rewrite confidence (`proposed_conf=0.95`). Created_at signals can still produce a proposal when the UUID is empty/unresolved, but at conf=0.5 as `date-window-hint` (not auto-applyable) rather than the old high-confidence path.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `vault-doctor source-sessions`: detection refactored around UUID-first contract. The conf=0.4–0.6 wrong-pick class is eliminated. Confidence bands are now strictly `0.99` (uuid-basename-stale, auto-apply), `0.5` (date-window-hint, manual verify), `0.0` (uuid-day-mismatch / missing-session-note / unresolved, WARN). Every emitted Issue carries `extra.signal_class` (also exposed in `--json` output). The `apply()` path refuses to write unless `signal_class == "uuid-basename-stale"`, regardless of `--min-confidence`. (#106)
+
+### Removed
+- `vault-doctor source-sessions`: removed the `capture_signal != "created_at"` carve-out around Phase 1b — UUID-first now runs uniformly.
+- `vault-doctor source-sessions`: removed the convergence guard (multiple-flag confidence cap). Made moot by UUID-first.
+- `vault-doctor source-sessions`: removed the mtime SID-rewrite path (`proposed_conf=0.3`). Mtime emits as unresolved.
+- `vault-doctor source-sessions`: removed the `created_at` SID-rewrite path (`proposed_conf=0.95`). Made moot by UUID-first.
+
 ### Fixed
 
 - Fix YAML-frontmatter regex `\s*` cross-newline bug across 8 call sites in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- `vault-doctor source-sessions`: detection refactored around UUID-first contract. The conf=0.4–0.6 wrong-pick class is eliminated. Confidence bands are now strictly `0.99` (uuid-basename-stale, auto-apply), `0.5` (date-window-hint, manual verify), `0.0` (uuid-day-mismatch / missing-session-note / unresolved, WARN). Every emitted Issue carries `extra.signal_class` (also exposed in `--json` output). The `apply()` path refuses to write unless `signal_class == "uuid-basename-stale"`, regardless of `--min-confidence`. (#106)
+- `vault-doctor source-sessions`: detection refactored around UUID-first contract. The conf=0.4–0.6 wrong-pick class is eliminated. Confidence bands are now strictly `0.99` (uuid-basename-stale, auto-apply), `0.5` (date-window-hint, manual verify), `0.0` (uuid-day-mismatch / missing-session-note / unresolved, WARN). Every emitted Issue carries a `signal_class` tag. In the `--json` output, `signal_class` is exposed as a **top-level** field on each issue (no `extra` wrapper); the internal `Issue` dataclass stores it under `extra` as an implementation detail. The `apply()` path refuses to write unless `signal_class == "uuid-basename-stale"`, regardless of `--min-confidence`. (#106)
 
 ### Removed
 - `vault-doctor source-sessions`: removed the `capture_signal != "created_at"` carve-out around Phase 1b — UUID-first now runs uniformly.

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -181,6 +181,7 @@ def main() -> int:
                     "reason": i.reason,
                     "confidence": i.confidence,
                     "unresolved": i.extra.get("unresolved", False),
+                    "signal_class": i.extra.get("signal_class", ""),
                     "capture_signal": i.extra.get("capture_signal", ""),
                     "capture_confidence": i.extra.get("capture_confidence", 0.0),
                     "convergence_warning": i.extra.get("convergence_warning", False),

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -184,6 +184,10 @@ def main() -> int:
                     "signal_class": i.extra.get("signal_class", ""),
                     "capture_signal": i.extra.get("capture_signal", ""),
                     "capture_confidence": i.extra.get("capture_confidence", 0.0),
+                    # convergence_warning/convergence_count are deprecated as of #106
+                    # (UUID-first matching obsoleted the convergence guard). Kept in the
+                    # payload as hard-coded defaults for downstream schema stability;
+                    # consumers should migrate to signal_class for triage.
                     "convergence_warning": i.extra.get("convergence_warning", False),
                     "convergence_count": i.extra.get("convergence_count", 0),
                 }

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -919,6 +919,20 @@ def apply(issues, backup_root) -> list[Result]:
             )
             continue
 
+        # Issue #106 defense-in-depth: only uuid-basename-stale issues are
+        # auto-applyable. Anything else reaching this point (i.e., not
+        # filtered by the unresolved skip above) is a programming error —
+        # scan() should have marked all non-applyable signal classes
+        # unresolved=True. Raise loudly so operators see it instead of
+        # writing the wrong file.
+        sc = issue.extra.get("signal_class", "")
+        if sc != "uuid-basename-stale":
+            raise RuntimeError(
+                f"apply() refuses signal_class={sc!r} for {issue.note_path}; "
+                f"only uuid-basename-stale is auto-applyable. "
+                f"Edit the note manually after content-grep."
+            )
+
         proposed_sid = issue.extra.get("proposed_sid", "")
         proposed_basename = issue.proposed_source.strip().lstrip("[").rstrip("]")
         if not proposed_sid or not proposed_basename:

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -14,7 +14,6 @@ Detection strategy:
 
 from __future__ import annotations
 
-import dataclasses
 import glob
 import json
 import os
@@ -858,45 +857,6 @@ def scan(
                     },
                 )
             )
-
-    # Convergence guard: if multiple flags in a project propose the same
-    # target session, the date-window heuristic has structurally collapsed
-    # across a multi-session day. Lower confidence and tag for operator review.
-    #
-    # Restrict the guard to day-precision signals (date/filename/mtime) —
-    # `created_at` matches use point-in-window with sub-day precision, so two
-    # legitimate stale notes from the same session sharing a proposal target
-    # is just normal cluster behavior, not heuristic collapse (Copilot R4-2).
-    from collections import Counter
-    _DAY_PRECISION_SIGNALS = {"date", "filename", "mtime"}
-    targets = Counter(
-        (i.project, i.extra.get("proposed_sid", ""))
-        for i in issues
-        if (
-            i.extra.get("proposed_sid")
-            and not i.extra.get("basename_only")
-            and i.extra.get("capture_signal") in _DAY_PRECISION_SIGNALS
-        )
-    )
-    issues = [
-        dataclasses.replace(
-            i,
-            confidence=min(i.confidence, 0.4),
-            extra={
-                **i.extra,
-                "convergence_warning": True,
-                "convergence_count": targets[(i.project, i.extra.get("proposed_sid", ""))],
-            },
-        )
-        if (
-            not i.extra.get("basename_only")
-            and i.extra.get("proposed_sid")
-            and i.extra.get("capture_signal") in _DAY_PRECISION_SIGNALS
-            and targets[(i.project, i.extra.get("proposed_sid", ""))] >= 2
-        )
-        else i
-        for i in issues
-    ]
 
     return issues
 

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -791,16 +791,37 @@ def scan(
             if match["sid"] == current_sid:
                 continue  # correct
 
-            # Cap confidence on date-only signals: day-precision matching can still
-            # be ambiguous on multi-session days because multiple windows may overlap
-            # the same UTC calendar day. `created_at` is the only signal precise
-            # enough for high confidence.
-            if capture_signal == "created_at":
-                proposed_conf = 0.95
-            elif capture_signal == "mtime":
-                proposed_conf = 0.3  # below convergence floor; never auto-apply
-            else:
-                proposed_conf = 0.6
+            # Issue #106: date-window matcher only fires when UUID is empty/unresolved.
+            # When it does fire, it's a HINT, never an auto-applyable proposal:
+            #   date / filename → conf=0.5 (date-window-hint); operator content-greps
+            #   mtime → handled below; early-exits as unresolved (no SID proposal)
+            #   corrupt (signal=none, conf=0.0) → filtered before this block; never reaches here
+            if capture_signal == "mtime":
+                # mtime is too imprecise to anchor a hint. Re-emit as unresolved
+                # so it surfaces in the WARN list without proposing a SID.
+                if current_sid not in idx:
+                    issues.append(
+                        Issue(
+                            check=NAME,
+                            note_path=str(note),
+                            project=note_project,
+                            current_source=current_source_display,
+                            proposed_source="",
+                            reason=(
+                                f"capture_signal=mtime is too imprecise to "
+                                f"anchor a date-window hint (issue #106)"
+                            ),
+                            confidence=0.0,
+                            extra={
+                                "unresolved": True,
+                                "capture_signal": capture_signal,
+                                "capture_confidence": capture_conf,
+                                "signal_class": "unresolved",
+                            },
+                        )
+                    )
+                continue
+            proposed_conf = 0.5
             # Build reason text matching the matcher actually used (Copilot R4):
             # day-overlap → describe calendar-day match; point-in-window →
             # describe capture_time match. mtime with no date/filename takes

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -1,15 +1,22 @@
-"""vault_doctor check: detect and repair stale source_session backlinks.
+"""vault-doctor source-sessions check: UUID-first stale-attribution detector.
 
-Detection strategy:
-  For each insight-type note with a `source_session` frontmatter field,
-  determine capture-time via an immutable-signal preference chain
-  (`created_at` ISO-8601 → `date` YYYY-MM-DD midday UTC → filename prefix
-  YYYY-MM-DD-... midday UTC → mtime as low-confidence last resort).
-  For each JSONL file under ~/.claude/projects/*<project>/*.jsonl,
-  determine its activity window (first entry timestamp → file mtime).
-  The correct source session is the JSONL whose window contains the
-  note's capture-time. Flag as stale whenever the note's current
-  source_session does not match.
+Detection strategy (spec #106):
+1. Phase 1 — UUID-first: when an insight's source_session UUID resolves to a
+   session note in the cross-project vault, the UUID is authoritative. Compare
+   the stamped basename against the resolved session note's basename:
+   - Match → skip (note is correct).
+   - Diverge AND JSONL window overlaps note day → emit uuid-basename-stale
+     (conf=0.99, auto-applyable basename-only repair).
+   - Diverge AND overlap fails or is inconclusive → emit uuid-day-mismatch
+     WARN (conf=0.0, never auto-applyable).
+   - UUID has JSONL but no session note → emit missing-session-note WARN.
+2. Phase 2 — date-window fallback (only when UUID is empty/unknown/unresolved):
+   - Match by point-in-window or day-overlap → emit date-window-hint (conf=0.5,
+     manual verify only).
+   - No match → emit unresolved WARN (conf=0.0).
+
+apply() refuses to write any Issue whose signal_class != "uuid-basename-stale",
+making `--min-confidence` override-safe.
 """
 
 from __future__ import annotations
@@ -634,51 +641,27 @@ def scan(
                         )
                         if fallback_path is not None:
                             window = _jsonl_window(str(fallback_path))
+                    actual_basename = sess["basename"]
+                    # Spec #106 nesting: skip when basename matches; only check
+                    # day-overlap on basename divergence. Inconclusive overlap
+                    # (day_start=None or window=None) does NOT auto-apply at 0.99 —
+                    # downgrade to uuid-day-mismatch WARN so operators verify manually.
+                    if not current_src_basename or current_src_basename == actual_basename:
+                        # UUID resolves AND basename matches (or basename is empty,
+                        # which we don't auto-repair). Skip — note is correct.
+                        continue
+
                     overlap_ok = False
+                    overlap_known = False
                     if day_start is not None and window is not None:
+                        overlap_known = True
                         day_end = day_start + 86400
                         first_ts, last_ts = window
                         overlap_ok = first_ts < day_end and last_ts > day_start
 
-                    actual_basename = sess["basename"]
-                    if day_start is not None and window is not None and not overlap_ok:
-                        # Issue #106: UUID resolves but JSONL window does NOT overlap
-                        # note's calendar day. Emit a WARN at conf=0.0; never propose
-                        # a SID rewrite. Operators must verify manually (likely a
-                        # cross-midnight write-side stamp bug or a worktree edge case
-                        # outside #101's scope).
-                        first_ts, last_ts = window
-                        issues.append(
-                            Issue(
-                                check=NAME,
-                                note_path=str(note),
-                                project=note_project,
-                                current_source=current_source_display,
-                                proposed_source="",
-                                reason=(
-                                    f"source_session UUID {current_sid[:8]} resolves "
-                                    f"but JSONL window "
-                                    f"{datetime.fromtimestamp(first_ts, timezone.utc).date()}..{datetime.fromtimestamp(last_ts, timezone.utc).date()} "
-                                    f"does not overlap note day {datetime.fromtimestamp(day_start, timezone.utc).date()} "
-                                    f"— verify manually, never auto-rewrite"
-                                ),
-                                confidence=0.0,
-                                extra={
-                                    "unresolved": True,
-                                    "capture_signal": capture_signal,
-                                    "capture_confidence": capture_conf,
-                                    "signal_class": "uuid-day-mismatch",
-                                },
-                            )
-                        )
-                        continue
-
-                    # UUID resolves AND (overlap_ok OR overlap inconclusive) →
-                    # UUID is authoritative. Check basename staleness.
-                    if (
-                        current_src_basename
-                        and current_src_basename != actual_basename
-                    ):
+                    if overlap_known and overlap_ok:
+                        # UUID resolves, basename diverges, JSONL window overlaps
+                        # note's day → high-confidence basename-only repair.
                         issues.append(
                             Issue(
                                 check=NAME,
@@ -702,7 +685,46 @@ def scan(
                                 },
                             )
                         )
-                    continue  # UUID is authoritative; skip matcher
+                        continue
+
+                    # overlap_known=False (inconclusive) OR overlap_known=True
+                    # but overlap_ok=False (window doesn't overlap note day).
+                    # Both cases: emit uuid-day-mismatch WARN; never auto-apply.
+                    if overlap_known:
+                        first_ts, last_ts = window
+                        reason = (
+                            f"source_session UUID {current_sid[:8]} resolves "
+                            f"but JSONL window "
+                            f"{datetime.fromtimestamp(first_ts, timezone.utc).date()}..{datetime.fromtimestamp(last_ts, timezone.utc).date()} "
+                            f"does not overlap note day {datetime.fromtimestamp(day_start, timezone.utc).date()} "
+                            f"— verify manually, never auto-rewrite"
+                        )
+                    else:
+                        reason = (
+                            f"source_session UUID {current_sid[:8]} resolves "
+                            f"and basename '{current_src_basename}' differs from "
+                            f"'{actual_basename}', but day-overlap check is "
+                            f"inconclusive (no note date or no JSONL window) "
+                            f"— verify manually, never auto-rewrite"
+                        )
+                    issues.append(
+                        Issue(
+                            check=NAME,
+                            note_path=str(note),
+                            project=note_project,
+                            current_source=current_source_display,
+                            proposed_source="",
+                            reason=reason,
+                            confidence=0.0,
+                            extra={
+                                "unresolved": True,
+                                "capture_signal": capture_signal,
+                                "capture_confidence": capture_conf,
+                                "signal_class": "uuid-day-mismatch",
+                            },
+                        )
+                    )
+                    continue
                 else:
                     # UUID not in session-note index — but a real JSONL may
                     # still exist (SessionEnd hook missed; see issue #98).
@@ -798,6 +820,17 @@ def scan(
             if capture_signal == "mtime":
                 # mtime is too imprecise to anchor a hint. Re-emit as unresolved
                 # so it surfaces in the WARN list without proposing a SID.
+                if not current_sid or current_sid == "unknown":
+                    mtime_reason = (
+                        f"note has no source_session UUID and capture_signal=mtime "
+                        f"is too imprecise to anchor a date-window hint (#106)"
+                    )
+                else:
+                    mtime_reason = (
+                        f"current source_session {current_sid[:8]} did not resolve "
+                        f"and capture_signal=mtime is too imprecise to anchor a "
+                        f"date-window hint (#106)"
+                    )
                 if current_sid not in idx:
                     issues.append(
                         Issue(
@@ -806,10 +839,7 @@ def scan(
                             project=note_project,
                             current_source=current_source_display,
                             proposed_source="",
-                            reason=(
-                                f"capture_signal=mtime is too imprecise to "
-                                f"anchor a date-window hint (issue #106)"
-                            ),
+                            reason=mtime_reason,
                             confidence=0.0,
                             extra={
                                 "unresolved": True,

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -635,44 +635,75 @@ def scan(
                         )
                         if fallback_path is not None:
                             window = _jsonl_window(str(fallback_path))
+                    overlap_ok = False
                     if day_start is not None and window is not None:
                         day_end = day_start + 86400
                         first_ts, last_ts = window
-                        if first_ts < day_end and last_ts > day_start:
-                            # UUID resolves AND window overlaps note's day → UUID is correct.
-                            # Now check if source_session_note basename is stale.
-                            actual_basename = sess["basename"]
-                            if (
-                                current_src_basename
-                                and current_src_basename != actual_basename
-                            ):
-                                # Basename mismatch (e.g., un-truncated worktree slug
-                                # vs truncated actual filename). Propose basename-only
-                                # repair; UUID stays the same.
-                                issues.append(
-                                    Issue(
-                                        check=NAME,
-                                        note_path=str(note),
-                                        project=note_project,
-                                        current_source=current_source_display,
-                                        proposed_source=f"[[{actual_basename}]]",
-                                        reason=(
-                                            f"source_session UUID {current_sid[:8]} resolves "
-                                            f"correctly but source_session_note basename is "
-                                            f"stale (expected '{actual_basename}', got "
-                                            f"'{current_src_basename}')"
-                                        ),
-                                        confidence=0.99,
-                                        extra={
-                                            "proposed_sid": current_sid,
-                                            "basename_only": True,
-                                            "capture_signal": capture_signal,
-                                            "capture_confidence": capture_conf,
-                                            "signal_class": "uuid-basename-stale",
-                                        },
-                                    )
-                                )
-                            continue  # UUID is authoritative either way; skip matcher
+                        overlap_ok = first_ts < day_end and last_ts > day_start
+
+                    actual_basename = sess["basename"]
+                    if day_start is not None and window is not None and not overlap_ok:
+                        # Issue #106: UUID resolves but JSONL window does NOT overlap
+                        # note's calendar day. Emit a WARN at conf=0.0; never propose
+                        # a SID rewrite. Operators must verify manually (likely a
+                        # cross-midnight write-side stamp bug or a worktree edge case
+                        # outside #101's scope).
+                        first_ts, last_ts = window
+                        issues.append(
+                            Issue(
+                                check=NAME,
+                                note_path=str(note),
+                                project=note_project,
+                                current_source=current_source_display,
+                                proposed_source="",
+                                reason=(
+                                    f"source_session UUID {current_sid[:8]} resolves "
+                                    f"but JSONL window "
+                                    f"{datetime.fromtimestamp(first_ts, timezone.utc).date()}..{datetime.fromtimestamp(last_ts, timezone.utc).date()} "
+                                    f"does not overlap note day {datetime.fromtimestamp(day_start, timezone.utc).date()} "
+                                    f"— verify manually, never auto-rewrite"
+                                ),
+                                confidence=0.0,
+                                extra={
+                                    "unresolved": True,
+                                    "capture_signal": capture_signal,
+                                    "capture_confidence": capture_conf,
+                                    "signal_class": "uuid-day-mismatch",
+                                },
+                            )
+                        )
+                        continue
+
+                    # UUID resolves AND (overlap_ok OR overlap inconclusive) →
+                    # UUID is authoritative. Check basename staleness.
+                    if (
+                        current_src_basename
+                        and current_src_basename != actual_basename
+                    ):
+                        issues.append(
+                            Issue(
+                                check=NAME,
+                                note_path=str(note),
+                                project=note_project,
+                                current_source=current_source_display,
+                                proposed_source=f"[[{actual_basename}]]",
+                                reason=(
+                                    f"source_session UUID {current_sid[:8]} resolves "
+                                    f"correctly but source_session_note basename is "
+                                    f"stale (expected '{actual_basename}', got "
+                                    f"'{current_src_basename}')"
+                                ),
+                                confidence=0.99,
+                                extra={
+                                    "proposed_sid": current_sid,
+                                    "basename_only": True,
+                                    "capture_signal": capture_signal,
+                                    "capture_confidence": capture_conf,
+                                    "signal_class": "uuid-basename-stale",
+                                },
+                            )
+                        )
+                    continue  # UUID is authoritative; skip matcher
                 else:
                     # UUID not in session-note index — but a real JSONL may
                     # still exist (SessionEnd hook missed; see issue #98).

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -884,6 +884,7 @@ def scan(
                         "capture_signal": capture_signal,
                         "capture_confidence": capture_conf,
                         "signal_class": "date-window-hint",
+                        "unresolved": True,
                     },
                 )
             )

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -667,6 +667,7 @@ def scan(
                                             "basename_only": True,
                                             "capture_signal": capture_signal,
                                             "capture_confidence": capture_conf,
+                                            "signal_class": "uuid-basename-stale",
                                         },
                                     )
                                 )
@@ -700,6 +701,7 @@ def scan(
                                     "jsonl_path": str(jsonl_path),
                                     "capture_signal": capture_signal,
                                     "capture_confidence": capture_conf,
+                                    "signal_class": "missing-session-note",
                                 },
                             )
                         )
@@ -748,6 +750,7 @@ def scan(
                                 "unresolved": True,
                                 "capture_signal": capture_signal,
                                 "capture_confidence": capture_conf,
+                                "signal_class": "unresolved",
                             },
                         )
                     )
@@ -798,6 +801,7 @@ def scan(
                         "proposed_sid": match["sid"],
                         "capture_signal": capture_signal,
                         "capture_confidence": capture_conf,
+                        "signal_class": "date-window-hint",
                     },
                 )
             )

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -595,18 +595,19 @@ def scan(
             else:
                 current_source_display = ""
 
-            # Phase 1b — UUID-first authoritative signal:
+            # Phase 1 — UUID-FIRST (uniform across all capture signals):
             # if current source's UUID resolves to ANY session note in the
             # vault (cross-project, since worktree-launched skills may write
             # `project:` from main-repo cwd while their source session ran
             # in a worktree), check whether the JSONL window overlaps the
             # note's calendar day. If yes, the UUID is correct; only the
-            # basename in source_session_note may need updating.
+            # basename in source_session_note may need updating. If no,
+            # emit a uuid-day-mismatch WARN — never a SID rewrite proposal.
             #
-            # Only applies for day-precision signals (date, filename, mtime).
-            # When created_at provides a precise sub-day timestamp the matcher
-            # has enough resolution; let it run.
-            if current_sid and capture_signal != "created_at":
+            # Issue #106: removed the capture_signal != "created_at" carve-out;
+            # UUID resolution is the primary signal regardless of capture-time
+            # precision.
+            if current_sid and current_sid != "unknown":
                 if global_sid_index is None:
                     global_sid_index = _list_all_session_notes(sessions_dir)
                 if current_sid in global_sid_index:

--- a/scripts/vault_doctor_checks/source_sessions.py
+++ b/scripts/vault_doctor_checks/source_sessions.py
@@ -860,7 +860,8 @@ def scan(
                     f"note calendar day {note_date_for_match}"
                     f" (signal={capture_signal}, conf={capture_conf})"
                     f" overlaps session {match['sid'][:8]} window most, "
-                    f"not current source {current_sid[:8]}"
+                    f"not current source {current_sid[:8] if current_sid else '<empty>'}"
+                    f" — content-grep the JSONL before applying"
                 )
             else:
                 reason = (
@@ -868,7 +869,8 @@ def scan(
                     f"{datetime.fromtimestamp(capture_time, timezone.utc).isoformat(timespec='seconds')}"
                     f" (signal={capture_signal}, conf={capture_conf})"
                     f" matches session {match['sid'][:8]} window, "
-                    f"not current source {current_sid[:8]}"
+                    f"not current source {current_sid[:8] if current_sid else '<empty>'}"
+                    f" — content-grep the JSONL before applying"
                 )
             issues.append(
                 Issue(

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -98,7 +98,7 @@ heuristic-fall cases are visible (e.g., `signal=mtime conf=0.5` indicates
 no immutable signal was available — the operator should sample a few flagged
 notes before running `fix`). For unresolved issues with no `proposed:` line,
 render `signal:` after `reason:`.
-Render `signal_class` (from extra.signal_class) as a prefix tag so operators
+Render `signal_class` (from the top-level signal_class field) as a prefix tag so operators
 can distinguish: [uuid-basename-stale], [uuid-day-mismatch],
 [missing-session-note], [date-window-hint], [unresolved]. The
 convergence_warning/convergence_count fields are deprecated as of #106

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -89,15 +89,22 @@ come from the top-level `capture_signal` and `capture_confidence` fields
 in the JSON payload (not from `extra.*`). `capture_confidence` reports
 how reliable the capture-time *signal* is (created_at=1.0, date=0.9,
 filename=0.85, mtime=0.5); the issue's top-level `confidence` field
-reports the *rewrite-proposal* confidence (created_at=0.95, mtime=0.3,
-otherwise 0.6) that gates `--apply --min-confidence`. The two are
-distinct — render `capture_confidence` here so heuristic-fall cases
-are visible (e.g., `signal=mtime conf=0.5` indicates no immutable
-signal was available — the operator should sample a few flagged
-notes before running `fix`). For
-unresolved issues with no `proposed:` line, render `signal:` after `reason:`.
-When `convergence_warning` is `true` in the issue, prefix the issue line
-with `[CONVERGED <N> flags]` where `N` is `convergence_count`.
+reports the *rewrite-proposal* confidence per the strict 3-band taxonomy:
+0.99 = uuid-basename-stale (auto-applyable basename-only repair);
+0.5 = date-window-hint (operator must content-grep before applying);
+0.0 = unresolved / uuid-day-mismatch / missing-session-note (never auto-apply).
+The two fields are distinct — render `capture_confidence` here so
+heuristic-fall cases are visible (e.g., `signal=mtime conf=0.5` indicates
+no immutable signal was available — the operator should sample a few flagged
+notes before running `fix`). For unresolved issues with no `proposed:` line,
+render `signal:` after `reason:`.
+Render `signal_class` (from extra.signal_class) as a prefix tag so operators
+can distinguish: [uuid-basename-stale], [uuid-day-mismatch],
+[missing-session-note], [date-window-hint], [unresolved]. The
+convergence_warning/convergence_count fields are deprecated as of #106
+(UUID-first matching obsoleted the convergence guard) — they remain in the
+JSON payload as hard-coded defaults for output schema stability but should
+not drive rendering.
 
 Example:
 

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -67,9 +67,11 @@ def test_cli_dry_run_reports_issues(tmp_path):
         "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\nproject: proj1\nstatus: summarized\n---\n# s\n",
         encoding="utf-8",
     )
+    # source_session matches sid-b (in the index) but source_session_note
+    # erroneously points to session-A's note → uuid-basename-stale (Issue #106).
     insight = vault / "claude-insights" / "2026-04-10-stale.md"
     insight.write_text(
-        '---\ntype: claude-insight\ndate: 2026-04-10\nsource_session: sid-a\nsource_session_note: "[[2026-04-09-proj1-aaaa]]"\nproject: proj1\n---\n# x\n',
+        '---\ntype: claude-insight\ndate: 2026-04-10\nsource_session: sid-b\nsource_session_note: "[[2026-04-09-proj1-aaaa]]"\nproject: proj1\n---\n# x\n',
         encoding="utf-8",
     )
     os.utime(insight, (b_start + 1800, b_start + 1800))
@@ -94,7 +96,7 @@ def test_cli_dry_run_reports_issues(tmp_path):
     assert payload["total_issues"] >= 1
     assert any(i["check"] == "source-sessions" for i in payload["issues"])
     # File was NOT modified (dry-run default)
-    assert "source_session: sid-a" in insight.read_text(encoding="utf-8")
+    assert "source_session: sid-b" in insight.read_text(encoding="utf-8")
 
 
 def test_cli_apply_with_yes(tmp_path):
@@ -121,9 +123,11 @@ def test_cli_apply_with_yes(tmp_path):
         "---\ntype: claude-session\ndate: 2026-04-10\nsession_id: sid-b\nproject: proj1\nstatus: summarized\n---\n# s\n",
         encoding="utf-8",
     )
+    # source_session matches sid-b (in the index) but source_session_note
+    # erroneously points to session-A's note → uuid-basename-stale (Issue #106).
     insight = vault / "claude-insights" / "2026-04-10-apply.md"
     insight.write_text(
-        '---\ntype: claude-insight\ndate: 2026-04-10\nsource_session: sid-a\nsource_session_note: "[[2026-04-09-proj1-aaaa]]"\nproject: proj1\n---\n# x\n',
+        '---\ntype: claude-insight\ndate: 2026-04-10\nsource_session: sid-b\nsource_session_note: "[[2026-04-09-proj1-aaaa]]"\nproject: proj1\n---\n# x\n',
         encoding="utf-8",
     )
     os.utime(insight, (b_start + 1800, b_start + 1800))

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -48,13 +48,18 @@ def test_end_to_end_scan_apply_verify(tmp_path):
         encoding="utf-8",
     )
 
-    # Stale insight (captured in session B but stamped with session A)
+    # Stale insight (captured in session B but stamped with a UUID not in the
+    # session-note index). Using a UUID absent from the index ensures Phase 1
+    # UUID-first does not intercept it — the date-window matcher then finds sid-b
+    # and produces a rewritable issue. (Issue #106: if source_session were sid-a,
+    # which IS in the index with date 2026-04-09, Phase 1 would emit
+    # uuid-day-mismatch/unresolved for this 2026-04-10 note and stop.)
     insight = vault / "claude-insights" / "2026-04-10-stale-e2e.md"
     insight.write_text(
         '---\n'
         'type: claude-insight\n'
         'date: 2026-04-10\n'
-        'source_session: sid-a\n'
+        'source_session: not-in-index-e2e-uuid\n'
         'source_session_note: "[[2026-04-09-proj1-aaaa]]"\n'
         'project: proj1\n'
         'tags:\n'
@@ -172,15 +177,18 @@ def test_json_payload_has_top_level_signal_and_convergence_keys(tmp_path):
         encoding="utf-8",
     )
 
-    # Two stale insights on 2026-04-10 both pointing at sid-a — both will
-    # converge onto sid-b via the date-overlap matcher.
-    for slug in ("conv-one", "conv-two"):
+    # Two stale insights on 2026-04-10 both converging onto sid-b via the
+    # date-overlap matcher. source_session uses UUIDs not in the session-note
+    # index so Phase 1 UUID-first does not intercept them (Issue #106: if they
+    # pointed at sid-a, Phase 1 would emit uuid-day-mismatch/unresolved for
+    # these 2026-04-10 notes and the convergence guard would never fire).
+    for i, slug in enumerate(("conv-one", "conv-two")):
         insight = vault / "claude-insights" / f"2026-04-10-{slug}.md"
         insight.write_text(
             '---\n'
             'type: claude-insight\n'
             'date: 2026-04-10\n'
-            'source_session: sid-a\n'
+            f'source_session: not-in-index-conv-{i}\n'
             'source_session_note: "[[2026-04-09-convproj-aaaa]]"\n'
             'project: convproj\n'
             'tags:\n'

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -225,3 +225,14 @@ def test_json_payload_has_top_level_signal_and_convergence_keys(tmp_path):
         assert "capture_confidence" in issue, f"missing capture_confidence: {issue}"
         assert "convergence_warning" in issue, f"missing convergence_warning: {issue}"
         assert "convergence_count" in issue, f"missing convergence_count: {issue}"
+        assert "signal_class" in issue, (
+            f"signal_class must be top-level in JSON payload, got keys: {list(issue.keys())}"
+        )
+        assert issue["signal_class"] in (
+            "uuid-basename-stale",
+            "uuid-day-mismatch",
+            "missing-session-note",
+            "date-window-hint",
+            "unresolved",
+            "",  # default for any future Issue lacking the field
+        ), f"signal_class={issue['signal_class']!r} not in documented taxonomy"

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -48,18 +48,17 @@ def test_end_to_end_scan_apply_verify(tmp_path):
         encoding="utf-8",
     )
 
-    # Stale insight (captured in session B but stamped with a UUID not in the
-    # session-note index). Using a UUID absent from the index ensures Phase 1
-    # UUID-first does not intercept it — the date-window matcher then finds sid-b
-    # and produces a rewritable issue. (Issue #106: if source_session were sid-a,
-    # which IS in the index with date 2026-04-09, Phase 1 would emit
-    # uuid-day-mismatch/unresolved for this 2026-04-10 note and stop.)
+    # Stale insight: source_session matches sid-b (in the session-note index)
+    # but source_session_note erroneously points to session-A's note. This is
+    # the uuid-basename-stale scenario (Issue #106 Phase 1 UUID-first,
+    # conf=0.99, auto-applyable). date-window-hint issues are blocked by the
+    # apply() defense-in-depth guard.
     insight = vault / "claude-insights" / "2026-04-10-stale-e2e.md"
     insight.write_text(
         '---\n'
         'type: claude-insight\n'
         'date: 2026-04-10\n'
-        'source_session: not-in-index-e2e-uuid\n'
+        'source_session: sid-b\n'
         'source_session_note: "[[2026-04-09-proj1-aaaa]]"\n'
         'project: proj1\n'
         'tags:\n'

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -134,10 +134,10 @@ def test_end_to_end_scan_apply_verify(tmp_path):
 
 
 def test_json_payload_has_top_level_signal_and_convergence_keys(tmp_path):
-    """Two stale insights converging on a single proposed sid must emit
-    convergence_warning=True and convergence_count>=2 at the top level of
-    each issue dict — alongside capture_signal and capture_confidence
-    (review C1, I6).
+    """Stale insights must emit capture_signal and capture_confidence at the
+    top level of each issue dict in the JSON payload (review C1, I6).
+    convergence_warning and convergence_count keys are still present (as
+    defaults False/0) but the convergence guard was removed in issue #106.
     """
     vault = tmp_path / "vault"
     (vault / "claude-sessions").mkdir(parents=True)
@@ -218,19 +218,11 @@ def test_json_payload_has_top_level_signal_and_convergence_keys(tmp_path):
     issues = payload["issues"]
     assert len(issues) >= 2, f"expected >=2 issues, got {len(issues)}: {issues}"
 
-    # Every issue must have all four keys at the TOP level (not under extra).
+    # Every issue must have capture_signal and capture_confidence at the TOP
+    # level (not under extra). convergence_warning/count keys are still present
+    # as defaults (False/0) after the convergence guard was removed (#106).
     for issue in issues:
         assert "capture_signal" in issue, f"missing capture_signal: {issue}"
         assert "capture_confidence" in issue, f"missing capture_confidence: {issue}"
         assert "convergence_warning" in issue, f"missing convergence_warning: {issue}"
         assert "convergence_count" in issue, f"missing convergence_count: {issue}"
-
-    converged = [i for i in issues if i["convergence_warning"] is True]
-    assert len(converged) >= 2, (
-        f"expected >=2 issues with convergence_warning=True, got {len(converged)}: "
-        f"{[(i['note_path'], i['convergence_warning']) for i in issues]}"
-    )
-    for issue in converged:
-        assert issue["convergence_count"] >= 2, (
-            f"convergence_count must be >=2 when warned: {issue}"
-        )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -2062,6 +2062,10 @@ def test_unresolvable_uuid_with_date_window_candidate_hint(doctor_vault, monkeyp
     assert flagged[0].extra.get("signal_class") == "date-window-hint"
     assert flagged[0].extra.get("proposed_sid") == sid_real
     assert sess.stem in flagged[0].proposed_source
+    assert "content-grep" in flagged[0].reason.lower(), (
+        f"date-window-hint reason should instruct operator to content-grep "
+        f"the JSONL before applying. Got: {flagged[0].reason}"
+    )
 
 
 def test_apply_raises_runtime_error_on_unknown_signal_class(tmp_path):
@@ -2239,3 +2243,7 @@ def test_unknown_literal_with_date_window_candidate_hint(doctor_vault, monkeypat
     assert flagged[0].confidence == 0.5
     assert flagged[0].extra.get("signal_class") == "date-window-hint"
     assert flagged[0].extra.get("proposed_sid") == sid_real
+    assert "content-grep" in flagged[0].reason.lower(), (
+        f"date-window-hint reason should instruct operator to content-grep "
+        f"the JSONL before applying. Got: {flagged[0].reason}"
+    )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1330,6 +1330,7 @@ def test_scan_trusts_uuid_when_jsonl_exists_but_note_missing(doctor_vault, monke
         "regression: must not propose a different session when source UUID "
         "had a real JSONL (just missing session note)"
     )
+    assert flagged[0].extra.get("signal_class") == "missing-session-note"
 
 
 # ---------------------------------------------------------------------------
@@ -1446,6 +1447,7 @@ def test_scan_emits_unresolved_when_jsonl_exists_but_session_note_missing(
     assert issue.extra.get("missing_session_note") is True
     assert issue.extra.get("jsonl_path") == str(orphan_jsonl)
     assert issue.confidence == 0.0
+    assert issue.extra.get("signal_class") == "missing-session-note"
 
 
 def test_list_all_session_notes_warns_on_malformed_frontmatter(tmp_path, capsys):
@@ -2089,3 +2091,143 @@ def test_apply_raises_runtime_error_on_unknown_signal_class(tmp_path):
     backup_root = tmp_path / "backup"
     with pytest.raises(RuntimeError, match="signal_class='date-window-hint'"):
         ss.apply([bad], str(backup_root))
+
+
+# ---------------------------------------------------------------------------
+# PR #151 review fixes — Phase 1 nesting correctness
+# ---------------------------------------------------------------------------
+
+def test_uuid_resolves_basename_matches_skips_even_when_window_disjoint(doctor_vault, monkeypatch):
+    """Spec #106 nesting: when basename matches, skip outright — even if the
+    JSONL window doesn't overlap the note's day. Cross-midnight notes whose
+    basename is correct should not produce WARN noise."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Session ran 2026-04-20 evening; note dated 2026-04-21 (cross-midnight scenario)
+    sid = "12121212-1212-1212-1212-121212121212"
+    s_first = datetime(2026, 4, 20, 22, 0, tzinfo=timezone.utc).timestamp()
+    s_last = datetime(2026, 4, 20, 23, 30, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid}.jsonl",
+                 datetime.fromtimestamp(s_first, tz=timezone.utc).isoformat(),
+                 s_last)
+    sess = _write_session_note(vault / "claude-sessions", "2026-04-20", project, sid, "1212")
+
+    insight_path = vault / "claude-insights" / "2026-04-21-cross-midnight-correct.md"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-21\n"
+        f"source_session: {sid}\n"
+        f'source_session_note: "[[{sess.stem}]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_path, (s_last + 60, s_last + 60))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert flagged == [], (
+        f"basename matches resolved UUID — should skip outright, got {flagged}"
+    )
+
+
+def test_uuid_resolves_basename_diverges_no_jsonl_emits_day_mismatch(doctor_vault, monkeypatch):
+    """Spec #106 fail-closed: UUID resolves, basename diverges, but no JSONL
+    is available anywhere → emit uuid-day-mismatch (overlap inconclusive),
+    NEVER auto-apply at conf=0.99."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Session note exists but no JSONL anywhere
+    sid = "13131313-1313-1313-1313-131313131313"
+    sess = _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid, "1313")
+
+    insight_path = vault / "claude-insights" / "2026-04-22-no-jsonl.md"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-22\n"
+        f"source_session: {sid}\n"
+        f'source_session_note: "[[2026-04-22-WRONG-bn]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_path, (
+        datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc).timestamp(),
+        datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc).timestamp(),
+    ))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert len(flagged) == 1
+    assert flagged[0].confidence == 0.0
+    assert flagged[0].extra.get("signal_class") == "uuid-day-mismatch"
+    assert flagged[0].proposed_source == ""
+    assert flagged[0].extra.get("proposed_sid") in (None, "")
+
+
+def test_unknown_literal_with_date_window_candidate_hint(doctor_vault, monkeypatch):
+    """Verify literal source_session: 'unknown' sentinel → falls through to
+    date-window matcher (the carve-out at line 609 short-circuits empty/unknown)."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_real = "14141414-1414-1414-1414-141414141414"
+    r_first = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
+    r_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_real}.jsonl",
+                 datetime.fromtimestamp(r_first, tz=timezone.utc).isoformat(),
+                 r_last)
+    _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_real, "1414")
+
+    insight_path = vault / "claude-insights" / "2026-04-22-unknown-sentinel.md"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-22\n"
+        f"source_session: unknown\n"
+        f'source_session_note: "[[2026-04-22-stub]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_path, (r_first + 1800, r_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [
+        i for i in issues
+        if i.note_path == str(insight_path) and not i.extra.get("unresolved")
+    ]
+    assert len(flagged) == 1
+    assert flagged[0].confidence == 0.5
+    assert flagged[0].extra.get("signal_class") == "date-window-hint"
+    assert flagged[0].extra.get("proposed_sid") == sid_real

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1385,9 +1385,13 @@ def test_scan_day_overlap_picks_morning_session(doctor_vault, monkeypatch):
         days=10000,
         project=project,
     )
-    flagged = [i for i in issues if i.note_path == str(insight) and not i.extra.get("unresolved")]
+    flagged = [
+        i for i in issues
+        if i.note_path == str(insight)
+        and i.extra.get("signal_class") == "date-window-hint"
+    ]
     assert len(flagged) == 1, (
-        f"expected exactly one non-unresolved issue for {insight}, got {len(flagged)}: {flagged}"
+        f"expected exactly one date-window-hint issue for {insight}, got {len(flagged)}: {flagged}"
     )
     # Day-overlap matcher should pick the morning session (larger overlap)
     assert flagged[0].extra.get("proposed_sid") == sid_morning, (
@@ -2048,7 +2052,8 @@ def test_unknown_uuid_with_date_window_candidate_hint(doctor_vault, monkeypatch)
     )
     flagged = [
         i for i in issues
-        if i.note_path == str(insight_path) and not i.extra.get("unresolved")
+        if i.note_path == str(insight_path)
+        and i.extra.get("signal_class") == "date-window-hint"
     ]
     assert len(flagged) == 1
     assert flagged[0].confidence == 0.5
@@ -2225,7 +2230,8 @@ def test_unknown_literal_with_date_window_candidate_hint(doctor_vault, monkeypat
     )
     flagged = [
         i for i in issues
-        if i.note_path == str(insight_path) and not i.extra.get("unresolved")
+        if i.note_path == str(insight_path)
+        and i.extra.get("signal_class") == "date-window-hint"
     ]
     assert len(flagged) == 1
     assert flagged[0].confidence == 0.5

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -2011,10 +2011,12 @@ def test_uuid_resolves_jsonl_window_outside_note_day_emits_warn(doctor_vault, mo
     assert flagged[0].extra.get("proposed_sid") in (None, "")
 
 
-def test_unknown_uuid_with_date_window_candidate_hint(doctor_vault, monkeypatch):
-    """Spec #106 test #5: source_session: 'unknown' + date-window candidate exists →
-    1 issue, conf=0.5, signal_class='date-window-hint', reason instructs operator
-    to content-grep before applying."""
+def test_unresolvable_uuid_with_date_window_candidate_hint(doctor_vault, monkeypatch):
+    """Spec #106 test #5: source_session is an unresolvable UUID literal (not in
+    the session-note index, no JSONL anywhere) AND a date-window candidate
+    exists → 1 issue, conf=0.5, signal_class='date-window-hint', reason
+    instructs operator to content-grep before applying. The literal `unknown`
+    sentinel is covered separately by test_unknown_literal_with_date_window_candidate_hint."""
     vault = doctor_vault["vault"]
     home = doctor_vault["home"]
     jsonl_dir = doctor_vault["jsonl_dir"]

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -401,7 +401,13 @@ def test_parse_date_midpoint_negative_edges_return_none(bad_date):
 
 
 def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
-    """When two session windows both contain capture_time, latest first_ts wins."""
+    """When two session windows both contain capture_time, latest first_ts wins.
+
+    Issue #106: UUID-first now fires for created_at signals too. To exercise
+    the timestamp-matcher tie-break path, the note's source_session must be a
+    UUID that has neither a JSONL nor a session note — so UUID-first cannot
+    resolve it and the matcher runs on the created_at anchor.
+    """
     import vault_doctor_checks.source_sessions as check
 
     v = doctor_vault["vault"]
@@ -421,17 +427,17 @@ def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
     _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T14:00:00Z", b_mtime)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
-    # Insight captured at 14:02 — inside BOTH windows.
-    # We inject created_at so _capture_time uses the precise sub-day timestamp
-    # (date: midday = 12:00, which only falls in A; we need 14:02 in both).
+    # Insight: currently stamped with a phantom SID (no JSONL, no session note)
+    # so UUID-first cannot resolve it; the matcher runs on created_at.
+    phantom_sid = "ffffffff-ffff-ffff-ffff-000000000000"
     insight_mtime = calendar.timegm(time.strptime("2026-04-10 14:02", "%Y-%m-%d %H:%M"))
     insight_path = _write_insight(
         v / "claude-insights",
         "2026-04-10",
         "boundary-tie-insight",
         "proj1",
-        "sid-a",  # currently (wrongly) stamped with the older session
-        "2026-04-10-proj1-aaaa",
+        phantom_sid,  # UUID that resolves nowhere
+        "2026-04-10-proj1-phantom",
         insight_mtime,
     )
     # Inject created_at so _capture_time resolves to 14:02 (inside both windows)
@@ -959,86 +965,6 @@ def test_scan_trusts_current_source_when_same_day(doctor_vault, monkeypatch):
     )
 
 
-def test_scan_created_at_bypasses_early_exit(doctor_vault, monkeypatch):
-    """Pin test for the capture_signal != 'created_at' carve-out in Phase 1b
-    early-exit (issue #93). A note with created_at AND a same-day current
-    source MUST still be validated by the matcher; the early-exit must NOT
-    short-circuit just because date strings agree.
-
-    If this test goes silent (passes when it shouldn't), the carve-out has
-    been removed and high-precision created_at notes are being trusted on
-    same-day SID match alone — masking actual corruption."""
-    vault = doctor_vault["vault"]
-    home = doctor_vault["home"]
-    jsonl_dir = doctor_vault["jsonl_dir"]
-    project = doctor_vault["project"]
-
-    monkeypatch.setenv("HOME", str(home))
-
-    day = "2026-04-22"
-    sid_x = "33333333-3333-3333-3333-333333333333"
-    sid_y = "44444444-4444-4444-4444-444444444444"
-
-    # Two same-day sessions, NON-overlapping.
-    # Session X: 09:00–11:00 (current source — INCORRECT for the note).
-    # Session Y: 14:00–16:00 (the note's actual created_at falls here).
-    x_start = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
-    x_end = datetime(2026, 4, 22, 11, 0, tzinfo=timezone.utc).timestamp()
-    _write_jsonl(jsonl_dir / f"{sid_x}.jsonl",
-                 datetime.fromtimestamp(x_start, tz=timezone.utc).isoformat(),
-                 x_end)
-
-    y_start = datetime(2026, 4, 22, 14, 0, tzinfo=timezone.utc).timestamp()
-    y_end = datetime(2026, 4, 22, 16, 0, tzinfo=timezone.utc).timestamp()
-    _write_jsonl(jsonl_dir / f"{sid_y}.jsonl",
-                 datetime.fromtimestamp(y_start, tz=timezone.utc).isoformat(),
-                 y_end)
-
-    sess_x = _write_session_note(vault / "claude-sessions", day, project, sid_x, "3333")
-    sess_y = _write_session_note(vault / "claude-sessions", day, project, sid_y, "4444")
-
-    # Insight: source_session is X (same day, would satisfy date-equality early-exit
-    # if signal were date/filename), but created_at = 14:30 falls in Y's window.
-    # The matcher MUST be allowed to run and propose Y. Early-exit must NOT fire.
-    insight_path = vault / "claude-insights" / f"{day}-pin-carveout.md"
-    insight_path.write_text(
-        f"---\n"
-        f"type: claude-insight\n"
-        f"date: {day}\n"
-        f"created_at: 2026-04-22T14:30:00+00:00\n"
-        f"source_session: {sid_x}\n"
-        f'source_session_note: "[[{sess_x.stem}]]"\n'
-        f"project: {project}\n"
-        f"tags:\n"
-        f"  - claude/insight\n"
-        f"  - claude/project/{project}\n"
-        f"---\n"
-        f"# pin\n",
-        encoding="utf-8",
-    )
-    # Set mtime to a known stable value (irrelevant for matching now)
-    import os as _os
-    _os.utime(insight_path, (y_start + 1800, y_start + 1800))
-
-    issues = ss.scan(
-        vault_path=str(vault),
-        sessions_folder="claude-sessions",
-        insights_folder="claude-insights",
-        days=10000,
-        project=project,
-    )
-    flagged = [i for i in issues if i.note_path == str(insight_path)]
-    assert len(flagged) == 1, (
-        "carve-out regression: created_at note with same-day current source "
-        "was not re-validated by matcher (early-exit fired when it should not)"
-    )
-    iss = flagged[0]
-    assert iss.extra.get("capture_signal") == "created_at"
-    assert iss.extra.get("proposed_sid") == sid_y, (
-        f"matcher should propose Y (where created_at falls), got {iss.extra.get('proposed_sid')!r}"
-    )
-
-
 def test_scan_uuid_first_lookup_across_projects(doctor_vault, monkeypatch):
     """Phase 1b looks up source_session UUID across all projects, not just
     the note's declared project. Insight notes from a worktree-launched skill
@@ -1099,6 +1025,32 @@ def test_scan_uuid_first_lookup_across_projects(doctor_vault, monkeypatch):
         "regression: cross-project UUID resolution failed; insight flagged "
         "despite source UUID resolving to a real session note"
     )
+
+    # Issue #106 broaden: also exercise the basename-stale case across projects.
+    # Worktree-style adjacent project's session, but insight has a STALE basename.
+    insight2_path = vault / "claude-insights" / "2026-04-22-cross-stale-bn.md"
+    insight2_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-22\n"
+        f"source_session: {sid_w}\n"
+        f'source_session_note: "[[2026-04-22-proj1-OLD-truncated]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    os.utime(insight2_path, (w_first + 1800, w_first + 1800))
+
+    issues2 = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged2 = [i for i in issues2 if i.note_path == str(insight2_path)]
+    assert len(flagged2) == 1
+    assert flagged2[0].extra.get("signal_class") == "uuid-basename-stale"
 
 
 def test_scan_basename_only_repair_when_uuid_resolves(doctor_vault, monkeypatch):
@@ -2206,3 +2158,63 @@ def test_uuid_resolves_basename_points_at_unrelated_session(doctor_vault, monkey
     )
     assert sess_a.stem in flagged[0].proposed_source
     assert sess_b.stem not in flagged[0].proposed_source
+
+
+@pytest.mark.parametrize("capture_signal_kind", ["created_at", "date", "filename", "mtime"])
+def test_uuid_resolves_basename_matches_no_issue(doctor_vault, monkeypatch, capture_signal_kind):
+    """Spec #106 test #1: UUID resolves and basename matches → 0 issues, uniformly
+    across all capture signals. Verifies the dropped capture_signal != 'created_at'
+    carve-out: UUID-first now fires for every signal class."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid = "ccccccc1-cccc-cccc-cccc-cccccccccccc"
+    s_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    s_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid}.jsonl",
+                 datetime.fromtimestamp(s_first, tz=timezone.utc).isoformat(),
+                 s_last)
+    sess = _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid, "ccc1")
+
+    fm_lines = [
+        "---",
+        "type: claude-insight",
+        f"source_session: {sid}",
+        f'source_session_note: "[[{sess.stem}]]"',
+        f"project: {project}",
+    ]
+    if capture_signal_kind == "created_at":
+        fm_lines.append("date: 2026-04-22")
+        fm_lines.append(
+            f"created_at: {datetime.fromtimestamp(s_first + 1800, tz=timezone.utc).isoformat()}"
+        )
+        insight_path = vault / "claude-insights" / "2026-04-22-uniform-created-at.md"
+    elif capture_signal_kind == "date":
+        fm_lines.append("date: 2026-04-22")
+        insight_path = vault / "claude-insights" / "2026-04-22-uniform-date.md"
+    elif capture_signal_kind == "filename":
+        # No date in fm; filename prefix carries the date signal.
+        insight_path = vault / "claude-insights" / "2026-04-22-uniform-filename.md"
+    else:  # mtime
+        # No date, no filename prefix → mtime is the only signal.
+        insight_path = vault / "claude-insights" / "uniform-mtime-only.md"
+    fm_lines.append("---")
+
+    insight_path.write_text("\n".join(fm_lines) + "\n# stub\n", encoding="utf-8")
+    os.utime(insight_path, (s_first + 1800, s_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert flagged == [], (
+        f"capture_signal_kind={capture_signal_kind}: expected 0 issues "
+        f"(UUID resolves + basename matches), got {len(flagged)}: {flagged}"
+    )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -2095,3 +2095,114 @@ def test_convergence_guard_excludes_created_at_signal(doctor_vault, monkeypatch)
             f"convergence_warning must be False for created_at flags. "
             f"Got: {issue.extra}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #106 — UUID-first detection contract
+# ---------------------------------------------------------------------------
+
+def test_uuid_resolves_basename_stale_emits_basename_only(doctor_vault, monkeypatch):
+    """Spec #106 test #2: UUID resolves correctly but stamp's basename is stale →
+    1 issue, conf=0.99, signal_class='uuid-basename-stale', proposed_sid==current_sid."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid = "11111111-1111-1111-1111-111111111111"
+    s_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
+    s_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid}.jsonl",
+                 datetime.fromtimestamp(s_first, tz=timezone.utc).isoformat(),
+                 s_last)
+    sess = _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid, "1111")
+
+    insight_path = vault / "claude-insights" / "2026-04-22-stale-bn.md"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-22\n"
+        f"source_session: {sid}\n"
+        f'source_session_note: "[[2026-04-22-proj1-WRONG]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_path, (s_first + 1800, s_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert len(flagged) == 1
+    assert flagged[0].confidence == 0.99
+    assert flagged[0].extra.get("signal_class") == "uuid-basename-stale"
+    assert flagged[0].extra.get("basename_only") is True
+    assert flagged[0].extra.get("proposed_sid") == sid
+    assert sess.stem in flagged[0].proposed_source
+
+
+def test_uuid_resolves_basename_points_at_unrelated_session(doctor_vault, monkeypatch):
+    """Spec #106 test #3 (telegram-analytics regression): UUID resolves to A but
+    stamp's basename points at unrelated B. Must propose A's canonical basename
+    (not B, not date-window pick)."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Session A — the correct one (UUID resolves here)
+    sid_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa11"
+    a_first = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
+    a_last = datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_a}.jsonl",
+                 datetime.fromtimestamp(a_first, tz=timezone.utc).isoformat(),
+                 a_last)
+    sess_a = _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_a, "aaaa")
+
+    # Session B — unrelated, also same day, larger window
+    sid_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb11"
+    b_first = datetime(2026, 4, 22, 13, 0, tzinfo=timezone.utc).timestamp()
+    b_last = datetime(2026, 4, 22, 22, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_b}.jsonl",
+                 datetime.fromtimestamp(b_first, tz=timezone.utc).isoformat(),
+                 b_last)
+    sess_b = _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_b, "bbbb")
+
+    # Insight: source_session=A (correct), source_session_note=B (wrong stamp).
+    # Pre-#106: matcher would propose B (larger overlap). Post-#106: must propose A.
+    insight_path = vault / "claude-insights" / "2026-04-22-tgan.md"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-22\n"
+        f"source_session: {sid_a}\n"
+        f'source_session_note: "[[{sess_b.stem}]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_path, (a_first + 1800, a_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert len(flagged) == 1
+    assert flagged[0].extra.get("signal_class") == "uuid-basename-stale"
+    assert flagged[0].extra.get("proposed_sid") == sid_a, (
+        f"regression: must propose A's UUID (UUID-first is authoritative), "
+        f"got {flagged[0].extra.get('proposed_sid')}"
+    )
+    assert sess_a.stem in flagged[0].proposed_source
+    assert sess_b.stem not in flagged[0].proposed_source

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -232,6 +232,7 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
     assert iss.confidence == 0.0
     assert iss.proposed_source == ""
     assert "gap-insight" in iss.note_path
+    assert iss.extra.get("signal_class") == "unresolved"
 
 
 def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monkeypatch):
@@ -928,6 +929,7 @@ def test_scan_unresolved_reason_uses_capture_time(doctor_vault, monkeypatch):
     assert "mtime" not in iss.reason, f"reason should not mention mtime: {iss.reason!r}"
     assert iss.extra.get("capture_signal") == "date"
     assert iss.extra.get("capture_confidence") == 0.9
+    assert iss.extra.get("signal_class") == "unresolved"
 
 
 def test_scan_trusts_current_source_when_same_day(doctor_vault, monkeypatch):
@@ -1131,57 +1133,6 @@ def test_scan_basename_only_repair_when_uuid_resolves(doctor_vault, monkeypatch)
     assert sess.stem in iss.proposed_source  # actual basename in proposal
     assert iss.confidence >= 0.95
 
-
-def test_scan_caps_date_signal_confidence(doctor_vault, monkeypatch):
-    """Matcher-proposed flags using only date/filename signals must be capped
-    at confidence <= 0.6 -- multi-session days collapse onto noon-UTC and
-    produce uniform-but-wrong proposals."""
-    vault = doctor_vault["vault"]
-    home = doctor_vault["home"]
-    jsonl_dir = doctor_vault["jsonl_dir"]
-    project = doctor_vault["project"]
-    monkeypatch.setenv("HOME", str(home))
-
-    sid_a = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaa11"
-    sid_b = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbb11"
-
-    a_first = datetime(2026, 4, 21, 10, 0, tzinfo=timezone.utc).timestamp()
-    a_last = datetime(2026, 4, 21, 18, 0, tzinfo=timezone.utc).timestamp()
-    _write_jsonl(jsonl_dir / f"{sid_a}.jsonl",
-                 datetime.fromtimestamp(a_first, tz=timezone.utc).isoformat(),
-                 a_last)
-    b_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
-    b_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
-    _write_jsonl(jsonl_dir / f"{sid_b}.jsonl",
-                 datetime.fromtimestamp(b_first, tz=timezone.utc).isoformat(),
-                 b_last)
-
-    _write_session_note(vault / "claude-sessions", "2026-04-21", project, sid_a, "1111")
-    _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_b, "2222")
-
-    # Insight on day B (sole same-day session) but source_session points to
-    # day-A session whose UUID does NOT resolve (no entry in idx for proj1)
-    bogus_sid = "00000000-0000-0000-0000-000000000000"
-    _write_insight(
-        vault / "claude-insights",
-        date="2026-04-22",
-        slug="conf-cap",
-        project=project,
-        src_sid=bogus_sid,
-        src_note_basename="2026-04-22-bogus",
-        mtime=b_first + 1800,
-    )
-
-    issues = ss.scan(
-        vault_path=str(vault),
-        sessions_folder="claude-sessions",
-        insights_folder="claude-insights",
-        days=10000,
-        project=project,
-    )
-    flagged = [i for i in issues if "conf-cap" in i.note_path and not i.extra.get("unresolved")]
-    assert len(flagged) == 1
-    assert flagged[0].confidence <= 0.6
 
 
 @pytest.mark.parametrize("n_flags", [2, 3, 5])
@@ -1551,80 +1502,6 @@ def test_scan_day_overlap_picks_morning_session(doctor_vault, monkeypatch):
     )
 
 
-def test_scan_caps_mtime_signal_confidence_below_convergence_floor(doctor_vault, monkeypatch):
-    """When capture_signal falls all the way to mtime (no created_at, no date
-    frontmatter, no YYYY-MM-DD filename prefix), the proposed-rewrite confidence
-    must be capped at <=0.3 — below the convergence floor of 0.4 — so an
-    operator never auto-applies an mtime-only proposal (review C2)."""
-    vault = doctor_vault["vault"]
-    home = doctor_vault["home"]
-    jsonl_dir = doctor_vault["jsonl_dir"]
-    project = doctor_vault["project"]
-    monkeypatch.setenv("HOME", str(home))
-
-    # Two sessions on different days so the date-overlap matcher returns a
-    # different session than the one currently referenced.
-    a_start = calendar.timegm(time.strptime("2026-04-15 10:00", "%Y-%m-%d %H:%M"))
-    a_end = a_start + 3600
-    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-15T10:00:00Z", a_end)
-    _write_session_note(vault / "claude-sessions", "2026-04-15", project, "sid-a", "aaaa")
-
-    b_start = calendar.timegm(time.strptime("2026-04-16 10:00", "%Y-%m-%d %H:%M"))
-    b_end = b_start + 4 * 3600
-    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-16T10:00:00Z", b_end)
-    _write_session_note(vault / "claude-sessions", "2026-04-16", project, "sid-b", "bbbb")
-
-    # Insight with NO created_at, NO date frontmatter, NO YYYY-MM-DD filename
-    # prefix → mtime is the only available signal. Filename intentionally
-    # avoids the date prefix.
-    #
-    # NOTE (Issue #106): source_session is set to a UUID not in the session-note
-    # index. If it were set to "sid-a" (which is in the index), Phase 1 UUID-first
-    # would intercept: with no date in the note, day_start=None → the basename
-    # check runs → basename matches ("2026-04-15-proj1-aaaa") → continue, skip
-    # matcher. The mtime-stale path would never fire.
-    insight = vault / "claude-insights" / "no-date-prefix-mtime-only.md"
-    insight.write_text(
-        "---\n"
-        "type: claude-insight\n"
-        f"source_session: not-in-index-mtime-uuid\n"
-        f'source_session_note: "[[2026-04-15-{project}-aaaa]]"\n'
-        f"project: {project}\n"
-        "tags:\n"
-        "  - claude/insight\n"
-        f"  - claude/project/{project}\n"
-        "---\n"
-        "# body\n",
-        encoding="utf-8",
-    )
-    # Set mtime inside session B's window so the matcher proposes sid-b.
-    insight_mtime = b_start + 1800
-    os.utime(insight, (insight_mtime, insight_mtime))
-
-    issues = ss.scan(
-        vault_path=str(vault),
-        sessions_folder="claude-sessions",
-        insights_folder="claude-insights",
-        days=10000,
-        project=project,
-    )
-    flagged = [
-        i for i in issues
-        if i.note_path == str(insight)
-        and not i.extra.get("unresolved")
-        and not i.extra.get("basename_only")
-    ]
-    assert len(flagged) == 1, (
-        f"expected 1 stale flag for mtime-signal insight, got {len(flagged)}: "
-        f"{[(i.confidence, i.extra) for i in flagged]}"
-    )
-    assert flagged[0].extra.get("capture_signal") == "mtime", (
-        f"test setup error: expected mtime signal, got {flagged[0].extra.get('capture_signal')}"
-    )
-    assert flagged[0].confidence <= 0.3, (
-        f"mtime-signal confidence must be <=0.3, got {flagged[0].confidence}"
-    )
-
 
 def test_scan_emits_unresolved_when_jsonl_exists_but_session_note_missing(
     doctor_vault, monkeypatch
@@ -1949,13 +1826,13 @@ def test_scan_reason_text_branches_by_signal(doctor_vault, monkeypatch):
     assert "matches session" in ca_issue.reason and "window" in ca_issue.reason
 
 
-def test_scan_reason_text_for_mtime_fallback_uses_point_in_window(
+def test_scan_reason_text_for_mtime_fallback_emits_unresolved(
     doctor_vault, monkeypatch
 ):
-    """Copilot R4-1: when capture_signal is 'mtime' AND there's no fm.date
-    AND no YYYY-MM-DD filename prefix, scan() falls through to the point-in-
-    window matcher (not day-overlap). Reason text must say 'capture_time
-    matches session window' not 'calendar day overlaps session window'.
+    """Issue #106: when capture_signal is 'mtime' AND there's no fm.date
+    AND no YYYY-MM-DD filename prefix, scan() now emits an unresolved WARN
+    (conf=0.0, no proposed SID) rather than a point-in-window SID rewrite.
+    mtime is too imprecise to anchor a date-window hint.
     """
     vault = doctor_vault["vault"]
     home = doctor_vault["home"]
@@ -1999,15 +1876,17 @@ def test_scan_reason_text_for_mtime_fallback_uses_point_in_window(
         project=project,
     )
     flagged = [i for i in issues if i.note_path == str(note)]
-    assert flagged, "mtime-only note should flag (mtime falls inside window)"
+    assert flagged, "mtime-only note should flag as unresolved (issue #106)"
     issue = flagged[0]
     assert issue.extra.get("capture_signal") == "mtime"
-    assert "capture_time" in issue.reason, (
-        f"mtime fallback uses point-in-window matcher; reason should say "
-        f"'capture_time' not 'calendar day'. Got: {issue.reason}"
+    assert issue.extra.get("unresolved") is True, (
+        f"mtime-only note must emit as unresolved, not a SID rewrite. Got: {issue!r}"
     )
-    assert "calendar day" not in issue.reason, (
-        f"mtime-fallback reason must not claim calendar-day overlap. Got: {issue.reason}"
+    assert issue.extra.get("signal_class") == "unresolved"
+    assert issue.confidence == 0.0
+    assert issue.proposed_source == ""
+    assert "mtime" in issue.reason, (
+        f"reason should mention mtime. Got: {issue.reason}"
     )
 
 
@@ -2072,8 +1951,8 @@ def test_convergence_guard_excludes_created_at_signal(doctor_vault, monkeypatch)
         f"got {len(created_at_flags)}"
     )
     for issue in created_at_flags:
-        assert issue.confidence == 0.95, (
-            f"created_at-signal flag must keep its 0.95 confidence — "
+        assert issue.confidence == 0.5, (
+            f"created_at-signal flag must keep its 0.5 confidence (issue #106 band) — "
             f"convergence guard should not cap created_at. Got: {issue.confidence}"
         )
         assert not issue.extra.get("convergence_warning"), (
@@ -2302,3 +2181,53 @@ def test_uuid_resolves_jsonl_window_outside_note_day_emits_warn(doctor_vault, mo
     assert flagged[0].extra.get("unresolved") is True
     assert flagged[0].proposed_source == ""
     assert flagged[0].extra.get("proposed_sid") in (None, "")
+
+
+def test_unknown_uuid_with_date_window_candidate_hint(doctor_vault, monkeypatch):
+    """Spec #106 test #5: source_session: 'unknown' + date-window candidate exists →
+    1 issue, conf=0.5, signal_class='date-window-hint', reason instructs operator
+    to content-grep before applying."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    sid_real = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+    r_first = datetime(2026, 4, 22, 9, 0, tzinfo=timezone.utc).timestamp()
+    r_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid_real}.jsonl",
+                 datetime.fromtimestamp(r_first, tz=timezone.utc).isoformat(),
+                 r_last)
+    sess = _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_real, "eeee")
+
+    bogus_sid = "00000000-0000-0000-0000-000000000099"
+    insight_path = vault / "claude-insights" / "2026-04-22-dwh.md"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-22\n"
+        f"source_session: {bogus_sid}\n"
+        f'source_session_note: "[[2026-04-22-bogus]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_path, (r_first + 1800, r_first + 1800))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [
+        i for i in issues
+        if i.note_path == str(insight_path) and not i.extra.get("unresolved")
+    ]
+    assert len(flagged) == 1
+    assert flagged[0].confidence == 0.5
+    assert flagged[0].extra.get("signal_class") == "date-window-hint"
+    assert flagged[0].extra.get("proposed_sid") == sid_real
+    assert sess.stem in flagged[0].proposed_source

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -83,7 +83,15 @@ def _write_insight(dir_path: Path, date: str, slug: str, project: str, src_sid: 
 
 
 def test_scan_flags_insight_stamped_to_wrong_session(doctor_vault, monkeypatch):
-    """Insight mtime falls in session-B window but references session-A → stale."""
+    """Insight dated 2026-04-10 references a source_session UUID not in the
+    session-note index; date-window matcher proposes session-B (same day).
+
+    NOTE (Issue #106): the UUID must NOT resolve to a known session note.
+    If it did, Phase 1's UUID-first path would emit uuid-day-mismatch (conf=0.0,
+    unresolved) and stop — never proposing a rewrite. This test exercises the
+    fall-through-to-date-matcher path that still fires when UUID is absent from
+    the global session-note index.
+    """
     import vault_doctor_checks.source_sessions as check
 
     v = doctor_vault["vault"]
@@ -91,7 +99,7 @@ def test_scan_flags_insight_stamped_to_wrong_session(doctor_vault, monkeypatch):
     jsonl_dir = doctor_vault["jsonl_dir"]
     monkeypatch.setenv("HOME", str(home))
 
-    # Session A: 2026-04-09 10:00–11:00
+    # Session A: 2026-04-09 10:00–11:00 (NOT referenced by the insight)
     a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
     a_end = a_start + 3600
     _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_end)
@@ -104,14 +112,16 @@ def test_scan_flags_insight_stamped_to_wrong_session(doctor_vault, monkeypatch):
     _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T10:00:00Z", b_end)
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
-    # Insight captured 2026-04-10 10:30 but wrongly stamped with sid-a
+    # Insight captured 2026-04-10 10:30 but wrongly stamped with a UUID that
+    # is NOT in the session-note index (so Phase 1 UUID-first does not intercept
+    # it, and the date-window matcher runs and proposes sid-b).
     insight_mtime = b_start + 1800
     _write_insight(
         v / "claude-insights",
         "2026-04-10",
         "stale-insight-0001",
         "proj1",
-        "sid-a",
+        "not-in-index-uuid",
         "2026-04-09-proj1-aaaa",
         insight_mtime,
     )
@@ -225,7 +235,13 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
 
 
 def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monkeypatch):
-    """After apply, only source_session/source_session_note change; body+tags preserved."""
+    """After apply, only source_session/source_session_note change; body+tags preserved.
+
+    NOTE (Issue #106): uses a source_session UUID that is NOT in the session-note
+    index so the date-window fall-through produces a rewritable issue. If the UUID
+    resolved to a session note on a different day, Phase 1 would emit uuid-day-mismatch
+    (unresolved) and apply() would skip it — making this test moot.
+    """
     import vault_doctor_checks.source_sessions as check
 
     v = doctor_vault["vault"]
@@ -242,13 +258,15 @@ def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monke
     _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
-    # Build an insight with extra tags and body content we want preserved
+    # Build an insight with extra tags and body content we want preserved.
+    # source_session is a UUID not in the session-note index so the date-window
+    # matcher can fire and produce a rewritable issue.
     note = v / "claude-insights" / "2026-04-10-rewrite-me.md"
     note.write_text(
         "---\n"
         "type: claude-insight\n"
         "date: 2026-04-10\n"
-        "source_session: sid-a\n"
+        "source_session: not-in-index-uuid\n"
         'source_session_note: "[[2026-04-09-proj1-aaaa]]"\n'
         "project: proj1\n"
         "tags:\n"
@@ -536,12 +554,15 @@ def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
     original_mtime = b_start + 1800  # 2026-04-10 10:30
+    # Use a source_session UUID not in the session-note index so Phase 1 UUID-first
+    # does not intercept it (Issue #106: if the UUID resolves to a session note on a
+    # different day, Phase 1 emits uuid-day-mismatch/unresolved and apply() skips it).
     _write_insight(
         v / "claude-insights",
         "2026-04-10",
         "mtime-preserve",
         "proj1",
-        "sid-a",
+        "not-in-index-uuid",
         "2026-04-09-proj1-aaaa",
         original_mtime,
     )
@@ -803,7 +824,14 @@ def test_scan_ignores_mtime_when_date_present(doctor_vault, monkeypatch):
 
 def test_scan_emits_capture_signal_and_confidence(doctor_vault, monkeypatch):
     """Issue.extra must include capture_signal and capture_confidence so the
-    skill report can flag low-confidence matches to the operator."""
+    skill report can flag low-confidence matches to the operator.
+
+    NOTE (Issue #106): the current source_session is set to a UUID that is NOT
+    in the session-note index. If it were in the index (and dated a different
+    day from the note), Phase 1 would emit uuid-day-mismatch (unresolved=True)
+    and stop — never setting proposed_sid to sid_correct. Using a UUID absent
+    from the index lets the date-window matcher run and propose sid_correct.
+    """
     vault = doctor_vault["vault"]
     home = doctor_vault["home"]
     jsonl_dir = doctor_vault["jsonl_dir"]
@@ -813,6 +841,11 @@ def test_scan_emits_capture_signal_and_confidence(doctor_vault, monkeypatch):
 
     day = "2026-04-22"
     sid_correct = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    # sid_wrong has neither a session note nor a JSONL file, so Phase 1 UUID-first
+    # does not intercept it (UUID not in global index, _find_jsonl_anywhere returns
+    # None → the else-branch no-ops). The date-window matcher then runs and proposes
+    # sid_correct. (Issue #106: if sid_wrong had a JSONL, Phase 1's else-branch would
+    # emit missing-session-note/unresolved and stop before the date-matcher.)
     sid_wrong = "wwwwwwww-wwww-wwww-wwww-wwwwwwwwwwww"
 
     ts_start = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
@@ -820,15 +853,9 @@ def test_scan_emits_capture_signal_and_confidence(doctor_vault, monkeypatch):
     _write_jsonl(jsonl_dir / f"{sid_correct}.jsonl",
                  datetime.fromtimestamp(ts_start, tz=timezone.utc).isoformat(),
                  ts_end)
-    # A different session whose window will be the *current* (wrong) source
-    other_start = datetime(2026, 4, 20, 10, 0, tzinfo=timezone.utc).timestamp()
-    other_end = datetime(2026, 4, 20, 18, 0, tzinfo=timezone.utc).timestamp()
-    _write_jsonl(jsonl_dir / f"{sid_wrong}.jsonl",
-                 datetime.fromtimestamp(other_start, tz=timezone.utc).isoformat(),
-                 other_end)
+    # No JSONL for sid_wrong: absent from both index and JSONL dir so Phase 1 skips.
 
     sess_correct = _write_session_note(vault / "claude-sessions", day, project, sid_correct, "1234")
-    _write_session_note(vault / "claude-sessions", "2026-04-20", project, sid_wrong, "5678")
 
     insight = _write_insight(
         vault / "claude-insights",
@@ -1550,11 +1577,17 @@ def test_scan_caps_mtime_signal_confidence_below_convergence_floor(doctor_vault,
     # Insight with NO created_at, NO date frontmatter, NO YYYY-MM-DD filename
     # prefix → mtime is the only available signal. Filename intentionally
     # avoids the date prefix.
+    #
+    # NOTE (Issue #106): source_session is set to a UUID not in the session-note
+    # index. If it were set to "sid-a" (which is in the index), Phase 1 UUID-first
+    # would intercept: with no date in the note, day_start=None → the basename
+    # check runs → basename matches ("2026-04-15-proj1-aaaa") → continue, skip
+    # matcher. The mtime-stale path would never fire.
     insight = vault / "claude-insights" / "no-date-prefix-mtime-only.md"
     insight.write_text(
         "---\n"
         "type: claude-insight\n"
-        f"source_session: sid-a\n"
+        f"source_session: not-in-index-mtime-uuid\n"
         f'source_session_note: "[[2026-04-15-{project}-aaaa]]"\n'
         f"project: {project}\n"
         "tags:\n"
@@ -2218,3 +2251,54 @@ def test_uuid_resolves_basename_matches_no_issue(doctor_vault, monkeypatch, capt
         f"capture_signal_kind={capture_signal_kind}: expected 0 issues "
         f"(UUID resolves + basename matches), got {len(flagged)}: {flagged}"
     )
+
+
+def test_uuid_resolves_jsonl_window_outside_note_day_emits_warn(doctor_vault, monkeypatch):
+    """Spec #106 test #4: UUID resolves but JSONL window does not overlap note's
+    day → 1 issue, conf=0.0, signal_class='uuid-day-mismatch', no SID rewrite."""
+    vault = doctor_vault["vault"]
+    home = doctor_vault["home"]
+    jsonl_dir = doctor_vault["jsonl_dir"]
+    project = doctor_vault["project"]
+    monkeypatch.setenv("HOME", str(home))
+
+    # Session ran on 2026-04-20 (window entirely before the note's day)
+    sid = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+    s_first = datetime(2026, 4, 20, 10, 0, tzinfo=timezone.utc).timestamp()
+    s_last = datetime(2026, 4, 20, 18, 0, tzinfo=timezone.utc).timestamp()
+    _write_jsonl(jsonl_dir / f"{sid}.jsonl",
+                 datetime.fromtimestamp(s_first, tz=timezone.utc).isoformat(),
+                 s_last)
+    _write_session_note(vault / "claude-sessions", "2026-04-20", project, sid, "dddd")
+
+    # Insight dated 2026-04-22 (two days after the JSONL window)
+    insight_path = vault / "claude-insights" / "2026-04-22-day-mismatch.md"
+    insight_path.write_text(
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: 2026-04-22\n"
+        f"source_session: {sid}\n"
+        f'source_session_note: "[[2026-04-22-proj1-mism]]"\n'
+        f"project: {project}\n"
+        f"---\n# stub\n",
+        encoding="utf-8",
+    )
+    os.utime(insight_path, (
+        datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc).timestamp(),
+        datetime(2026, 4, 22, 12, 0, tzinfo=timezone.utc).timestamp(),
+    ))
+
+    issues = ss.scan(
+        vault_path=str(vault),
+        sessions_folder="claude-sessions",
+        insights_folder="claude-insights",
+        days=10000,
+        project=project,
+    )
+    flagged = [i for i in issues if i.note_path == str(insight_path)]
+    assert len(flagged) == 1
+    assert flagged[0].confidence == 0.0
+    assert flagged[0].extra.get("signal_class") == "uuid-day-mismatch"
+    assert flagged[0].extra.get("unresolved") is True
+    assert flagged[0].proposed_source == ""
+    assert flagged[0].extra.get("proposed_sid") in (None, "")

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -82,62 +82,6 @@ def _write_insight(dir_path: Path, date: str, slug: str, project: str, src_sid: 
     return note
 
 
-def test_scan_flags_insight_stamped_to_wrong_session(doctor_vault, monkeypatch):
-    """Insight dated 2026-04-10 references a source_session UUID not in the
-    session-note index; date-window matcher proposes session-B (same day).
-
-    NOTE (Issue #106): the UUID must NOT resolve to a known session note.
-    If it did, Phase 1's UUID-first path would emit uuid-day-mismatch (conf=0.0,
-    unresolved) and stop — never proposing a rewrite. This test exercises the
-    fall-through-to-date-matcher path that still fires when UUID is absent from
-    the global session-note index.
-    """
-    import vault_doctor_checks.source_sessions as check
-
-    v = doctor_vault["vault"]
-    home = doctor_vault["home"]
-    jsonl_dir = doctor_vault["jsonl_dir"]
-    monkeypatch.setenv("HOME", str(home))
-
-    # Session A: 2026-04-09 10:00–11:00 (NOT referenced by the insight)
-    a_start = calendar.timegm(time.strptime("2026-04-09 10:00", "%Y-%m-%d %H:%M"))
-    a_end = a_start + 3600
-    _write_jsonl(jsonl_dir / "sid-a.jsonl", "2026-04-09T10:00:00Z", a_end)
-    _write_session_note(v / "claude-sessions", "2026-04-09", "proj1", "sid-a", "aaaa")
-
-    # Session B: 2026-04-10 10:00–14:00 (window must contain midday for the
-    # date-based capture_time match under the fix for issue #93)
-    b_start = calendar.timegm(time.strptime("2026-04-10 10:00", "%Y-%m-%d %H:%M"))
-    b_end = b_start + 4 * 3600
-    _write_jsonl(jsonl_dir / "sid-b.jsonl", "2026-04-10T10:00:00Z", b_end)
-    _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
-
-    # Insight captured 2026-04-10 10:30 but wrongly stamped with a UUID that
-    # is NOT in the session-note index (so Phase 1 UUID-first does not intercept
-    # it, and the date-window matcher runs and proposes sid-b).
-    insight_mtime = b_start + 1800
-    _write_insight(
-        v / "claude-insights",
-        "2026-04-10",
-        "stale-insight-0001",
-        "proj1",
-        "not-in-index-uuid",
-        "2026-04-09-proj1-aaaa",
-        insight_mtime,
-    )
-
-    issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
-    )
-    assert len(issues) == 1
-    iss = issues[0]
-    assert "stale-insight-0001" in iss.note_path
-    assert iss.current_source == "[[2026-04-09-proj1-aaaa]]"
-    assert iss.proposed_source == "[[2026-04-10-proj1-bbbb]]"
-    assert iss.project == "proj1"
-    assert iss.extra.get("proposed_sid") == "sid-b"
-
-
 def test_scan_ignores_correct_insight(doctor_vault, monkeypatch):
     """Insight mtime matches its referenced session window → not flagged."""
     import vault_doctor_checks.source_sessions as check
@@ -238,10 +182,10 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
 def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monkeypatch):
     """After apply, only source_session/source_session_note change; body+tags preserved.
 
-    NOTE (Issue #106): uses a source_session UUID that is NOT in the session-note
-    index so the date-window fall-through produces a rewritable issue. If the UUID
-    resolved to a session note on a different day, Phase 1 would emit uuid-day-mismatch
-    (unresolved) and apply() would skip it — making this test moot.
+    Uses the uuid-basename-stale scenario (Issue #106 Phase 1): source_session UUID
+    resolves to a known session note but source_session_note basename points to the
+    wrong session. scan() emits signal_class='uuid-basename-stale' (conf=0.99) which
+    apply() accepts. date-window-hint issues are blocked by the apply() guard.
     """
     import vault_doctor_checks.source_sessions as check
 
@@ -260,14 +204,15 @@ def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monke
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
     # Build an insight with extra tags and body content we want preserved.
-    # source_session is a UUID not in the session-note index so the date-window
-    # matcher can fire and produce a rewritable issue.
+    # source_session matches sid-b (in the index) but source_session_note
+    # erroneously points to session-A's note — the uuid-basename-stale
+    # scenario (Issue #106 Phase 1 UUID-first, conf=0.99, auto-applyable).
     note = v / "claude-insights" / "2026-04-10-rewrite-me.md"
     note.write_text(
         "---\n"
         "type: claude-insight\n"
         "date: 2026-04-10\n"
-        "source_session: not-in-index-uuid\n"
+        "source_session: sid-b\n"
         'source_session_note: "[[2026-04-09-proj1-aaaa]]"\n'
         "project: proj1\n"
         "tags:\n"
@@ -343,7 +288,7 @@ def test_apply_skips_unresolved(doctor_vault, tmp_path):
         proposed_source="",
         reason="no window",
         confidence=0.0,
-        extra={"unresolved": True},
+        extra={"unresolved": True, "signal_class": "unresolved"},
     )
 
     backup_root = tmp_path / "backups"
@@ -373,7 +318,7 @@ def test_apply_errors_on_missing_proposed_sid(doctor_vault, tmp_path):
         proposed_source="[[bar]]",  # proposed basename exists but extra['proposed_sid'] is missing
         reason="test",
         confidence=0.95,
-        extra={},  # no proposed_sid
+        extra={"signal_class": "uuid-basename-stale"},  # no proposed_sid
     )
 
     backup_root = tmp_path / "backups"
@@ -555,15 +500,16 @@ def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
     _write_session_note(v / "claude-sessions", "2026-04-10", "proj1", "sid-b", "bbbb")
 
     original_mtime = b_start + 1800  # 2026-04-10 10:30
-    # Use a source_session UUID not in the session-note index so Phase 1 UUID-first
-    # does not intercept it (Issue #106: if the UUID resolves to a session note on a
-    # different day, Phase 1 emits uuid-day-mismatch/unresolved and apply() skips it).
+    # source_session matches sid-b (in the index) but source_session_note
+    # erroneously points to session-A's note — uuid-basename-stale (conf=0.99,
+    # auto-applyable). Issue #106: only uuid-basename-stale issues can be
+    # auto-applied; date-window-hint issues are blocked by the apply() guard.
     _write_insight(
         v / "claude-insights",
         "2026-04-10",
         "mtime-preserve",
         "proj1",
-        "not-in-index-uuid",
+        "sid-b",
         "2026-04-09-proj1-aaaa",
         original_mtime,
     )
@@ -679,7 +625,7 @@ def test_apply_rejects_path_traversal_in_project_name(doctor_vault, tmp_path):
         proposed_source="[[new]]",
         reason="test",
         confidence=0.95,
-        extra={"proposed_sid": "sid-b"},
+        extra={"proposed_sid": "sid-b", "signal_class": "uuid-basename-stale"},
     )
 
     backup_root = tmp_path / "backups"
@@ -2107,3 +2053,39 @@ def test_unknown_uuid_with_date_window_candidate_hint(doctor_vault, monkeypatch)
     assert flagged[0].extra.get("signal_class") == "date-window-hint"
     assert flagged[0].extra.get("proposed_sid") == sid_real
     assert sess.stem in flagged[0].proposed_source
+
+
+def test_apply_raises_runtime_error_on_unknown_signal_class(tmp_path):
+    """Spec #106 (apply guard): apply() refuses any non-skipped Issue whose
+    signal_class != 'uuid-basename-stale', regardless of confidence value.
+    --min-confidence override-safety."""
+    from vault_doctor_checks import Issue
+
+    note_path = tmp_path / "note.md"
+    note_path.write_text(
+        "---\n"
+        "type: claude-insight\n"
+        "source_session: 99999999-9999-9999-9999-999999999999\n"
+        'source_session_note: "[[2026-04-22-stub]]"\n'
+        "---\n# stub\n",
+        encoding="utf-8",
+    )
+
+    bad = Issue(
+        check="source-sessions",
+        note_path=str(note_path),
+        project="proj1",
+        current_source='[[2026-04-22-stub]]',
+        proposed_source="[[2026-04-22-replacement]]",
+        reason="hypothetical bypass",
+        confidence=0.5,
+        extra={
+            "proposed_sid": "88888888-8888-8888-8888-888888888888",
+            "signal_class": "date-window-hint",
+            # NOTE: no "unresolved": True — to exercise the new guard.
+        },
+    )
+
+    backup_root = tmp_path / "backup"
+    with pytest.raises(RuntimeError, match="signal_class='date-window-hint'"):
+        ss.apply([bad], str(backup_root))

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -1135,59 +1135,6 @@ def test_scan_basename_only_repair_when_uuid_resolves(doctor_vault, monkeypatch)
 
 
 
-@pytest.mark.parametrize("n_flags", [2, 3, 5])
-def test_scan_convergence_guard_lowers_confidence(doctor_vault, monkeypatch, n_flags):
-    """When N>=2 flags in a project converge on the same proposed session,
-    confidence drops to <= 0.4 and convergence_warning is set, with
-    convergence_count == N (review T3)."""
-    vault = doctor_vault["vault"]
-    home = doctor_vault["home"]
-    jsonl_dir = doctor_vault["jsonl_dir"]
-    project = doctor_vault["project"]
-    monkeypatch.setenv("HOME", str(home))
-
-    # One real session whose window contains noon on the day notes claim
-    sid_real = "cccccccc-cccc-cccc-cccc-cccccccccc11"
-    r_first = datetime(2026, 4, 22, 10, 0, tzinfo=timezone.utc).timestamp()
-    r_last = datetime(2026, 4, 22, 18, 0, tzinfo=timezone.utc).timestamp()
-    _write_jsonl(jsonl_dir / f"{sid_real}.jsonl",
-                 datetime.fromtimestamp(r_first, tz=timezone.utc).isoformat(),
-                 r_last)
-    _write_session_note(vault / "claude-sessions", "2026-04-22", project, sid_real, "real")
-
-    # N insights with bogus UUIDs that don't resolve -> matcher proposes sid_real for all
-    for n in range(n_flags):
-        slug = f"converge-{n+1}"
-        # Distinct bogus UUIDs ensure the global SID index doesn't resolve them,
-        # which forces the day-overlap matcher to propose sid_real for each.
-        bogus = f"{n+1:08d}-1111-1111-1111-{n+1:012d}"
-        _write_insight(
-            vault / "claude-insights",
-            date="2026-04-22",
-            slug=slug,
-            project=project,
-            src_sid=bogus,
-            src_note_basename="2026-04-22-bogus",
-            mtime=r_first + 1800,
-        )
-
-    issues = ss.scan(
-        vault_path=str(vault),
-        sessions_folder="claude-sessions",
-        insights_folder="claude-insights",
-        days=10000,
-        project=project,
-    )
-    flagged = [i for i in issues if "converge" in i.note_path and i.extra.get("proposed_sid") == sid_real]
-    assert len(flagged) == n_flags, f"expected {n_flags} convergence flags, got {len(flagged)}"
-    for i in flagged:
-        assert i.extra.get("convergence_warning") is True, (
-            f"expected convergence_warning on {i.note_path}"
-        )
-        assert i.extra.get("convergence_count") == n_flags
-        assert i.confidence <= 0.4
-
-
 def test_scan_trusts_cross_midnight_source(doctor_vault, monkeypatch):
     """Phase 1b extension (issue #93): a session that started the night before
     note.date and ran into note.date is the legitimate cross-midnight case.
@@ -1888,77 +1835,6 @@ def test_scan_reason_text_for_mtime_fallback_emits_unresolved(
     assert "mtime" in issue.reason, (
         f"reason should mention mtime. Got: {issue.reason}"
     )
-
-
-def test_convergence_guard_excludes_created_at_signal(doctor_vault, monkeypatch):
-    """Copilot R4-2: created_at signal uses point-in-window matching with
-    sub-day precision. Two legitimate stale insights from the same session
-    sharing a proposal target is normal — not heuristic collapse — so they
-    must NOT be capped to 0.4 by the convergence guard.
-    """
-    vault = doctor_vault["vault"]
-    home = doctor_vault["home"]
-    jsonl_dir = doctor_vault["jsonl_dir"]
-    project = doctor_vault["project"]
-    monkeypatch.setenv("HOME", str(home))
-
-    sid_target = "66666666-6666-6666-6666-666666666666"
-    t_first = datetime(2026, 4, 25, 9, 0, tzinfo=timezone.utc).timestamp()
-    t_last = datetime(2026, 4, 25, 18, 0, tzinfo=timezone.utc).timestamp()
-    _write_jsonl(
-        jsonl_dir / f"{sid_target}.jsonl",
-        datetime.fromtimestamp(t_first, tz=timezone.utc).isoformat(),
-        t_last,
-    )
-    _write_session_note(
-        vault / "claude-sessions", "2026-04-25", project, sid_target, "tgt6"
-    )
-
-    # Two insights with created_at signal both stale-pointing at a missing UUID.
-    # Both will be matched to sid_target (point-in-window). Without the R4-2
-    # fix, the convergence guard would cap both to 0.4 — a false positive.
-    for slug, ts in (("alpha", "2026-04-25T10:00:00+00:00"),
-                     ("beta", "2026-04-25T11:30:00+00:00")):
-        n = vault / "claude-insights" / f"created-at-conv-{slug}.md"
-        n.write_text(
-            "---\n"
-            "type: claude-insight\n"
-            f"created_at: {ts}\n"
-            "source_session: 00000000-0000-0000-0000-000000000066\n"
-            'source_session_note: "[[bogus]]"\n'
-            f"project: {project}\n"
-            "tags:\n"
-            f"  - claude/insight\n"
-            "---\n# x\n",
-            encoding="utf-8",
-        )
-        os.utime(n, (t_first + 3600, t_first + 3600))
-
-    issues = ss.scan(
-        vault_path=str(vault),
-        sessions_folder="claude-sessions",
-        insights_folder="claude-insights",
-        days=10000,
-        project=project,
-    )
-    created_at_flags = [
-        i for i in issues
-        if i.extra.get("capture_signal") == "created_at"
-        and i.extra.get("proposed_sid") == sid_target
-    ]
-    assert len(created_at_flags) == 2, (
-        f"expected exactly 2 created_at flags converging on {sid_target}, "
-        f"got {len(created_at_flags)}"
-    )
-    for issue in created_at_flags:
-        assert issue.confidence == 0.5, (
-            f"created_at-signal flag must keep its 0.5 confidence (issue #106 band) — "
-            f"convergence guard should not cap created_at. Got: {issue.confidence}"
-        )
-        assert not issue.extra.get("convergence_warning"), (
-            f"convergence_warning must be False for created_at flags. "
-            f"Got: {issue.extra}"
-        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Refactors `vault-doctor source-sessions` detection around a uniform UUID-first contract. Eliminates the conf=0.4–0.6 wrong-pick class. Adds defense-in-depth on `apply()` keyed on `signal_class`.

- UUID-first runs uniformly across all capture-time signals (drops `capture_signal != "created_at"` carve-out).
- Strict 3-band confidence: 0.99 / 0.5 / 0.0.
- New WARN signal_class `uuid-day-mismatch` for cross-day mis-stamps.
- `apply()` refuses to write unless `signal_class == "uuid-basename-stale"`.
- `--json` output now exposes `signal_class` in each issue payload (spec requirement).
- 5 new tests, 6 retired, 4 updated (per spec); plus minimal fixture-shape adaptations across CLI and integration tests where the new guard reshaped applyable Issue requirements.

Spec: `docs/superpowers/specs/2026-05-07-vault-doctor-uuid-first-detection-design.md`
Plan: `docs/superpowers/plans/2026-05-07-vault-doctor-uuid-first-detection.md`

Closes #106.

## Live-vault scan (Task 8)

Run against `/Users/abhishek/obsidian/claude-code-vault` on 2026-05-08:

- Total issues: 1
- conf=0.6 count: **0** (regression-free)
- signal_class distribution: `uuid-day-mismatch: 1` (conf=0.0, manual verify, no auto-rewrite)

## Test plan

- [x] Full pytest suite GREEN with coverage ≥90% (975 passed, 90.90% coverage — preflight runs every commit).
- [ ] Reviewer: confirm no regression in cross-midnight session detection (`test_scan_trusts_cross_midnight_source`).
- [ ] Live-vault scan: report `conf=0.6` count and signal_class distribution (see Task 8 step 1 — already run above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)