### PR TITLE
feat(check-items): L2 evidence-presence prefilter + telemetry (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- L2 evidence-presence pre-filter for `/check-items` Stage 4 (`hooks/check_items_prefilter.py`).
+  Items with no token overlap with the evidence bundle and no `#N`/commit-sha references are
+  classified as ACTIVE or STALE (LOW confidence) without dispatching a `claude -p` sub-agent.
+  Bypass with `CHECK_ITEMS_PREFILTER=off`. (#160)
+- Telemetry line on every Stage 4 run: `[check-items-cli] classifier: total=N cache_hit=- prefiltered=P subagent=S wall=Ws`
+  emitted to stderr for verification and debugging. (#160)
+- `mtime` field threaded through `classify_groups_with_agent` payload so L2 can compute item
+  age (STALE threshold: >90 days since earliest member mtime). (#160)
+
+### Fixed
+- Reduced `claude -p` sub-agent invocations for vaults with many open items that lack
+  completion evidence, addressing the timeout root cause reported in issue #160.
+
 ## [2.5.0] - 2026-05-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -258,6 +258,13 @@ Machine-local config at `~/.claude/obsidian-brain-config.json`:
 }
 ```
 
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CHECK_ITEMS_PREFILTER` | `on` | Set to `off` to disable the L2 evidence-presence pre-filter and route all L1-miss items to the `claude -p` sub-agent. Useful for debugging or A/B comparison. L1 cache is unaffected. |
+| `CHECK_ITEMS_SUBAGENT_TIMEOUT_SEC` | `180` | Timeout in seconds for each `claude -p` sub-agent call during `/check-items` Stage 4 classification. |
+
 ## Multi-Device Support
 
 - **Obsidian Sync:** Works seamlessly — all vault writes are new markdown files (no conflict risk). Config lives at `~/.claude/` (machine-local, outside the vault).

--- a/hooks/check_items_cli.py
+++ b/hooks/check_items_cli.py
@@ -372,10 +372,25 @@ def _bridge_project_evidence(evidence: dict, project: str) -> dict:
     if _TEXT_KEYS.intersection(evidence.keys()):
         return evidence
 
-    # Unknown shape or missing project → no evidence (fail-safe)
-    # Warn when the evidence dict has keys but matches neither shape — this
-    # indicates a payload format change and would silently STALE all groups
-    # without this diagnostic.
+    # Unknown shape or missing project → no evidence (fail-safe).
+    # Before warning, check whether the payload IS a valid shape A for a
+    # different project (multi-project payload, this group's project not
+    # present). Shape A is recognized by any top-level value being a dict
+    # that contains at least one bare evidence key. In that case, the
+    # legitimate answer is "no evidence for this project" — return {} silently.
+    # Only WARN when neither shape A nor shape B is recognizable at all.
+    _BARE_KEYS = {"commits", "merged_prs", "closed_issues", "releases",
+                  "changelog_excerpt", "fts_mentions"}
+    _is_shape_a_payload = any(
+        isinstance(v, dict) and _BARE_KEYS.intersection(v.keys())
+        for v in evidence.values()
+    )
+    if _is_shape_a_payload:
+        # Valid shape A payload, but project not present — no evidence for this group.
+        return {}
+
+    # Genuinely unrecognized shape — warn, as this indicates a format change
+    # that would silently STALE all groups without this diagnostic.
     if evidence:
         print(
             f"[check-items-cli] WARN: _bridge_project_evidence unrecognized shape "

--- a/hooks/check_items_cli.py
+++ b/hooks/check_items_cli.py
@@ -373,6 +373,15 @@ def _bridge_project_evidence(evidence: dict, project: str) -> dict:
         return evidence
 
     # Unknown shape or missing project → no evidence (fail-safe)
+    # Warn when the evidence dict has keys but matches neither shape — this
+    # indicates a payload format change and would silently STALE all groups
+    # without this diagnostic.
+    if evidence:
+        print(
+            f"[check-items-cli] WARN: _bridge_project_evidence unrecognized shape "
+            f"for project={project!r}; top-level keys={list(evidence.keys())[:10]}",
+            file=sys.stderr,
+        )
     return {}
 
 
@@ -405,6 +414,20 @@ def run_classifier(stdin_json: str, output_path: str) -> int:
 
     groups = payload.get("groups", [])
     evidence = payload.get("evidence", {})
+
+    # -----------------------------------------------------------------------
+    # Validate group_id presence — a None group_id causes silent key collision
+    # in merged_by_id, so two groups overwrite each other and the ordered list
+    # contains the same record twice.  Fail fast with a clear diagnostic.
+    # -----------------------------------------------------------------------
+    invalid_ids = [i for i, g in enumerate(groups) if g.get("group_id") is None]
+    if invalid_ids:
+        print(
+            f"[check-items-cli] ERROR: {len(invalid_ids)} group(s) have group_id=None "
+            f"(indices {invalid_ids[:10]}); cannot merge — aborting classifier",
+            file=sys.stderr,
+        )
+        return 5
 
     # -----------------------------------------------------------------------
     # L2: evidence-presence pre-filter
@@ -482,6 +505,13 @@ def run_classifier(stdin_json: str, output_path: str) -> int:
                 sub_results = json.loads(Path(output_path).read_text(encoding="utf-8"))
             except json.JSONDecodeError as exc:
                 print(f"[check-items-cli] classifier output invalid JSON: {exc}", file=sys.stderr)
+                return 4
+            if not _validate_classifier_payload(sub_results):
+                print(
+                    "[check-items-cli] classifier file-path output produced invalid shape"
+                    f" (expected list of classifier objects, got {type(sub_results).__name__})",
+                    file=sys.stderr,
+                )
                 return 4
         else:
             try:

--- a/hooks/check_items_cli.py
+++ b/hooks/check_items_cli.py
@@ -513,14 +513,14 @@ def run_classifier(stdin_json: str, output_path: str) -> int:
     os.chmod(output_path, 0o600)
 
     # -----------------------------------------------------------------------
-    # Telemetry (Task 7 stub — full implementation in Task 7)
+    # Telemetry — inner line (CLI sees only L1-miss groups; cache_hit is '-'
+    # by design — the orchestration layer in open_item_dedup.py holds that
+    # count and emits the outer classifier-result line with real cache_hit).
     # -----------------------------------------------------------------------
     _wall = int(_time.monotonic() - _wall_start)
     total = len(groups)
     prefiltered_count = len(synthetic)
     subagent_count = len(sub_results)
-    # cache_hit is tracked by the SKILL.md orchestration layer (partition()),
-    # not here. Emit '-' as placeholder; see Task 7b for outer telemetry line.
     print(
         f"[check-items-cli] classifier: total={total} cache_hit=- "
         f"prefiltered={prefiltered_count} subagent={subagent_count} wall={_wall}s",

--- a/hooks/check_items_cli.py
+++ b/hooks/check_items_cli.py
@@ -316,15 +316,86 @@ def _pick_classifier_model(group_count: int) -> str:
     return "haiku" if group_count <= 30 else "sonnet"
 
 
+def _bridge_project_evidence(evidence: dict, project: str) -> dict:
+    """Convert project evidence to the _text-suffixed flat format expected by
+    has_classifiable_evidence().
+
+    The live evidence payload from open_item_dedup.py uses a project-keyed nested
+    structure with bare keys:
+        {project_name: {"commits": [...], "merged_prs": [...], ...}}
+
+    has_classifiable_evidence() expects a flat dict with _text-suffixed keys:
+        {"commits_text": "...", "merged_prs_text": "...", ...}
+
+    This helper bridges both shapes:
+    - If the evidence dict contains the project key AND its value is a dict
+      with bare keys → extract and convert to _text form.
+    - If the evidence dict already has _text-suffixed keys at the top level
+      (test fixtures, simplified payloads) → return as-is.
+    - If neither shape matches → return empty dict (fail-safe: no evidence → synthetic).
+    """
+    # Shape A: project-nested bare keys (production shape from open_item_dedup.py)
+    if project and project in evidence and isinstance(evidence[project], dict):
+        proj = evidence[project]
+        # Convert list/dict values to text by joining stringified items
+        def _to_text(val) -> str:
+            if not val:
+                return ""
+            if isinstance(val, str):
+                return val
+            if isinstance(val, list):
+                parts = []
+                for item in val:
+                    if isinstance(item, str):
+                        parts.append(item)
+                    elif isinstance(item, dict):
+                        # merged_prs / closed_issues are dicts with title, number, etc.
+                        parts.append(" ".join(str(v) for v in item.values() if v))
+                return " ".join(parts)
+            if isinstance(val, dict):
+                # fts_mentions: {text: count} — join all keys
+                return " ".join(str(k) for k in val)
+            return str(val)
+
+        return {
+            "commits_text": _to_text(proj.get("commits")),
+            "merged_prs_text": _to_text(proj.get("merged_prs")),
+            "closed_issues_text": _to_text(proj.get("closed_issues")),
+            "releases_text": _to_text(proj.get("releases")),
+            "changelog_excerpt": proj.get("changelog_excerpt") or "",
+            "fts_mentions_text": _to_text(proj.get("fts_mentions")),
+        }
+
+    # Shape B: already _text-suffixed at top level (test fixtures / simplified payloads)
+    _TEXT_KEYS = {"commits_text", "merged_prs_text", "closed_issues_text",
+                  "releases_text", "changelog_excerpt", "fts_mentions_text"}
+    if _TEXT_KEYS.intersection(evidence.keys()):
+        return evidence
+
+    # Unknown shape or missing project → no evidence (fail-safe)
+    return {}
+
+
 def run_classifier(stdin_json: str, output_path: str) -> int:
     """
-    Stage 4: invoke the classifier sub-agent.
+    Stage 4: invoke the classifier sub-agent, with L2 evidence-presence
+    pre-filter applied to all groups before any claude -p dispatch.
 
-    Reads merged groups + evidence from stdin_json, writes a strict-JSON
-    array of {group_id, classification, confidence, canonical_text,
-    evidence_citation, action_required} to output_path. Returns 0 on
-    success, non-zero on failure.
+    Flow:
+      1. Parse stdin JSON to extract groups + evidence.
+      2. Apply L2 pre-filter (if enabled): items with no evidence go to
+         synthetic_classification(); items with evidence go to the sub-agent.
+      3. If to_classify is non-empty, dispatch claude -p exactly once on
+         the reduced payload.
+      4. Merge sub-agent results + synthetic results in input order.
+      5. Write merged output to output_path (0o600).
+      6. Emit telemetry line to stderr.
+
+    Returns 0 on success, non-zero on failure.
     """
+    import time as _time
+    _wall_start = _time.monotonic()
+
     try:
         payload = json.loads(stdin_json)
     except json.JSONDecodeError as exc:
@@ -333,60 +404,128 @@ def run_classifier(stdin_json: str, output_path: str) -> int:
         return 2
 
     groups = payload.get("groups", [])
-    model = _pick_classifier_model(len(groups))
+    evidence = payload.get("evidence", {})
 
-    workdir = _safe_workdir()
-    in_tmp = tempfile.NamedTemporaryFile(
-        mode="w", delete=False, dir=str(workdir), suffix=".classin.json", encoding="utf-8"
-    )
-    try:
-        json.dump(payload, in_tmp)
-        in_tmp.flush()
-    finally:
-        in_tmp.close()
-    os.chmod(in_tmp.name, 0o600)
-
-    prompt = CLASSIFIER_PROMPT.replace(
-        "<input-json-path>", in_tmp.name
-    ).replace(
-        "<output-json-path>", output_path
+    # -----------------------------------------------------------------------
+    # L2: evidence-presence pre-filter
+    # Groups reaching this function are already L1-miss (partition() in the
+    # SKILL.md orchestration layer handled cache hits before calling the CLI).
+    # -----------------------------------------------------------------------
+    from check_items_prefilter import (
+        has_classifiable_evidence,
+        synthetic_classification,
+        is_prefilter_enabled,
     )
 
-    cmd = ["claude", "-p", "--model", model]
-    try:
-        cp = subprocess.run(
-            cmd, input=prompt, capture_output=True, text=True, timeout=SUBAGENT_TIMEOUT_SEC
+    synthetic: list = []
+    to_classify: list = list(groups)
+
+    if is_prefilter_enabled() and groups:
+        to_classify = []
+        for g in groups:
+            project = g.get("project", "")
+            bridged_evidence = _bridge_project_evidence(evidence, project)
+            if has_classifiable_evidence(g, bridged_evidence):
+                to_classify.append(g)
+            else:
+                synthetic.append(synthetic_classification(g))
+
+    # -----------------------------------------------------------------------
+    # Sub-agent dispatch — only on groups that have evidence
+    # -----------------------------------------------------------------------
+    sub_results: list = []
+
+    if to_classify:
+        model = _pick_classifier_model(len(to_classify))
+
+        workdir = _safe_workdir()
+        in_tmp = tempfile.NamedTemporaryFile(
+            mode="w", delete=False, dir=str(workdir), suffix=".classin.json", encoding="utf-8"
         )
-    except subprocess.TimeoutExpired:
-        print(f"[check-items-cli] classifier timeout after {SUBAGENT_TIMEOUT_SEC}s",
-              file=sys.stderr)
-        return 3
-    finally:
         try:
-            os.unlink(in_tmp.name)
-        except OSError:
-            pass
+            sub_payload = {"groups": to_classify, "evidence": evidence}
+            json.dump(sub_payload, in_tmp)
+            in_tmp.flush()
+        finally:
+            in_tmp.close()
+        os.chmod(in_tmp.name, 0o600)
 
-    if cp.returncode != 0:
-        print(f"[check-items-cli] classifier failed rc={cp.returncode}: {cp.stderr[:500]}",
-              file=sys.stderr)
-        return cp.returncode
+        prompt = CLASSIFIER_PROMPT.replace(
+            "<input-json-path>", in_tmp.name
+        ).replace(
+            "<output-json-path>", output_path
+        )
 
-    if not Path(output_path).exists():
+        cmd = ["claude", "-p", "--model", model]
         try:
-            parsed = json.loads(_strip_json_fences(cp.stdout))
-        except json.JSONDecodeError as exc:
-            print(f"[check-items-cli] classifier output invalid JSON: {exc}", file=sys.stderr)
-            return 4
-        if not _validate_classifier_payload(parsed):
-            print(
-                "[check-items-cli] classifier stdout-fallback produced invalid shape"
-                f" (expected list of classifier objects, got {type(parsed).__name__})",
-                file=sys.stderr,
+            cp = subprocess.run(
+                cmd, input=prompt, capture_output=True, text=True, timeout=SUBAGENT_TIMEOUT_SEC
             )
-            return 4
-        Path(output_path).write_text(json.dumps(parsed), encoding="utf-8")
-        os.chmod(output_path, 0o600)
+        except subprocess.TimeoutExpired:
+            print(f"[check-items-cli] classifier timeout after {SUBAGENT_TIMEOUT_SEC}s",
+                  file=sys.stderr)
+            return 3
+        finally:
+            try:
+                os.unlink(in_tmp.name)
+            except OSError:
+                pass
+
+        if cp.returncode != 0:
+            print(f"[check-items-cli] classifier failed rc={cp.returncode}: {cp.stderr[:500]}",
+                  file=sys.stderr)
+            return cp.returncode
+
+        # Load sub-agent results from output_path or stdout fallback
+        if Path(output_path).exists():
+            try:
+                sub_results = json.loads(Path(output_path).read_text(encoding="utf-8"))
+            except json.JSONDecodeError as exc:
+                print(f"[check-items-cli] classifier output invalid JSON: {exc}", file=sys.stderr)
+                return 4
+        else:
+            try:
+                parsed = json.loads(_strip_json_fences(cp.stdout))
+            except json.JSONDecodeError as exc:
+                print(f"[check-items-cli] classifier output invalid JSON: {exc}", file=sys.stderr)
+                return 4
+            if not _validate_classifier_payload(parsed):
+                print(
+                    "[check-items-cli] classifier stdout-fallback produced invalid shape"
+                    f" (expected list of classifier objects, got {type(parsed).__name__})",
+                    file=sys.stderr,
+                )
+                return 4
+            sub_results = parsed
+
+    # -----------------------------------------------------------------------
+    # Merge in input order and write final output
+    # -----------------------------------------------------------------------
+    merged_by_id: dict = {}
+    for s in sub_results:
+        merged_by_id[s["group_id"]] = s
+    for s in synthetic:
+        merged_by_id[s["group_id"]] = s
+
+    ordered = [merged_by_id[g["group_id"]] for g in groups if g["group_id"] in merged_by_id]
+
+    Path(output_path).write_text(json.dumps(ordered), encoding="utf-8")
+    os.chmod(output_path, 0o600)
+
+    # -----------------------------------------------------------------------
+    # Telemetry (Task 7 stub — full implementation in Task 7)
+    # -----------------------------------------------------------------------
+    _wall = int(_time.monotonic() - _wall_start)
+    total = len(groups)
+    prefiltered_count = len(synthetic)
+    subagent_count = len(sub_results)
+    # cache_hit is tracked by the SKILL.md orchestration layer (partition()),
+    # not here. Emit '-' as placeholder; see Task 7b for outer telemetry line.
+    print(
+        f"[check-items-cli] classifier: total={total} cache_hit=- "
+        f"prefiltered={prefiltered_count} subagent={subagent_count} wall={_wall}s",
+        file=sys.stderr,
+    )
 
     return 0
 

--- a/hooks/check_items_prefilter.py
+++ b/hooks/check_items_prefilter.py
@@ -1,0 +1,26 @@
+"""L2 pre-filter for /check-items Stage 4.
+
+Deterministic triage that classifies items with no plausible completion
+evidence as ACTIVE/STALE without dispatching a claude -p sub-agent.
+Python stdlib only. Per spec docs/superpowers/specs/2026-05-15-check-items-call-reduction-design.md.
+"""
+from __future__ import annotations
+
+import re
+
+STOPWORDS = frozenset({
+    "the", "and", "or", "for", "of", "to", "in", "is", "a", "an",
+    "that", "this", "with", "on", "by", "it", "as", "be", "are",
+})
+
+REF_PATTERN = re.compile(r'(?<!\w)#\d+\b|\b[0-9a-f]{7,40}\b')
+
+_WORD_RE = re.compile(r'\w+')
+
+
+def _content_tokens(text: str) -> list[str]:
+    """Extract content-bearing tokens from text. Drops stopwords and tokens shorter than 3 chars."""
+    if not text:
+        return []
+    return [t for t in _WORD_RE.findall(text)
+            if t.lower() not in STOPWORDS and len(t) > 2]

--- a/hooks/check_items_prefilter.py
+++ b/hooks/check_items_prefilter.py
@@ -6,6 +6,7 @@ Python stdlib only. Per spec docs/superpowers/specs/2026-05-15-check-items-call-
 """
 from __future__ import annotations
 
+import os
 import re
 import time
 
@@ -122,3 +123,14 @@ def synthetic_classification(group: dict, now: float | None = None) -> dict:
         "action_required": None,
         "prefiltered": True,
     }
+
+
+def is_prefilter_enabled() -> bool:
+    """Return True unless CHECK_ITEMS_PREFILTER=off (case-insensitive).
+
+    Default: enabled. Set CHECK_ITEMS_PREFILTER=off to skip L2 and route
+    all L1-miss items directly to the sub-agent (useful for A/B comparison
+    and debugging). L1 cache is unaffected by this flag.
+    """
+    val = os.environ.get("CHECK_ITEMS_PREFILTER", "on")
+    return val.strip().lower() != "off"

--- a/hooks/check_items_prefilter.py
+++ b/hooks/check_items_prefilter.py
@@ -24,3 +24,46 @@ def _content_tokens(text: str) -> list[str]:
         return []
     return [t for t in _WORD_RE.findall(text)
             if t.lower() not in STOPWORDS and len(t) > 2]
+
+
+def has_classifiable_evidence(group: dict, evidence: dict) -> bool:
+    """Return True if the group has any plausible completion evidence.
+
+    Two checks (first match wins):
+    1. Explicit issue/PR/commit-sha references in canonical_text — let the
+       sub-agent handle anti-conflation (spec § Anti-conflation rule).
+    2. Token overlap between canonical_text content tokens and the evidence
+       bundle haystack.
+
+    Args:
+        group: A group dict with at minimum a 'representative' field containing
+               the canonical text. May also carry 'instances' list with 'text'.
+        evidence: Dict with optional keys: commits_text, merged_prs_text,
+                  closed_issues_text, releases_text, changelog_excerpt,
+                  fts_mentions_text. Any missing key is treated as empty string.
+
+    Returns:
+        True if the sub-agent should classify this item; False if L2 can
+        synthesize a result deterministically.
+    """
+    canonical_text = group.get("representative") or group.get("canonical_text", "")
+
+    # Check 1: explicit issue/PR/commit-sha reference
+    if REF_PATTERN.search(canonical_text):
+        return True
+
+    # Check 2: token overlap with evidence bundle
+    tokens = _content_tokens(canonical_text)
+    if not tokens:
+        return False
+
+    haystack = "\n".join([
+        evidence.get("commits_text") or "",
+        evidence.get("merged_prs_text") or "",
+        evidence.get("closed_issues_text") or "",
+        evidence.get("releases_text") or "",
+        evidence.get("changelog_excerpt") or "",
+        evidence.get("fts_mentions_text") or "",
+    ]).lower()
+
+    return any(t.lower() in haystack for t in tokens)

--- a/hooks/check_items_prefilter.py
+++ b/hooks/check_items_prefilter.py
@@ -95,7 +95,7 @@ def synthetic_classification(group: dict, now: float | None = None) -> dict:
     Args:
         group: Group dict with 'group_id', 'representative' (canonical text),
                and 'instances' list. Each instance may carry 'mtime' (float,
-               seconds since epoch; from Task 1 threading in open_item_dedup.py).
+               seconds since epoch; threaded from member dicts in classify_groups_with_agent).
         now: Current time as float (seconds since epoch). Defaults to time.time().
              Injectable for deterministic tests.
 

--- a/hooks/check_items_prefilter.py
+++ b/hooks/check_items_prefilter.py
@@ -7,6 +7,7 @@ Python stdlib only. Per spec docs/superpowers/specs/2026-05-15-check-items-call-
 from __future__ import annotations
 
 import re
+import time
 
 STOPWORDS = frozenset({
     "the", "and", "or", "for", "of", "to", "in", "is", "a", "an",
@@ -67,3 +68,57 @@ def has_classifiable_evidence(group: dict, evidence: dict) -> bool:
     ]).lower()
 
     return any(t.lower() in haystack for t in tokens)
+
+
+_STALE_THRESHOLD_DAYS = 90
+_STALE_THRESHOLD_SECS = _STALE_THRESHOLD_DAYS * 86_400
+
+
+def synthetic_classification(group: dict, now: float | None = None) -> dict:
+    """Produce a synthetic classification record for a group with no evidence.
+
+    Decision matrix (per spec § L2 Decision matrix):
+    - Item age > 90 days since oldest (smallest) member mtime → STALE / LOW
+    - Item age <= 90 days                                     → ACTIVE / LOW
+
+    Age is derived from the oldest (smallest) mtime across the group's
+    'instances' list. If mtime is 0 or missing, defaults to 0 (epoch),
+    which yields an age larger than any threshold → STALE.
+
+    The returned record shape matches _validate_classifier_payload():
+        group_id, classification, confidence, canonical_text,
+        evidence_citation, action_required.
+    Plus the L2-specific marker: prefiltered=True.
+    L2 synthetic records are NOT written to the L1 cache.
+
+    Args:
+        group: Group dict with 'group_id', 'representative' (canonical text),
+               and 'instances' list. Each instance may carry 'mtime' (float,
+               seconds since epoch; from Task 1 threading in open_item_dedup.py).
+        now: Current time as float (seconds since epoch). Defaults to time.time().
+             Injectable for deterministic tests.
+
+    Returns:
+        Classification dict compatible with the classifier output schema.
+    """
+    if now is None:
+        now = time.time()
+
+    instances = group.get("instances", [])
+    mtimes = [float(inst.get("mtime", 0)) for inst in instances]
+    earliest_mtime = min(mtimes) if mtimes else 0.0
+
+    age_secs = now - earliest_mtime
+    classification = "STALE" if age_secs > _STALE_THRESHOLD_SECS else "ACTIVE"
+
+    canonical_text = group.get("representative") or group.get("canonical_text", "")
+
+    return {
+        "group_id": group.get("group_id"),
+        "classification": classification,
+        "confidence": "LOW",
+        "canonical_text": canonical_text,
+        "evidence_citation": None,
+        "action_required": None,
+        "prefiltered": True,
+    }

--- a/hooks/open_item_dedup.py
+++ b/hooks/open_item_dedup.py
@@ -126,6 +126,24 @@ def _tokenize(text: str) -> set[str]:
     return {w for w in words if len(w) >= 3 and w not in _STOPWORDS}
 
 
+def _safe_mtime(path: str) -> float:
+    """Return os.path.getmtime(path), falling back to 0.0 on OSError.
+
+    0.0 (epoch) is the safe-conservative fallback: age = now - 0 is always
+    > 90 days, so L2 classifies the item as STALE rather than silently
+    treating a stat-failure as ACTIVE. A one-line warning is emitted to
+    stderr so the failure is visible in hook logs.
+    """
+    try:
+        return os.path.getmtime(path)
+    except OSError as exc:
+        print(
+            f"[obsidian-brain] mtime unavailable for {path!r}: {exc}; defaulting to 0 (STALE)",
+            file=sys.stderr,
+        )
+        return 0.0
+
+
 def collect_open_items(
     vault_path: str,
     sessions_folder: str,
@@ -808,6 +826,7 @@ def deep_analysis_pipeline(
                     "file": os.path.basename(fpath),
                     "line": line_num,
                     "text": item_text,
+                    "mtime": _safe_mtime(fpath),
                 }]
                 for df, dl, dt, dc in dupes:
                     # Mark dupe indices as seen
@@ -819,6 +838,7 @@ def deep_analysis_pipeline(
                         "line": dl,
                         "text": dt,
                         "confidence": dc,
+                        "mtime": _safe_mtime(df),
                     })
                 all_groups.append({
                     "project": project,

--- a/hooks/open_item_dedup.py
+++ b/hooks/open_item_dedup.py
@@ -1402,7 +1402,13 @@ def classify_groups_with_agent(merged_groups, evidence):
                 "project": g.get("project"),
                 "representative": g.get("representative", ""),
                 "instances": [
-                    {"file": m.get("file"), "line": m.get("line"), "text": m.get("text", "")}
+                    {
+                        "file": m.get("file"),
+                        "line": m.get("line"),
+                        "text": m.get("text", ""),
+                        # Missing mtime → 0 → epoch (1970), which L2 bins as STALE (fail-safe).
+                        "mtime": m.get("mtime", 0),
+                    }
                     for m in g.get("members", [])
                 ],
             }

--- a/hooks/open_item_dedup.py
+++ b/hooks/open_item_dedup.py
@@ -1471,6 +1471,17 @@ def classify_groups_with_agent(merged_groups, evidence):
             if cp.returncode != 0 or not out_path.exists():
                 continue
             candidate = json.loads(out_path.read_text())
+            # I4: warn early (pre-validation) so the diagnostic is always
+            # reachable, even though _validate_classifier_response will still
+            # reject the whole response if any non-dict is present.
+            if isinstance(candidate, list):
+                _non_dict = sum(1 for r in candidate if not isinstance(r, dict))
+                if _non_dict:
+                    print(
+                        f"[check-items] WARN: classifier emitted {_non_dict} non-dict"
+                        f" records — dropped",
+                        file=sys.stderr,
+                    )
             if not _validate_classifier_response(candidate):
                 continue
             parsed = candidate
@@ -1498,18 +1509,11 @@ def classify_groups_with_agent(merged_groups, evidence):
     # classify_groups_with_agent's signature is invasive; dropping it
     # entirely (emitting '-' from the CLI side) is cleaner than a placeholder.
     #
-    # All three counts derive from `parsed` (the output) so the invariant
-    # `total_classified == prefiltered + subagent` holds by construction
-    # even if the CLI returned fewer records than merged_groups (partial
-    # parse, dropped entries). Each dict-shaped entry is counted into
-    # exactly one bucket via direct iteration — no subtraction that could
-    # go negative when isinstance excludes malformed entries.
-    _dropped = sum(1 for r in parsed if not isinstance(r, dict))
-    if _dropped:
-        print(
-            f"[check-items] WARN: classifier emitted {_dropped} non-dict records — dropped",
-            file=sys.stderr,
-        )
+    # All three counts derive from `parsed` (the output). Non-dict records are
+    # detected and warned before _validate_classifier_response() runs (above);
+    # because the validator rejects any list containing a non-dict, `parsed`
+    # here is guaranteed to contain only dicts — the redundant post-validation
+    # drop guard is not needed.
     _prefiltered_count = sum(
         1 for r in parsed if isinstance(r, dict) and r.get("prefiltered")
     )

--- a/hooks/open_item_dedup.py
+++ b/hooks/open_item_dedup.py
@@ -1495,9 +1495,8 @@ def classify_groups_with_agent(merged_groups, evidence):
     # is SKILL.md prose: Step 3 heredoc owns partition()'s `known` list,
     # Step 6 heredoc owns this function's invocation, and they share state
     # only via partition.json on disk. Threading len(known) through
-    # classify_groups_with_agent's signature is invasive (plan Task 7
-    # Step 4 fallback: drop cache_hit entirely rather than emit a
-    # placeholder).
+    # classify_groups_with_agent's signature is invasive; dropping it
+    # entirely (emitting '-' from the CLI side) is cleaner than a placeholder.
     #
     # All three counts derive from `parsed` (the output) so the invariant
     # `total_classified == prefiltered + subagent` holds by construction
@@ -1505,6 +1504,12 @@ def classify_groups_with_agent(merged_groups, evidence):
     # parse, dropped entries). Each dict-shaped entry is counted into
     # exactly one bucket via direct iteration — no subtraction that could
     # go negative when isinstance excludes malformed entries.
+    _dropped = sum(1 for r in parsed if not isinstance(r, dict))
+    if _dropped:
+        print(
+            f"[check-items] WARN: classifier emitted {_dropped} non-dict records — dropped",
+            file=sys.stderr,
+        )
     _prefiltered_count = sum(
         1 for r in parsed if isinstance(r, dict) and r.get("prefiltered")
     )

--- a/hooks/open_item_dedup.py
+++ b/hooks/open_item_dedup.py
@@ -1469,6 +1469,34 @@ def classify_groups_with_agent(merged_groups, evidence):
     if parsed is None:
         _LAST_CLASSIFIER_MODE = "heuristic-fallback"
         return []
+
+    # Outer telemetry: summary of this classification run.
+    # cache_hit is intentionally NOT emitted here — the orchestration layer
+    # is SKILL.md prose: Step 3 heredoc owns partition()'s `known` list,
+    # Step 6 heredoc owns this function's invocation, and they share state
+    # only via partition.json on disk. Threading len(known) through
+    # classify_groups_with_agent's signature is invasive (plan Task 7
+    # Step 4 fallback: drop cache_hit entirely rather than emit a
+    # placeholder).
+    #
+    # All three counts derive from `parsed` (the output) so the invariant
+    # `total_classified == prefiltered + subagent` holds by construction
+    # even if the CLI returned fewer records than merged_groups (partial
+    # parse, dropped entries). Each dict-shaped entry is counted into
+    # exactly one bucket via direct iteration — no subtraction that could
+    # go negative when isinstance excludes malformed entries.
+    _prefiltered_count = sum(
+        1 for r in parsed if isinstance(r, dict) and r.get("prefiltered")
+    )
+    _subagent_count = sum(
+        1 for r in parsed if isinstance(r, dict) and not r.get("prefiltered")
+    )
+    _total_classified = _prefiltered_count + _subagent_count
+    print(
+        f"[check-items] classifier-result: total_classified={_total_classified} "
+        f"prefiltered={_prefiltered_count} subagent={_subagent_count}",
+        file=sys.stderr,
+    )
     return parsed
 
 

--- a/tests/test_check_items_cli.py
+++ b/tests/test_check_items_cli.py
@@ -542,6 +542,44 @@ def test_bridge_project_evidence_no_warning_on_empty(monkeypatch, capsys):
     )
 
 
+def test_bridge_project_evidence_multi_project_no_warn_when_project_missing(monkeypatch, capsys):
+    """Multi-project shape A payload with a missing project key → {} without WARN (I1 fix).
+
+    When evidence = {"projA": {...}, "projB": {...}} and the group asks for
+    "projC", the payload IS shape A — just without this project's data.
+    This should silently return {} rather than emitting a WARN, because the
+    shape is recognized and the answer is legitimately "no evidence for projC".
+    """
+    import check_items_cli
+
+    evidence = {
+        "projA": {
+            "commits": ["abc1234 fix something"],
+            "merged_prs": [],
+            "closed_issues": [],
+            "releases": [],
+            "changelog_excerpt": "",
+        },
+        "projB": {
+            "commits": [],
+            "merged_prs": [{"title": "Add feature X", "number": 42}],
+            "closed_issues": [],
+            "releases": [],
+            "changelog_excerpt": "",
+        },
+    }
+
+    result = check_items_cli._bridge_project_evidence(evidence, "projC")
+
+    captured = capsys.readouterr()
+    assert result == {}, (
+        f"Expected {{}} for project not in multi-project payload; got: {result!r}"
+    )
+    assert "WARN" not in captured.err, (
+        f"Unexpected WARN for recognized shape A with missing project: {captured.err!r}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # I2: group_id=None collision in run_classifier
 # ---------------------------------------------------------------------------
@@ -664,28 +702,37 @@ def test_file_path_branch_validates_schema_missing_fields(tmp_path, monkeypatch)
 # ---------------------------------------------------------------------------
 
 def test_non_dict_records_dropped_with_warning(tmp_path, monkeypatch, capsys):
-    """Non-dict entries in classified output produce a stderr WARN and are dropped (I4).
+    """Non-dict entries in classifier output emit a WARN via production code (I4).
 
-    The telemetry block in classify_groups_with_agent (open_item_dedup.py) applies
-    isinstance(r, dict) filters on both prefiltered and subagent counts. Non-dict
-    records are silently excluded from both buckets without a diagnostic.
-
-    This test patches classify_groups_with_agent so that `parsed` reaches the
-    telemetry block with a non-dict entry. We verify: (1) WARN is emitted, (2) the
-    non-dict record is excluded from the return value (dropped), (3) valid dicts pass.
+    Invokes open_item_dedup.classify_groups_with_agent() for real, with a mocked
+    subprocess that writes JSON containing a stray non-dict entry to out_path.
+    Asserts:
+      (1) WARN is emitted to stderr by the production pre-validation check.
+      (2) The function returns [] because _validate_classifier_response rejects
+          any list containing a non-dict (warn-and-reject semantics).
+    Deleting the production WARN block in open_item_dedup.py would cause this
+    test to fail on assertion (1).
     """
-    import sys
-    import os
-    HOOKS_DIR = os.path.join(os.path.dirname(__file__), "..", "hooks")
-    if HOOKS_DIR not in sys.path:
-        sys.path.insert(0, HOOKS_DIR)
-
     import open_item_dedup as oid
 
-    # The warning fires inline in the telemetry block. We test the warning by
-    # simulating the same code path: count non-dicts and print warning to stderr.
-    # This matches the exact implementation added for I4.
-    parsed = [
+    mtime_recent = time.time() - (10 * 86400)  # 10 days ago → ACTIVE
+    merged_groups = [
+        _make_group("g1", "Fix session_log race condition", mtime_recent),
+    ]
+    evidence = {
+        "obsidian-brain": {
+            "commits": ["abc1234 fix session_log race condition"],
+            "merged_prs": [],
+            "closed_issues": [],
+            "releases": [],
+            "changelog_excerpt": "",
+        }
+    }
+
+    # Malformed sub-agent response: valid dict + stray non-dict string entry.
+    # _validate_classifier_response will reject this (non-dict present), but the
+    # pre-validation WARN block should fire first.
+    malformed_response = [
         {
             "group_id": "g1",
             "classification": "DONE",
@@ -693,31 +740,43 @@ def test_non_dict_records_dropped_with_warning(tmp_path, monkeypatch, capsys):
             "canonical_text": "Fix session_log race condition",
             "evidence_citation": "commit abc1234",
             "action_required": None,
-            "prefiltered": False,
         },
-        "this-is-not-a-dict",  # malformed entry
+        "this-is-not-a-dict",  # stray non-dict entry
     ]
 
-    # Simulate the telemetry logic as it exists in open_item_dedup.py (I4 fix).
-    # This mirrors the exact code added: count + warn, then filter.
-    _dropped = sum(1 for r in parsed if not isinstance(r, dict))
-    if _dropped:
-        print(
-            f"[check-items] WARN: classifier emitted {_dropped} non-dict records — dropped",
-            file=sys.stderr,
-        )
+    mock_cp = MagicMock()
+    mock_cp.returncode = 0
+    mock_cp.stderr = ""
+    mock_cp.stdout = ""
+
+    def fake_run(*args, **kwargs):
+        # Extract out_path from the CLI args: ["python3", cli_path, "classifier", out_path]
+        cli_args = args[0]
+        out_path = cli_args[3]
+        Path(out_path).write_text(json.dumps(malformed_response), encoding="utf-8")
+        return mock_cp
+
+    with patch("open_item_dedup.subprocess.run", side_effect=fake_run):
+        result = oid.classify_groups_with_agent(merged_groups, evidence)
 
     captured = capsys.readouterr()
-    assert _dropped == 1, f"Expected 1 non-dict record, got {_dropped}"
-    assert "WARN" in captured.err, f"Expected WARN in stderr; got: {captured.err!r}"
-    assert "non-dict" in captured.err, f"Expected 'non-dict' in warning; got: {captured.err!r}"
-    assert "dropped" in captured.err, f"Expected 'dropped' in warning; got: {captured.err!r}"
-    assert "1" in captured.err, f"Expected count '1' in warning; got: {captured.err!r}"
-
-    # Verify dict filtering keeps valid records
-    valid = [r for r in parsed if isinstance(r, dict)]
-    assert len(valid) == 1
-    assert valid[0]["group_id"] == "g1"
+    assert "WARN" in captured.err, (
+        f"Expected WARN in stderr for non-dict records; got: {captured.err!r}"
+    )
+    assert "non-dict" in captured.err, (
+        f"Expected 'non-dict' in warning; got: {captured.err!r}"
+    )
+    assert "1" in captured.err, (
+        f"Expected count '1' in warning; got: {captured.err!r}"
+    )
+    # validator rejects the response → heuristic-fallback → returns []
+    assert result == [], (
+        f"Expected [] when response contains non-dict records; got: {result!r}"
+    )
+    assert oid.get_last_classifier_mode() == "heuristic-fallback", (
+        f"Expected heuristic-fallback mode after non-dict rejection; "
+        f"got: {oid.get_last_classifier_mode()!r}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_check_items_cli.py
+++ b/tests/test_check_items_cli.py
@@ -357,3 +357,70 @@ def test_bare_key_evidence_bridging_no_match(tmp_path, monkeypatch):
     out = json.loads(Path(output_path).read_text())
     assert len(out) == 1
     assert out[0].get("prefiltered") is True
+
+
+# ---------------------------------------------------------------------------
+# Tests for telemetry line
+# ---------------------------------------------------------------------------
+
+def test_telemetry_line_appears_in_stderr(tmp_path, monkeypatch, capsys):
+    """run_classifier emits exactly one telemetry line to stderr."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [_make_group("g1", "Investigate dispatcher discovery", mtime_recent)]
+    payload_str = _make_payload(groups, EVIDENCE_EMPTY_TEXT)
+    output_path = str(tmp_path / "out.json")
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    with patch("check_items_cli.subprocess.run", MagicMock()):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    telemetry_lines = [
+        l for l in captured.err.splitlines()
+        if l.startswith("[check-items-cli] classifier:")
+    ]
+    assert len(telemetry_lines) == 1, f"Expected exactly 1 telemetry line, got: {telemetry_lines}"
+
+
+def test_telemetry_line_has_all_five_fields(tmp_path, monkeypatch, capsys):
+    """Telemetry line contains total, cache_hit, prefiltered, subagent, wall fields."""
+    import check_items_cli
+    import re
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [
+        _make_group("g1", "Investigate dispatcher discovery", mtime_recent),
+        _make_group("g2", "Explore vault growth patterns", mtime_recent),
+    ]
+    payload_str = _make_payload(groups, EVIDENCE_EMPTY_TEXT)
+    output_path = str(tmp_path / "out.json")
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    with patch("check_items_cli.subprocess.run", MagicMock()):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    telemetry_line = next(
+        (l for l in captured.err.splitlines() if "[check-items-cli] classifier:" in l),
+        None,
+    )
+    assert telemetry_line is not None
+
+    # Parse and verify all five fields are present and have parseable values
+    assert re.search(r'total=\d+', telemetry_line), f"Missing total= in: {telemetry_line}"
+    assert re.search(r'cache_hit=[-\d]+', telemetry_line), f"Missing cache_hit= in: {telemetry_line}"
+    assert re.search(r'prefiltered=\d+', telemetry_line), f"Missing prefiltered= in: {telemetry_line}"
+    assert re.search(r'subagent=\d+', telemetry_line), f"Missing subagent= in: {telemetry_line}"
+    assert re.search(r'wall=\d+s', telemetry_line), f"Missing wall= in: {telemetry_line}"
+
+    # Verify numeric values are consistent with the all-synthetic scenario
+    total_m = re.search(r'total=(\d+)', telemetry_line)
+    prefiltered_m = re.search(r'prefiltered=(\d+)', telemetry_line)
+    subagent_m = re.search(r'subagent=(\d+)', telemetry_line)
+    assert int(total_m.group(1)) == 2
+    assert int(prefiltered_m.group(1)) == 2
+    assert int(subagent_m.group(1)) == 0

--- a/tests/test_check_items_cli.py
+++ b/tests/test_check_items_cli.py
@@ -467,3 +467,300 @@ def test_all_synthetic_subprocess_never_invoked(tmp_path, monkeypatch):
         assert record.get("prefiltered") is True
         assert record["classification"] in ("ACTIVE", "STALE")
         assert record["confidence"] == "LOW"
+
+
+# ---------------------------------------------------------------------------
+# I1: _bridge_project_evidence fallthrough warning
+# ---------------------------------------------------------------------------
+
+def test_bridge_project_evidence_fallthrough_emits_warning(monkeypatch, capsys):
+    """Unrecognized evidence shape triggers a stderr WARN line (I1)."""
+    import check_items_cli
+
+    # Malformed evidence: neither bare-key nested nor _text-suffixed
+    malformed_evidence = {"some_random_key": "value", "another_key": 42}
+    check_items_cli._bridge_project_evidence(malformed_evidence, "some-project")
+
+    captured = capsys.readouterr()
+    assert "[check-items-cli] WARN:" in captured.err, (
+        f"Expected WARN on stderr for unrecognized evidence shape; got: {captured.err!r}"
+    )
+    assert "unrecognized shape" in captured.err
+    assert "some-project" in captured.err
+
+
+def test_bridge_project_evidence_no_warning_on_shape_a(monkeypatch, capsys):
+    """No WARN emitted for shape A (project-nested bare keys)."""
+    import check_items_cli
+
+    evidence = {
+        "obsidian-brain": {
+            "commits": ["abc1234 fix something"],
+            "merged_prs": [],
+            "closed_issues": [],
+            "releases": [],
+            "changelog_excerpt": "",
+        }
+    }
+    result = check_items_cli._bridge_project_evidence(evidence, "obsidian-brain")
+
+    captured = capsys.readouterr()
+    assert "WARN" not in captured.err, f"Unexpected WARN for valid shape A: {captured.err!r}"
+    assert "commits_text" in result
+
+
+def test_bridge_project_evidence_no_warning_on_shape_b(monkeypatch, capsys):
+    """No WARN emitted for shape B (_text-suffixed keys)."""
+    import check_items_cli
+
+    evidence = {
+        "commits_text": "fix session_log race condition abc1234",
+        "merged_prs_text": "",
+        "closed_issues_text": "",
+        "releases_text": "",
+        "changelog_excerpt": "",
+        "fts_mentions_text": "",
+    }
+    result = check_items_cli._bridge_project_evidence(evidence, "some-project")
+
+    captured = capsys.readouterr()
+    assert "WARN" not in captured.err, f"Unexpected WARN for valid shape B: {captured.err!r}"
+    assert result == evidence
+
+
+def test_bridge_project_evidence_no_warning_on_empty(monkeypatch, capsys):
+    """Empty evidence dict ({}) → returns {} without WARN (empty is not malformed)."""
+    import check_items_cli
+
+    result = check_items_cli._bridge_project_evidence({}, "some-project")
+
+    captured = capsys.readouterr()
+    # Empty dict with no keys is the normal "no evidence" case — should NOT warn
+    assert result == {}
+    assert "WARN" not in captured.err, (
+        f"Unexpected WARN for empty evidence dict: {captured.err!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# I2: group_id=None collision in run_classifier
+# ---------------------------------------------------------------------------
+
+def test_run_classifier_missing_group_id_returns_error(tmp_path, monkeypatch):
+    """Groups with group_id=None cause run_classifier to return a non-zero error code (I2)."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [
+        _make_group("g1", "Fix session_log race condition", mtime_recent),
+        # group with group_id=None — malformed input
+        {
+            "group_id": None,
+            "project": "obsidian-brain",
+            "representative": "Some orphaned item",
+            "instances": [{"file": "note.md", "line": 1, "text": "Some orphaned item", "mtime": mtime_recent}],
+        },
+    ]
+    payload_str = _make_payload(groups, EVIDENCE_EMPTY_TEXT)
+    output_path = str(tmp_path / "out.json")
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    with patch("check_items_cli.subprocess.run", MagicMock()):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc != 0, f"Expected non-zero rc for groups with group_id=None, got {rc}"
+
+
+def test_run_classifier_missing_group_id_logs_to_stderr(tmp_path, monkeypatch, capsys):
+    """Groups with group_id=None produce a diagnostic message on stderr (I2)."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [
+        {
+            "group_id": None,
+            "project": "obsidian-brain",
+            "representative": "An item without a valid group_id",
+            "instances": [{"file": "note.md", "line": 1, "text": "item", "mtime": mtime_recent}],
+        }
+    ]
+    payload_str = _make_payload(groups, EVIDENCE_EMPTY_TEXT)
+    output_path = str(tmp_path / "out.json")
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    with patch("check_items_cli.subprocess.run", MagicMock()):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    # Should emit a clear diagnostic mentioning group_id
+    assert "group_id" in captured.err.lower() or "group_id" in captured.err, (
+        f"Expected 'group_id' in stderr; got: {captured.err!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# I3: file-path branch must apply _validate_classifier_payload
+# ---------------------------------------------------------------------------
+
+def test_file_path_branch_validates_schema(tmp_path, monkeypatch):
+    """If sub-agent writes invalid JSON to output file, run_classifier returns rc=4 (I3)."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [_make_group("g1", "Fix session_log race condition", mtime_recent)]
+    payload_str = _make_payload(groups, EVIDENCE_WITH_MATCH_TEXT)
+    output_path = str(tmp_path / "out.json")
+
+    # Sub-agent writes a dict instead of a list (wrong shape) to output_path
+    invalid_result = {"wrong": "shape"}
+
+    mock_cp = MagicMock()
+    mock_cp.returncode = 0
+    mock_cp.stderr = ""
+    mock_cp.stdout = ""
+
+    def fake_run(*args, **kwargs):
+        Path(output_path).write_text(json.dumps(invalid_result), encoding="utf-8")
+        return mock_cp
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    with patch("check_items_cli.subprocess.run", side_effect=fake_run):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 4, f"Expected rc=4 for invalid file-path output shape, got {rc}"
+
+
+def test_file_path_branch_validates_schema_missing_fields(tmp_path, monkeypatch):
+    """File-path branch rejects list of dicts missing required classifier fields (I3)."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [_make_group("g1", "Fix session_log race condition", mtime_recent)]
+    payload_str = _make_payload(groups, EVIDENCE_WITH_MATCH_TEXT)
+    output_path = str(tmp_path / "out.json")
+
+    # Missing required fields like 'evidence_citation', 'action_required', etc.
+    invalid_result = [{"group_id": "g1", "classification": "DONE"}]
+
+    mock_cp = MagicMock()
+    mock_cp.returncode = 0
+    mock_cp.stderr = ""
+    mock_cp.stdout = ""
+
+    def fake_run(*args, **kwargs):
+        Path(output_path).write_text(json.dumps(invalid_result), encoding="utf-8")
+        return mock_cp
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    with patch("check_items_cli.subprocess.run", side_effect=fake_run):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 4, f"Expected rc=4 for file-path output missing required fields, got {rc}"
+
+
+# ---------------------------------------------------------------------------
+# I4: non-dict records in outer telemetry (open_item_dedup.py)
+# ---------------------------------------------------------------------------
+
+def test_non_dict_records_dropped_with_warning(tmp_path, monkeypatch, capsys):
+    """Non-dict entries in classified output produce a stderr WARN and are dropped (I4).
+
+    The telemetry block in classify_groups_with_agent (open_item_dedup.py) applies
+    isinstance(r, dict) filters on both prefiltered and subagent counts. Non-dict
+    records are silently excluded from both buckets without a diagnostic.
+
+    This test patches classify_groups_with_agent so that `parsed` reaches the
+    telemetry block with a non-dict entry. We verify: (1) WARN is emitted, (2) the
+    non-dict record is excluded from the return value (dropped), (3) valid dicts pass.
+    """
+    import sys
+    import os
+    HOOKS_DIR = os.path.join(os.path.dirname(__file__), "..", "hooks")
+    if HOOKS_DIR not in sys.path:
+        sys.path.insert(0, HOOKS_DIR)
+
+    import open_item_dedup as oid
+
+    # The warning fires inline in the telemetry block. We test the warning by
+    # simulating the same code path: count non-dicts and print warning to stderr.
+    # This matches the exact implementation added for I4.
+    parsed = [
+        {
+            "group_id": "g1",
+            "classification": "DONE",
+            "confidence": "HIGH",
+            "canonical_text": "Fix session_log race condition",
+            "evidence_citation": "commit abc1234",
+            "action_required": None,
+            "prefiltered": False,
+        },
+        "this-is-not-a-dict",  # malformed entry
+    ]
+
+    # Simulate the telemetry logic as it exists in open_item_dedup.py (I4 fix).
+    # This mirrors the exact code added: count + warn, then filter.
+    _dropped = sum(1 for r in parsed if not isinstance(r, dict))
+    if _dropped:
+        print(
+            f"[check-items] WARN: classifier emitted {_dropped} non-dict records — dropped",
+            file=sys.stderr,
+        )
+
+    captured = capsys.readouterr()
+    assert _dropped == 1, f"Expected 1 non-dict record, got {_dropped}"
+    assert "WARN" in captured.err, f"Expected WARN in stderr; got: {captured.err!r}"
+    assert "non-dict" in captured.err, f"Expected 'non-dict' in warning; got: {captured.err!r}"
+    assert "dropped" in captured.err, f"Expected 'dropped' in warning; got: {captured.err!r}"
+    assert "1" in captured.err, f"Expected count '1' in warning; got: {captured.err!r}"
+
+    # Verify dict filtering keeps valid records
+    valid = [r for r in parsed if isinstance(r, dict)]
+    assert len(valid) == 1
+    assert valid[0]["group_id"] == "g1"
+
+
+# ---------------------------------------------------------------------------
+# I5: evidence={} integration — all groups become synthetic via run_classifier
+# ---------------------------------------------------------------------------
+
+def test_empty_evidence_dict_all_groups_synthetic(tmp_path, monkeypatch):
+    """When evidence={} (bridge returns {}), all groups become synthetic with prefiltered=True (I5).
+
+    This exercises the full _bridge_project_evidence → has_classifiable_evidence →
+    synthetic_classification path when the evidence payload is completely absent.
+    All groups must appear in the output with prefiltered=True and rc=0.
+    """
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)  # 10 days ago → ACTIVE
+    groups = [
+        _make_group("g1", "Investigate dispatcher discovery", mtime_recent),
+        _make_group("g2", "Explore vault growth patterns", mtime_recent),
+        _make_group("g3", "Document architecture decisions", mtime_recent),
+    ]
+    # evidence={}: no evidence key at all in the payload
+    payload_str = json.dumps({"groups": groups, "evidence": {}})
+    output_path = str(tmp_path / "out.json")
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    mock_sub = MagicMock()
+    with patch("check_items_cli.subprocess.run", mock_sub):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0, f"Expected rc=0 for evidence={{}}, got {rc}"
+    assert mock_sub.call_count == 0, (
+        f"Sub-agent should not be invoked when evidence is empty; "
+        f"called {mock_sub.call_count} times"
+    )
+
+    out = json.loads(Path(output_path).read_text())
+    assert len(out) == 3, f"Expected 3 output records, got {len(out)}"
+
+    for record in out:
+        assert record.get("prefiltered") is True, (
+            f"Expected prefiltered=True for all groups with empty evidence; "
+            f"record={record}"
+        )
+    # Input order preserved
+    assert [r["group_id"] for r in out] == ["g1", "g2", "g3"]

--- a/tests/test_check_items_cli.py
+++ b/tests/test_check_items_cli.py
@@ -1,0 +1,359 @@
+"""Integration tests for check_items_cli.run_classifier() with L2 prefilter wired in."""
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+HOOKS_DIR = os.path.join(os.path.dirname(__file__), "..", "hooks")
+if HOOKS_DIR not in sys.path:
+    sys.path.insert(0, HOOKS_DIR)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_group(group_id: str, text: str, mtime: float = 0.0, project: str = "obsidian-brain") -> dict:
+    """Minimal group with instances carrying mtime."""
+    return {
+        "group_id": group_id,
+        "project": project,
+        "representative": text,
+        "instances": [{"file": "note.md", "line": 1, "text": text, "mtime": mtime}],
+    }
+
+
+def _make_payload(groups: list, evidence: dict | None = None) -> str:
+    return json.dumps({"groups": groups, "evidence": evidence or {}})
+
+
+# Evidence using _text-suffixed keys (as expected by has_classifiable_evidence)
+EVIDENCE_EMPTY_TEXT = {
+    "commits_text": "",
+    "merged_prs_text": "",
+    "closed_issues_text": "",
+    "releases_text": "",
+    "changelog_excerpt": "",
+    "fts_mentions_text": "",
+}
+
+EVIDENCE_WITH_MATCH_TEXT = {
+    "commits_text": "fix session_log race condition abc1234",
+    "merged_prs_text": "",
+    "closed_issues_text": "",
+    "releases_text": "",
+    "changelog_excerpt": "",
+    "fts_mentions_text": "",
+}
+
+# Evidence using bare keys (as produced by open_item_dedup.py's gather_session_evidence),
+# nested under a project key — this is the live production shape.
+EVIDENCE_BARE_KEYS_WITH_MATCH = {
+    "obsidian-brain": {
+        "commits": ["abc1234 fix session_log race condition"],
+        "merged_prs": [],
+        "closed_issues": [],
+        "releases": [],
+        "changelog_excerpt": "",
+    }
+}
+
+EVIDENCE_BARE_KEYS_EMPTY = {
+    "obsidian-brain": {
+        "commits": [],
+        "merged_prs": [],
+        "closed_issues": [],
+        "releases": [],
+        "changelog_excerpt": "",
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# Test: all groups have evidence → sub-agent called on all
+# ---------------------------------------------------------------------------
+
+def test_all_groups_have_evidence_subagent_called(tmp_path, monkeypatch):
+    """All groups have token overlap with evidence → sub-agent receives all groups."""
+    import check_items_cli
+
+    # Group text that overlaps with EVIDENCE_WITH_MATCH_TEXT
+    groups = [
+        _make_group("g1", "Fix session_log race condition"),
+        _make_group("g2", "Fix session_log race deadlock"),
+    ]
+    payload_str = _make_payload(groups, EVIDENCE_WITH_MATCH_TEXT)
+
+    output_path = str(tmp_path / "out.json")
+
+    # Sub-agent output: two classification records
+    subagent_result = [
+        {
+            "group_id": "g1",
+            "classification": "DONE",
+            "confidence": "HIGH",
+            "canonical_text": "Fix session_log race condition",
+            "evidence_citation": "commit abc1234",
+            "action_required": None,
+        },
+        {
+            "group_id": "g2",
+            "classification": "DONE",
+            "confidence": "HIGH",
+            "canonical_text": "Fix session_log race deadlock",
+            "evidence_citation": "commit abc1234",
+            "action_required": None,
+        },
+    ]
+
+    mock_cp = MagicMock()
+    mock_cp.returncode = 0
+    mock_cp.stderr = ""
+    mock_cp.stdout = ""
+
+    def fake_run(*args, **kwargs):
+        # Write the sub-agent result to output_path
+        Path(output_path).write_text(json.dumps(subagent_result), encoding="utf-8")
+        return mock_cp
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    with patch("check_items_cli.subprocess.run", side_effect=fake_run) as mock_sub:
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0
+    assert mock_sub.call_count == 1, "Sub-agent should be called once for all groups"
+
+    out = json.loads(Path(output_path).read_text())
+    assert len(out) == 2
+    assert out[0]["group_id"] == "g1"
+    assert out[1]["group_id"] == "g2"
+
+
+# ---------------------------------------------------------------------------
+# Test: no groups have evidence → sub-agent NOT called, all synthetic
+# ---------------------------------------------------------------------------
+
+def test_no_groups_have_evidence_subagent_not_called(tmp_path, monkeypatch):
+    """No token overlap, no refs → sub-agent skipped; output is all synthetic records."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)  # 10 days ago → ACTIVE
+    groups = [
+        _make_group("g1", "Investigate dispatcher discovery", mtime_recent),
+        _make_group("g2", "Explore vault growth patterns", mtime_recent),
+    ]
+    payload_str = _make_payload(groups, EVIDENCE_EMPTY_TEXT)
+
+    output_path = str(tmp_path / "out.json")
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    mock_sub = MagicMock()
+    with patch("check_items_cli.subprocess.run", mock_sub):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0
+    assert mock_sub.call_count == 0, "Sub-agent must NOT be invoked when all items are prefiltered"
+
+    out = json.loads(Path(output_path).read_text())
+    assert len(out) == 2
+    for record in out:
+        assert record["classification"] in ("ACTIVE", "STALE")
+        assert record["confidence"] == "LOW"
+        assert record.get("prefiltered") is True
+
+
+# ---------------------------------------------------------------------------
+# Test: mixed groups → sub-agent called only on subset; output order preserved
+# ---------------------------------------------------------------------------
+
+def test_mixed_groups_order_preserved(tmp_path, monkeypatch):
+    """Some groups have evidence, some don't. Output must be in input order."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [
+        _make_group("g1", "Investigate dispatcher discovery", mtime_recent),  # no evidence
+        _make_group("g2", "Fix session_log race condition", mtime_recent),    # has evidence
+        _make_group("g3", "Explore vault growth patterns", mtime_recent),     # no evidence
+    ]
+    payload_str = _make_payload(groups, EVIDENCE_WITH_MATCH_TEXT)
+
+    output_path = str(tmp_path / "out.json")
+
+    subagent_result = [
+        {
+            "group_id": "g2",
+            "classification": "DONE",
+            "confidence": "HIGH",
+            "canonical_text": "Fix session_log race condition",
+            "evidence_citation": "commit abc1234",
+            "action_required": None,
+        }
+    ]
+
+    mock_cp = MagicMock()
+    mock_cp.returncode = 0
+    mock_cp.stderr = ""
+    mock_cp.stdout = ""
+
+    subagent_call_count = []
+
+    def fake_run(*args, **kwargs):
+        subagent_call_count.append(1)
+        Path(output_path).write_text(json.dumps(subagent_result), encoding="utf-8")
+        return mock_cp
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    with patch("check_items_cli.subprocess.run", side_effect=fake_run):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0
+    assert len(subagent_call_count) == 1, "Sub-agent called exactly once for the one evidenced group"
+
+    out = json.loads(Path(output_path).read_text())
+    assert len(out) == 3, "All three input groups must appear in output"
+
+    # Verify input order is preserved: g1, g2, g3
+    assert out[0]["group_id"] == "g1"
+    assert out[1]["group_id"] == "g2"
+    assert out[2]["group_id"] == "g3"
+
+    # g2 came from sub-agent (DONE), g1 and g3 are synthetic
+    assert out[1]["classification"] == "DONE"
+    assert out[0].get("prefiltered") is True
+    assert out[2].get("prefiltered") is True
+
+
+# ---------------------------------------------------------------------------
+# Test: L2 disabled → sub-agent called on all groups (existing behavior)
+# ---------------------------------------------------------------------------
+
+def test_prefilter_disabled_subagent_called_for_all(tmp_path, monkeypatch):
+    """When CHECK_ITEMS_PREFILTER=off, all groups go to sub-agent regardless of evidence."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [
+        _make_group("g1", "Investigate dispatcher discovery", mtime_recent),
+        _make_group("g2", "Explore vault growth patterns", mtime_recent),
+    ]
+    payload_str = _make_payload(groups, EVIDENCE_EMPTY_TEXT)
+
+    output_path = str(tmp_path / "out.json")
+
+    subagent_result = [
+        {
+            "group_id": "g1",
+            "classification": "ACTIVE",
+            "confidence": "LOW",
+            "canonical_text": "Investigate dispatcher discovery",
+            "evidence_citation": None,
+            "action_required": None,
+        },
+        {
+            "group_id": "g2",
+            "classification": "ACTIVE",
+            "confidence": "LOW",
+            "canonical_text": "Explore vault growth patterns",
+            "evidence_citation": None,
+            "action_required": None,
+        },
+    ]
+
+    mock_cp = MagicMock()
+    mock_cp.returncode = 0
+    mock_cp.stderr = ""
+    mock_cp.stdout = ""
+
+    def fake_run(*args, **kwargs):
+        Path(output_path).write_text(json.dumps(subagent_result), encoding="utf-8")
+        return mock_cp
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "off")
+    with patch("check_items_cli.subprocess.run", side_effect=fake_run) as mock_sub:
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0
+    assert mock_sub.call_count == 1, "Sub-agent must be called when prefilter is disabled"
+
+    out = json.loads(Path(output_path).read_text())
+    assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: bare-key evidence (production shape from open_item_dedup.py) → bridging works
+# ---------------------------------------------------------------------------
+
+def test_bare_key_evidence_bridging_with_match(tmp_path, monkeypatch):
+    """Evidence in bare-key production shape {project: {commits: [...], ...}} is bridged
+    correctly so has_classifiable_evidence finds token overlap and routes to sub-agent."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [
+        _make_group("g1", "Fix session_log race condition", mtime_recent),
+    ]
+    # Use the live production evidence shape (bare keys, nested under project)
+    payload_str = _make_payload(groups, EVIDENCE_BARE_KEYS_WITH_MATCH)
+
+    output_path = str(tmp_path / "out.json")
+
+    subagent_result = [
+        {
+            "group_id": "g1",
+            "classification": "DONE",
+            "confidence": "HIGH",
+            "canonical_text": "Fix session_log race condition",
+            "evidence_citation": "commit abc1234",
+            "action_required": None,
+        }
+    ]
+
+    mock_cp = MagicMock()
+    mock_cp.returncode = 0
+    mock_cp.stderr = ""
+    mock_cp.stdout = ""
+
+    def fake_run(*args, **kwargs):
+        Path(output_path).write_text(json.dumps(subagent_result), encoding="utf-8")
+        return mock_cp
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    with patch("check_items_cli.subprocess.run", side_effect=fake_run) as mock_sub:
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0
+    # With match evidence, group should go to sub-agent (not synthetic)
+    assert mock_sub.call_count == 1, "Sub-agent should be called — evidence has token overlap"
+
+    out = json.loads(Path(output_path).read_text())
+    assert len(out) == 1
+    assert out[0]["classification"] == "DONE"
+    assert out[0].get("prefiltered") is not True
+
+
+def test_bare_key_evidence_bridging_no_match(tmp_path, monkeypatch):
+    """Evidence in bare-key production shape with empty values → group is synthetic."""
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [
+        _make_group("g1", "Investigate dispatcher discovery", mtime_recent),
+    ]
+    payload_str = _make_payload(groups, EVIDENCE_BARE_KEYS_EMPTY)
+
+    output_path = str(tmp_path / "out.json")
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    mock_sub = MagicMock()
+    with patch("check_items_cli.subprocess.run", mock_sub):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0
+    assert mock_sub.call_count == 0, "Sub-agent must NOT be called — no evidence"
+
+    out = json.loads(Path(output_path).read_text())
+    assert len(out) == 1
+    assert out[0].get("prefiltered") is True

--- a/tests/test_check_items_cli.py
+++ b/tests/test_check_items_cli.py
@@ -424,3 +424,46 @@ def test_telemetry_line_has_all_five_fields(tmp_path, monkeypatch, capsys):
     assert int(total_m.group(1)) == 2
     assert int(prefiltered_m.group(1)) == 2
     assert int(subagent_m.group(1)) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test: empty to_classify path — subprocess never invoked
+# ---------------------------------------------------------------------------
+
+def test_all_synthetic_subprocess_never_invoked(tmp_path, monkeypatch):
+    """When all groups are prefiltered by L2, subprocess.run is never called.
+
+    This is the critical optimization: no claude -p invocations when the vault
+    has no completion evidence for any open item. The all-synthetic case must
+    exit 0 and write valid output without touching the subprocess machinery.
+    """
+    import check_items_cli
+
+    mtime_recent = time.time() - (10 * 86400)
+    groups = [
+        _make_group("g1", "Investigate dispatcher discovery", mtime_recent),
+        _make_group("g2", "Explore vault growth patterns", mtime_recent),
+        _make_group("g3", "Document architecture decisions", mtime_recent),
+    ]
+    payload_str = _make_payload(groups, EVIDENCE_EMPTY_TEXT)
+    output_path = str(tmp_path / "out.json")
+
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "on")
+    mock_sub = MagicMock()
+    with patch("check_items_cli.subprocess.run", mock_sub):
+        rc = check_items_cli.run_classifier(payload_str, output_path)
+
+    assert rc == 0, f"Expected exit 0, got {rc}"
+    assert mock_sub.call_count == 0, (
+        f"subprocess.run was called {mock_sub.call_count} time(s) — "
+        "expected 0 when all groups have no evidence"
+    )
+
+    out = json.loads(Path(output_path).read_text())
+    assert len(out) == 3, "All 3 groups must appear in output"
+    group_ids = [r["group_id"] for r in out]
+    assert group_ids == ["g1", "g2", "g3"], "Input order must be preserved"
+    for record in out:
+        assert record.get("prefiltered") is True
+        assert record["classification"] in ("ACTIVE", "STALE")
+        assert record["confidence"] == "LOW"

--- a/tests/test_check_items_prefilter.py
+++ b/tests/test_check_items_prefilter.py
@@ -107,3 +107,124 @@ def test_has_evidence_empty_evidence_dict():
     from check_items_prefilter import has_classifiable_evidence
     group = _make_group("Investigate dispatcher discovery")
     assert has_classifiable_evidence(group, {}) is False
+
+
+# ---------------------------------------------------------------------------
+# Tests for synthetic_classification
+# ---------------------------------------------------------------------------
+
+import time as _time
+
+
+def _make_group_with_mtime(canonical_text: str, mtime: float) -> dict:
+    """Build a group with instances carrying a known mtime."""
+    return {
+        "group_id": "test-synth-01",
+        "project": "obsidian-brain",
+        "representative": canonical_text,
+        "instances": [
+            {"file": "note.md", "line": 1, "text": canonical_text, "mtime": mtime},
+        ],
+    }
+
+
+def test_synthetic_young_item_is_active():
+    """Item first seen 30 days ago (<=90d) → ACTIVE/LOW."""
+    from check_items_prefilter import synthetic_classification
+    mtime_30d_ago = _time.time() - (30 * 86400)
+    group = _make_group_with_mtime("Investigate dispatcher discovery", mtime_30d_ago)
+    result = synthetic_classification(group)
+    assert result["classification"] == "ACTIVE"
+    assert result["confidence"] == "LOW"
+    assert result["prefiltered"] is True
+    assert result["group_id"] == "test-synth-01"
+    assert result["evidence_citation"] is None
+    assert result["action_required"] is None
+
+
+def test_synthetic_old_item_is_stale():
+    """Item first seen >90 days ago → STALE/LOW."""
+    from check_items_prefilter import synthetic_classification
+    mtime_100d_ago = _time.time() - (100 * 86400)
+    group = _make_group_with_mtime("Fix ancient configuration bug", mtime_100d_ago)
+    result = synthetic_classification(group)
+    assert result["classification"] == "STALE"
+    assert result["confidence"] == "LOW"
+    assert result["prefiltered"] is True
+
+
+def test_synthetic_missing_mtime_treats_as_stale():
+    """No mtime in instances → defaults to 0 → age computed as large number → STALE.
+
+    Note: mtime=0 (epoch) means the file dates to 1970, which is >90 days ago.
+    This is the safe conservative path: if we don't know the age, treat as STALE
+    (older items are more likely to be stale). If the implementer finds 0→ACTIVE
+    is preferable (treat unknown as young), this test must be updated to assert ACTIVE.
+    The canonical decision: mtime=0 → age = now - 0 which is always > 90d → STALE.
+    """
+    from check_items_prefilter import synthetic_classification
+    group = {
+        "group_id": "test-synth-missing",
+        "project": "obsidian-brain",
+        "representative": "Some item text",
+        "instances": [{"file": "note.md", "line": 1, "text": "Some item text"}],
+        # no 'mtime' key in instances
+    }
+    result = synthetic_classification(group)
+    # mtime defaults to 0 → epoch → age >> 90d → STALE
+    assert result["classification"] == "STALE"
+    assert result["confidence"] == "LOW"
+    assert result["prefiltered"] is True
+
+
+def test_synthetic_empty_instances_treats_as_stale():
+    """Empty instances list → no mtimes → earliest_mtime = 0.0 → epoch → STALE.
+
+    Fail-safe path for groups with no instances at all (defensive guard against
+    malformed input). `min(mtimes) if mtimes else 0.0` yields 0.0, the epoch,
+    so age > 90d → STALE.
+    """
+    from check_items_prefilter import synthetic_classification
+    group = {
+        "group_id": "test-synth-empty",
+        "project": "obsidian-brain",
+        "representative": "Some item text",
+        "instances": [],
+    }
+    result = synthetic_classification(group)
+    assert result["classification"] == "STALE"
+    assert result["confidence"] == "LOW"
+    assert result["prefiltered"] is True
+
+
+def test_synthetic_record_has_canonical_text():
+    """The synthetic record carries canonical_text matching the representative."""
+    from check_items_prefilter import synthetic_classification
+    mtime_recent = _time.time() - (10 * 86400)
+    group = _make_group_with_mtime("Check vault integrity", mtime_recent)
+    result = synthetic_classification(group)
+    assert result["canonical_text"] == "Check vault integrity"
+
+
+def test_synthetic_classification_now_injection_active():
+    """Fixed clock — ACTIVE branch. Exercises the `now=` injection path."""
+    from check_items_prefilter import synthetic_classification
+    mtime = 1_000_000.0
+    group = _make_group_with_mtime("Investigate dispatcher discovery", mtime)
+    # 30 days after mtime → ACTIVE
+    result = synthetic_classification(group, now=mtime + 30 * 86_400)
+    assert result["classification"] == "ACTIVE"
+    assert result["confidence"] == "LOW"
+    assert result["prefiltered"] is True
+
+
+def test_synthetic_classification_now_injection_stale():
+    """Fixed clock — STALE branch. Exercises the `now=` injection path."""
+    from check_items_prefilter import synthetic_classification
+    mtime = 1_000_000.0
+    group = _make_group_with_mtime("Fix ancient configuration bug", mtime)
+    # 100 days after mtime → STALE
+    result = synthetic_classification(group, now=mtime + 100 * 86_400)
+    assert result["classification"] == "STALE"
+    assert result["confidence"] == "LOW"
+    assert result["prefiltered"] is True

--- a/tests/test_check_items_prefilter.py
+++ b/tests/test_check_items_prefilter.py
@@ -1,0 +1,31 @@
+"""Tests for check_items_prefilter.py — L2 evidence-presence pre-filter module."""
+import os
+import sys
+
+HOOKS_DIR = os.path.join(os.path.dirname(__file__), "..", "hooks")
+if HOOKS_DIR not in sys.path:
+    sys.path.insert(0, HOOKS_DIR)
+
+
+def test_content_tokens_drops_stopwords():
+    from check_items_prefilter import _content_tokens
+    out = _content_tokens("the fix is in the loader")
+    assert out == ["fix", "loader"]
+
+
+def test_content_tokens_drops_short_tokens():
+    from check_items_prefilter import _content_tokens
+    out = _content_tokens("Fix a 1 ab abc abcd")
+    assert "Fix" in out
+    assert "abc" in out
+    assert "abcd" in out
+    assert "1" not in out
+    assert "ab" not in out
+    assert "a" not in out
+
+
+def test_ref_pattern_matches_issue_number():
+    from check_items_prefilter import REF_PATTERN
+    assert REF_PATTERN.search("Close #42 once shipped")
+    assert REF_PATTERN.search("commit 1b1557b lands the fix")
+    assert not REF_PATTERN.search("no refs here")

--- a/tests/test_check_items_prefilter.py
+++ b/tests/test_check_items_prefilter.py
@@ -29,3 +29,81 @@ def test_ref_pattern_matches_issue_number():
     assert REF_PATTERN.search("Close #42 once shipped")
     assert REF_PATTERN.search("commit 1b1557b lands the fix")
     assert not REF_PATTERN.search("no refs here")
+
+
+# ---------------------------------------------------------------------------
+# Tests for has_classifiable_evidence
+# ---------------------------------------------------------------------------
+
+def _make_group(canonical_text: str, mtime: float = 0.0) -> dict:
+    """Minimal group dict for has_classifiable_evidence tests."""
+    return {
+        "group_id": "test-01",
+        "project": "obsidian-brain",
+        "representative": canonical_text,
+        "instances": [{"file": "note.md", "line": 1, "text": canonical_text, "mtime": mtime}],
+    }
+
+
+def _make_evidence(**kwargs) -> dict:
+    """Build an evidence dict with all keys; missing keys default to empty string."""
+    base = {
+        "commits_text": "",
+        "merged_prs_text": "",
+        "closed_issues_text": "",
+        "releases_text": "",
+        "changelog_excerpt": "",
+        "fts_mentions_text": "",
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_has_evidence_ref_match_wins_immediately():
+    """A group with '#42' in canonical_text returns True regardless of evidence bundle."""
+    from check_items_prefilter import has_classifiable_evidence
+    group = _make_group("Fix issue #42 once shipped")
+    evidence = _make_evidence()  # empty evidence
+    assert has_classifiable_evidence(group, evidence) is True
+
+
+def test_has_evidence_commit_sha_wins_immediately():
+    """A group with a 7-char hex token triggers the ref pattern."""
+    from check_items_prefilter import has_classifiable_evidence
+    group = _make_group("Patch landed in commit 1b1557b")
+    evidence = _make_evidence()
+    assert has_classifiable_evidence(group, evidence) is True
+
+
+def test_has_evidence_token_overlap_with_commits():
+    """Token overlap with commits_text returns True."""
+    from check_items_prefilter import has_classifiable_evidence
+    group = _make_group("Fix session_log race condition")
+    evidence = _make_evidence(commits_text="fix session_log race condition in hook abc1234")
+    assert has_classifiable_evidence(group, evidence) is True
+
+
+def test_has_evidence_no_overlap_returns_false():
+    """No ref and no token overlap returns False."""
+    from check_items_prefilter import has_classifiable_evidence
+    group = _make_group("Investigate dispatcher discovery")
+    evidence = _make_evidence(
+        commits_text="update vault index schema",
+        merged_prs_text="add snapshot recall feature",
+    )
+    assert has_classifiable_evidence(group, evidence) is False
+
+
+def test_has_evidence_stopwords_only_item():
+    """All-stopword canonical_text produces zero tokens → no overlap → False."""
+    from check_items_prefilter import has_classifiable_evidence
+    group = _make_group("the and or for")
+    evidence = _make_evidence(commits_text="the and or for is a an")
+    assert has_classifiable_evidence(group, evidence) is False
+
+
+def test_has_evidence_empty_evidence_dict():
+    """Entirely missing evidence keys (empty dict) → no overlap → False (no ref)."""
+    from check_items_prefilter import has_classifiable_evidence
+    group = _make_group("Investigate dispatcher discovery")
+    assert has_classifiable_evidence(group, {}) is False

--- a/tests/test_check_items_prefilter.py
+++ b/tests/test_check_items_prefilter.py
@@ -255,3 +255,118 @@ def test_prefilter_enabled_for_non_off_values(monkeypatch):
     for val in ("on", "1", "true", "yes", ""):
         monkeypatch.setenv("CHECK_ITEMS_PREFILTER", val)
         assert check_items_prefilter.is_prefilter_enabled() is True, f"Expected True for {val!r}"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: real os.path.getmtime flows through _safe_mtime →
+# group_members → classify payload → synthetic_classification
+#
+# These tests exercise the mtime threading bug that was silently STALE-ing
+# every item: _safe_mtime(fpath) must be called at group_members construction
+# time (open_item_dedup.py), not fabricated in test fixtures.
+# ---------------------------------------------------------------------------
+
+def _build_group_from_real_files(tmp_path, item_text: str, old: bool) -> dict:
+    """Build a minimal group dict whose mtime comes from os.path.getmtime().
+
+    Creates a real temp file, sets its mtime via os.utime(), then reads it
+    back via os.path.getmtime() — the same call that _safe_mtime() in
+    open_item_dedup.py makes. This exercises the real integration path:
+    "real mtime → group_members dict → synthetic_classification".
+
+    Args:
+        tmp_path: pytest tmp_path fixture.
+        item_text: Text for the open item.
+        old: If True, sets mtime to 100 days ago (→ STALE).
+             If False, sets mtime to 20 days ago (→ ACTIVE).
+    """
+    note = tmp_path / ("old_note.md" if old else "new_note.md")
+    note.write_text(
+        f"---\ntype: claude-session\nproject: test\n---\n\n"
+        f"## Open Questions / Next Steps\n- [ ] {item_text}\n",
+        encoding="utf-8",
+    )
+    days_ago = 100 if old else 20
+    target_mtime = _time.time() - (days_ago * 86_400)
+    os.utime(str(note), (target_mtime, target_mtime))
+
+    # Read mtime back via the same call _safe_mtime() makes — this is the
+    # integration point: if _safe_mtime were never called, mtime would be
+    # absent from the group dict and synthetic_classification would always
+    # compute epoch-age → STALE.
+    real_mtime = os.path.getmtime(str(note))
+
+    return {
+        "group_id": f"integ-{'old' if old else 'new'}-01",
+        "project": "test",
+        "representative": item_text,
+        "instances": [
+            {
+                "file": note.name,
+                "line": 4,
+                "text": item_text,
+                "mtime": real_mtime,  # populated as _safe_mtime(fpath) would be
+            }
+        ],
+    }
+
+
+def test_mtime_threading_old_file_classifies_stale(tmp_path):
+    """Group built with real mtime from a 100-day-old file → STALE.
+
+    This test would have caught the original bug: when mtime was never set
+    on group_members dicts, m.get('mtime', 0) returned 0 (epoch), and the
+    age was always >> 90 days. This test passes an actual os.path.getmtime()
+    value into the group, proving the ACTIVE branch is reachable with fresh
+    files (see companion test below).
+    """
+    from check_items_prefilter import synthetic_classification
+    group = _build_group_from_real_files(tmp_path, "Fix the old broken thing", old=True)
+    result = synthetic_classification(group)
+    assert result["classification"] == "STALE", (
+        f"Expected STALE for 100-day-old file mtime; got {result['classification']!r}. "
+        f"mtime={group['instances'][0]['mtime']}"
+    )
+    assert result["confidence"] == "LOW"
+    assert result["prefiltered"] is True
+
+
+def test_mtime_threading_new_file_classifies_active(tmp_path):
+    """Group built with real mtime from a 20-day-old file → ACTIVE.
+
+    This is the test that would have FAILED before the fix: because mtime
+    was never populated in group_members, mtime always defaulted to 0
+    (epoch) and every item was STALE regardless of file age. This test
+    proves the ACTIVE branch is reachable once _safe_mtime(fpath) is
+    wired in at group_members construction.
+    """
+    from check_items_prefilter import synthetic_classification
+    group = _build_group_from_real_files(tmp_path, "Investigate new feature discovery", old=False)
+    result = synthetic_classification(group)
+    assert result["classification"] == "ACTIVE", (
+        f"Expected ACTIVE for 20-day-old file mtime; got {result['classification']!r}. "
+        f"mtime={group['instances'][0]['mtime']} — "
+        "If STALE, mtime is likely still missing/0 from group_members (the original bug)."
+    )
+    assert result["confidence"] == "LOW"
+    assert result["prefiltered"] is True
+
+
+def test_mtime_threading_old_and_new_files_differ(tmp_path):
+    """Old and new groups must classify differently — STALE vs ACTIVE.
+
+    Regression guard: ensures both branches are independently exercised.
+    If either file's mtime were missing (→ 0 → epoch → STALE), the new
+    file would incorrectly be STALE and this assertion would fail.
+    """
+    from check_items_prefilter import synthetic_classification
+    old_group = _build_group_from_real_files(tmp_path, "Fix ancient configuration bug", old=True)
+    new_group = _build_group_from_real_files(tmp_path, "Ship new dashboard feature", old=False)
+    old_result = synthetic_classification(old_group)
+    new_result = synthetic_classification(new_group)
+    assert old_result["classification"] == "STALE"
+    assert new_result["classification"] == "ACTIVE"
+    assert old_result["classification"] != new_result["classification"], (
+        "Old and new groups must classify differently — if both are STALE, "
+        "mtime is likely not reaching synthetic_classification (original bug)."
+    )

--- a/tests/test_check_items_prefilter.py
+++ b/tests/test_check_items_prefilter.py
@@ -228,3 +228,30 @@ def test_synthetic_classification_now_injection_stale():
     assert result["classification"] == "STALE"
     assert result["confidence"] == "LOW"
     assert result["prefiltered"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests for is_prefilter_enabled
+# ---------------------------------------------------------------------------
+
+def test_prefilter_enabled_by_default(monkeypatch):
+    """CHECK_ITEMS_PREFILTER not set → prefilter is enabled."""
+    import check_items_prefilter
+    monkeypatch.delenv("CHECK_ITEMS_PREFILTER", raising=False)
+    assert check_items_prefilter.is_prefilter_enabled() is True
+
+
+def test_prefilter_disabled_by_off(monkeypatch):
+    """CHECK_ITEMS_PREFILTER=off → prefilter disabled (case-insensitive)."""
+    import check_items_prefilter
+    for val in ("off", "OFF", "Off"):
+        monkeypatch.setenv("CHECK_ITEMS_PREFILTER", val)
+        assert check_items_prefilter.is_prefilter_enabled() is False, f"Expected False for {val!r}"
+
+
+def test_prefilter_enabled_for_non_off_values(monkeypatch):
+    """Any value other than 'off' (case-insensitive) leaves prefilter enabled."""
+    import check_items_prefilter
+    for val in ("on", "1", "true", "yes", ""):
+        monkeypatch.setenv("CHECK_ITEMS_PREFILTER", val)
+        assert check_items_prefilter.is_prefilter_enabled() is True, f"Expected True for {val!r}"

--- a/tests/test_check_items_smart.py
+++ b/tests/test_check_items_smart.py
@@ -686,6 +686,9 @@ def test_run_classifier_picks_haiku_at_30_or_fewer(tmp_path, monkeypatch):
     """<=30 merged groups -> claude -p --model haiku per spec line 106."""
     import check_items_cli as cli
 
+    # Disable L2 prefilter: this test exercises sub-agent model selection, not L2.
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "off")
+
     captured = {}
 
     def fake_run(cmd, *args, **kwargs):
@@ -712,6 +715,9 @@ def test_run_classifier_picks_haiku_at_30_or_fewer(tmp_path, monkeypatch):
 def test_run_classifier_picks_sonnet_above_30(tmp_path, monkeypatch):
     """>30 merged groups escalates to sonnet."""
     import check_items_cli as cli
+
+    # Disable L2 prefilter: this test exercises sub-agent model selection, not L2.
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "off")
 
     captured = {}
 
@@ -813,6 +819,9 @@ def test_run_classifier_timeout_returns_3(tmp_path, monkeypatch):
     """run_classifier returns 3 on subprocess timeout."""
     import check_items_cli as cli
 
+    # Disable L2 prefilter so group reaches sub-agent and can trigger timeout.
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "off")
+
     def fake_run(cmd, *args, **kwargs):
         raise subprocess.TimeoutExpired(cmd, SUBAGENT_TIMEOUT_SEC)
 
@@ -829,6 +838,9 @@ def test_run_classifier_nonzero_rc_propagated(tmp_path, monkeypatch):
     """run_classifier propagates non-zero subprocess return code."""
     import check_items_cli as cli
 
+    # Disable L2 prefilter so group reaches sub-agent and can return non-zero rc.
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "off")
+
     monkeypatch.setattr(cli.subprocess, "run",
                         lambda *a, **kw: _fake_completed(returncode=7))
     payload = {"groups": [{"group_id": "g1", "project": "p",
@@ -842,6 +854,9 @@ def test_run_classifier_nonzero_rc_propagated(tmp_path, monkeypatch):
 def test_run_classifier_invalid_stdout_json_returns_4(tmp_path, monkeypatch):
     """run_classifier returns 4 when stdout is not valid JSON and output file absent."""
     import check_items_cli as cli
+
+    # Disable L2 prefilter so group reaches sub-agent and can trigger the json-error path.
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "off")
 
     monkeypatch.setattr(cli.subprocess, "run",
                         lambda *a, **kw: _fake_completed(stdout="not-json", returncode=0))
@@ -1499,18 +1514,29 @@ def test_run_classifier_pipes_prompt_via_stdin(tmp_path, monkeypatch):
     """
     import check_items_cli as cli
 
+    # Disable L2 prefilter: this test exercises prompt delivery via stdin, not L2.
+    # Also requires at least one group with content so sub-agent dispatch happens.
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "off")
+
     captured = {}
 
     def fake_run(cmd, *args, **kwargs):
         captured["cmd"] = list(cmd)
         captured["input"] = kwargs.get("input", "")
         out_path = tmp_path / "out.json"
-        out_path.write_text(json.dumps([]))
+        out_path.write_text(json.dumps([
+            {"group_id": "g1", "classification": "ACTIVE", "confidence": "LOW",
+             "canonical_text": "Investigate dispatcher", "evidence_citation": None,
+             "action_required": None}
+        ]))
         return _fake_completed(stdout=out_path.read_text(), returncode=0)
 
     monkeypatch.setattr(cli.subprocess, "run", fake_run)
 
-    payload = {"groups": [], "evidence": {}}
+    payload = {"groups": [{"group_id": "g1", "project": "p",
+                           "representative": "Investigate dispatcher",
+                           "instances": []}],
+               "evidence": {}}
     out_path = tmp_path / "classify.json"
     rc = cli.run_classifier(
         stdin_json=json.dumps(payload),
@@ -1621,6 +1647,9 @@ def test_classifier_stdout_fallback_rejects_invalid_shape(tmp_path, monkeypatch)
     import check_items_cli as cli
     from unittest.mock import patch, MagicMock
 
+    # Disable L2 prefilter so group reaches sub-agent and triggers the fallback path.
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "off")
+
     output_path = str(tmp_path / "out.json")
 
     valid_payload = json.dumps({
@@ -1647,6 +1676,9 @@ def test_classifier_stdout_fallback_accepts_valid_shape(tmp_path, monkeypatch):
     import json
     import check_items_cli as cli
     from unittest.mock import patch, MagicMock
+
+    # Disable L2 prefilter so group reaches sub-agent and triggers the fallback path.
+    monkeypatch.setenv("CHECK_ITEMS_PREFILTER", "off")
 
     output_path = str(tmp_path / "out.json")
 

--- a/tests/test_check_items_smart.py
+++ b/tests/test_check_items_smart.py
@@ -949,6 +949,158 @@ def test_needs_action_surfaces_command(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Task 7: outer telemetry line in classify_groups_with_agent
+# ---------------------------------------------------------------------------
+
+def test_outer_telemetry_line_format(monkeypatch, capsys):
+    """classify_groups_with_agent emits a [check-items] classifier-result line
+    with total_classified/prefiltered/subagent fields and no cache_hit key
+    (cache_hit lives outside this function's visibility — see Task 7 option b)."""
+    import open_item_dedup as oid
+    import re
+
+    def fake_cli_run(cmd, *args, **kwargs):
+        out_path = next((c for c in cmd if isinstance(c, str)
+                         and c.endswith(".json") and "out" in c), None)
+        if out_path:
+            with open(out_path, "w") as f:
+                json.dump([
+                    {
+                        "group_id": "g1",
+                        "classification": "DONE",
+                        "confidence": "HIGH",
+                        "canonical_text": "ship it",
+                        "evidence_citation": "PR #87 merged",
+                        "action_required": None,
+                    },
+                    {
+                        "group_id": "g2",
+                        "classification": "ACTIVE",
+                        "confidence": "LOW",
+                        "canonical_text": "explore growth",
+                        "evidence_citation": None,
+                        "action_required": None,
+                        "prefiltered": True,
+                    },
+                ], f)
+        return _fake_completed(returncode=0)
+
+    monkeypatch.setattr(oid.subprocess, "run", fake_cli_run)
+
+    merged_groups = [
+        {"group_id": "g1", "project": "p", "representative": "ship",
+         "members": [{"file": "a.md", "line": 1, "text": "ship"}]},
+        {"group_id": "g2", "project": "p", "representative": "explore growth",
+         "members": [{"file": "b.md", "line": 2, "text": "explore growth"}]},
+    ]
+    evidence = {"p": {"commits": [], "merged_prs": [], "closed_issues": []}}
+
+    parsed = oid.classify_groups_with_agent(merged_groups, evidence)
+    assert len(parsed) == 2
+
+    captured = capsys.readouterr()
+    outer_lines = [
+        l for l in captured.err.splitlines()
+        if l.startswith("[check-items] classifier-result:")
+    ]
+    assert len(outer_lines) == 1, (
+        f"Expected exactly 1 outer telemetry line, got: {outer_lines}"
+    )
+    line = outer_lines[0]
+
+    # Required fields
+    assert re.search(r'total_classified=2', line), f"Bad total_classified in: {line}"
+    assert re.search(r'prefiltered=1', line), f"Bad prefiltered in: {line}"
+    assert re.search(r'subagent=1', line), f"Bad subagent in: {line}"
+
+    # cache_hit must NOT appear in the outer line (plan Task 7 Step 4 option b:
+    # drop it entirely rather than emit a placeholder).
+    assert "cache_hit" not in line, (
+        f"Outer line must not include cache_hit (orchestration is SKILL.md "
+        f"prose; plan fallback drops the key). Got: {line}"
+    )
+
+
+def test_outer_telemetry_invariant_with_partial_parse(monkeypatch, capsys):
+    """total_classified must equal prefiltered + subagent even when the CLI
+    returns fewer records than merged_groups (e.g. partial parse, dropped
+    entries). All three counts derive from `parsed`, not merged_groups."""
+    import open_item_dedup as oid
+    import re
+
+    # 3 input groups but CLI only returns 2 records (one dropped/lost).
+    # Of the 2 returned: 1 prefiltered, 1 subagent.
+    def fake_cli_run(cmd, *args, **kwargs):
+        out_path = next((c for c in cmd if isinstance(c, str)
+                         and c.endswith(".json") and "out" in c), None)
+        if out_path:
+            with open(out_path, "w") as f:
+                json.dump([
+                    {
+                        "group_id": "g1",
+                        "classification": "DONE",
+                        "confidence": "HIGH",
+                        "canonical_text": "ship",
+                        "evidence_citation": "PR #1",
+                        "action_required": None,
+                    },
+                    {
+                        "group_id": "g3",
+                        "classification": "ACTIVE",
+                        "confidence": "LOW",
+                        "canonical_text": "explore",
+                        "evidence_citation": None,
+                        "action_required": None,
+                        "prefiltered": True,
+                    },
+                    # g2 deliberately omitted
+                ], f)
+        return _fake_completed(returncode=0)
+
+    monkeypatch.setattr(oid.subprocess, "run", fake_cli_run)
+
+    merged_groups = [
+        {"group_id": "g1", "project": "p", "representative": "ship",
+         "members": [{"file": "a.md", "line": 1, "text": "ship"}]},
+        {"group_id": "g2", "project": "p", "representative": "dropped",
+         "members": [{"file": "b.md", "line": 2, "text": "dropped"}]},
+        {"group_id": "g3", "project": "p", "representative": "explore",
+         "members": [{"file": "c.md", "line": 3, "text": "explore"}]},
+    ]
+    evidence = {"p": {"commits": [], "merged_prs": [], "closed_issues": []}}
+
+    parsed = oid.classify_groups_with_agent(merged_groups, evidence)
+    assert len(parsed) == 2  # one dropped
+
+    captured = capsys.readouterr()
+    outer_lines = [
+        l for l in captured.err.splitlines()
+        if l.startswith("[check-items] classifier-result:")
+    ]
+    assert len(outer_lines) == 1
+    line = outer_lines[0]
+
+    total_m = re.search(r'total_classified=(\d+)', line)
+    prefiltered_m = re.search(r'prefiltered=(\d+)', line)
+    subagent_m = re.search(r'subagent=(\d+)', line)
+    assert total_m and prefiltered_m and subagent_m, f"Missing field in: {line}"
+
+    total = int(total_m.group(1))
+    prefiltered = int(prefiltered_m.group(1))
+    subagent = int(subagent_m.group(1))
+
+    # Invariant: counts sum correctly. total_classified must reflect parsed,
+    # NOT merged_groups (which would give 3 and break the invariant).
+    assert total == 2, f"total_classified should equal len(parsed)=2, got {total}: {line}"
+    assert prefiltered == 1, f"prefiltered=1, got {prefiltered}: {line}"
+    assert subagent == 1, f"subagent=1, got {subagent}: {line}"
+    assert total == prefiltered + subagent, (
+        f"Invariant broken: total={total} != prefiltered={prefiltered} + "
+        f"subagent={subagent}; line: {line}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Task 17: heuristic fallback classifier
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `hooks/check_items_prefilter.py` — deterministic L2 triage that routes open items with zero completion evidence (no `#N`/commit-sha refs, no token overlap with the evidence bundle) to `synthetic_classification()` instead of dispatching `claude -p`.
- Threads `mtime` through `classify_groups_with_agent` in `open_item_dedup.py` so L2 can compute item age for ACTIVE/STALE decision (threshold: 90 days since earliest member mtime).
- Adds per-run telemetry line to stderr: `[check-items-cli] classifier: total=N cache_hit=- prefiltered=P subagent=S wall=Ws` — greppable for Phase 1 vs Phase 2 comparison.
- Existing L1 cache (`hooks/check_items_cache.py`) is unchanged — L2 slots between L1 and sub-agent dispatch.
- Bypass: `CHECK_ITEMS_PREFILTER=off` disables L2 entirely.

**Deferred:** L1 cache layer was already implemented in `hooks/check_items_cache.py` prior to this branch; this PR covers L2 + telemetry only per user direction 2026-05-15. The outer line's `cache_hit=-` (dash, not a count) reflects that L1 hit/miss accounting was intentionally not added to the telemetry in this pass (plan fallback: L1 bookkeeping deferred).

**Spec:** `docs/superpowers/specs/2026-05-15-check-items-call-reduction-design.md` (§ L2 — Evidence-presence pre-filter)
**Plan:** `docs/superpowers/plans/2026-05-15-check-items-l2-prefilter.md`

Closes #160

## Review fixes

Two follow-up commits from `pr-review-toolkit:review-pr` multi-aspect review:

- `6c92c68` — **C1:** populate `mtime` upstream so L2 ACTIVE branch is reachable.
  Every no-evidence item was classified STALE because both `group_members` construction sites in `deep_analysis_pipeline()` built dicts without `"mtime"`. `m.get("mtime", 0)` always returned 0 (epoch, 1970), so item age was always >> 90 days and the ACTIVE branch was dead code on the real call path. Fix adds `_safe_mtime(path)` helper (OSError → 0.0 + stderr warning) and calls it at both construction sites. Found by `/pr-review-toolkit:review-pr` multi-aspect review.

- `5e637bc` — **I1–I6 bundle:** observability and validation hardening.
  - **I1:** `_bridge_project_evidence` emits stderr `WARN` on unrecognized shape — silent fallthrough was silently STALE-classifying an entire project with no diagnostic surface.
  - **I2:** `run_classifier` validates `group_id` is non-`None` before merging; a `None` key causes silent collision in `merged_by_id`. Returns `rc=5` with a clear diagnostic.
  - **I3:** file-path branch now applies `_validate_classifier_payload()` immediately after `json.loads()`, closing an inconsistency with the stdout-fallback branch; returns `rc=4` on invalid shape.
  - **I4:** `classify_groups_with_agent` in `open_item_dedup.py` emits `WARN` when classifier output contains non-dict records, so dropped entries are visible.
  - **I5:** Two missing integration tests added — `evidence={}` (all-groups synthetic) and end-to-end mtime threading (old file → STALE, new file → ACTIVE, mixed).
  - **I6:** Comment polish — dropped stale `Task-N` references from inline comments.

## Test plan

- [x] `pytest tests/test_check_items_prefilter.py -v` — unit tests for L2 module (tokenize, has_classifiable_evidence, synthetic_classification, env toggle)
- [x] `pytest tests/test_check_items_cli.py -v` — integration tests: all-evidence, no-evidence, mixed+ordering, subprocess never called for all-synthetic
- [x] `pytest tests/test_check_items_cache.py -v` — L1 cache unaffected
- [x] `pytest tests/ -v` — full suite green
- [x] `./scripts/commit-preflight.sh` — green

## Updated test plan

- **1139 pytest pass** (was 1126 before review fixes), **90.54% coverage** (held)
- **13 new tests** added in the two review-fix commits:
  - `test_bridge_project_evidence_fallthrough_emits_warning` (I1)
  - `test_bridge_project_evidence_no_warning_on_shape_a` (I1)
  - `test_bridge_project_evidence_no_warning_on_shape_b` (I1)
  - `test_bridge_project_evidence_no_warning_on_empty` (I1)
  - `test_run_classifier_missing_group_id_returns_error` (I2)
  - `test_run_classifier_missing_group_id_logs_to_stderr` (I2)
  - `test_file_path_branch_validates_schema` (I3)
  - `test_file_path_branch_validates_schema_missing_fields` (I3)
  - `test_non_dict_records_dropped_with_warning` (I4)
  - `test_empty_evidence_dict_all_groups_synthetic` (I5)
  - `test_mtime_threading_old_file_classifies_stale` (I5/C1)
  - `test_mtime_threading_new_file_classifies_active` (I5/C1)
  - `test_mtime_threading_old_and_new_files_differ` (I5/C1)
- **Dogfood Phase 1+2 re-run needed:** The original dogfood run (`prefiltered=10 subagent=0`) confirmed sub-agent dispatch reduction but ran before C1 was fixed — every item was classified STALE. A fresh dogfood run with mtime threading in place is needed to verify the ACTIVE/STALE split is correct (items modified within 90 days should classify ACTIVE, not STALE).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Dogfood verdict (2026-05-15)

Executed the 10-row dogfood result matrix in a fresh CC session at HEAD `369d01c` with `./scripts/test-dev-skill.sh install` confirming the branch-local hooks. Driver: direct `hooks/check_items_cli.py classifier` invocation (Option B of the Task 12 plan).

**9/10 PASS, 1/10 PASS-with-divergence.** All load-bearing claims hold:

| Phase | Result | Evidence |
|-------|--------|----------|
| 3 ACTIVE/STALE correctness (post-C1) | **PASS** | mtime=now-10d → ACTIVE, mtime=now-200d → STALE. C1 mtime threading verified working end-to-end. |
| 5 Kill-switch OFF | PASS | `CHECK_ITEMS_PREFILTER=off` dispatched real `claude` (23s wall for 1 item, rc=0). |
| 9 group_id=None validation | PASS | Exits rc=5 with explicit stderr ERROR. |
| 10 Performance L2-on vs L2-off | **PASS — 584× speedup** | wall_on=0.025s, wall_off=14.661s for 8 items (load-bearing claim was ≥5×). |
| 6 Multi-project WARN noise | PASS-with-divergence | Healthy shape-A payloads emit 0 WARN (fixed). Genuinely unknown shapes still emit 1 WARN per group — not 1 per shape. Filed as https://github.com/abhattacherjee/obsidian-brain/issues/171. |

Full result matrix + verbatim telemetry captures: see [dogfood runbook in obsidian vault](`claude-insights/2026-05-15-dogfood-runbook-pr-164-l2-prefilter-result-matrix-9f41.md`).

**Ship verdict: ready to merge.** All load-bearing correctness, performance, and validation claims are empirically verified. One observability nice-to-have tracked as follow-up.

