### PR TITLE
feat(/recall): upgrade_batch instrumentation (#74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only on failure: `haiku_timeout`, `haiku_subprocess_error`, or `empty_output`.
 - **`upgrade_unsummarized_note`** — now returns
   `tuple[str, float, str | None, str | None]` (status, elapsed_s, model_used,
-  fallback_reason). `model_used` is `"haiku-4.5"` on success; `None` on failure
-  paths. Sonnet/Opus/sub-agent tags reserved for downstream phases (#165, #167).
+  fallback_reason). `model_used` reflects the resolved `summary_model` parameter
+  (default `"haiku"`); `None` on failure paths. `sonnet-4.6` / `opus-*` tags
+  reserved for Phase 3 (#165).
 
 ## [2.5.1] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `model_used`, and `fallback_reason`, and appends one record per call to
   `~/.claude/obsidian-brain-summarizer-metrics.jsonl` (100 KB rotation, owner-only).
   The `/recall` status line now reports total wall time and a per-model breakdown
-  (e.g., `Step 2: upgraded 7 note(s) in 12.4s (5 haiku / 2 fallback)`). Foundation
+  (e.g., `Step 2: upgraded 7 note(s) in 12.4s wall (5 haiku / 2 fallback)`). Foundation
   for the cost-reduction work tracked in #169. (#74)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`/recall` telemetry** — `upgrade_batch()` now returns per-note `elapsed_s`,
+  `model_used`, and `fallback_reason`, and appends one record per call to
+  `~/.claude/obsidian-brain-summarizer-metrics.jsonl` (100 KB rotation, owner-only).
+  The `/recall` status line now reports total wall time and a per-model breakdown
+  (e.g., `Step 2: upgraded 7 note(s) in 12.4s (5 haiku / 2 fallback)`). Foundation
+  for the cost-reduction work tracked in #169. (#74)
+
+### Changed
+- **`upgrade_batch()` return shape** — was `list[tuple[path, status]]`, now
+  `list[dict]` with 5 keys (`path`, `status`, `elapsed_s`, `model_used`,
+  `fallback_reason`). Backward-incompatible for direct callers; in-tree
+  callers (`skills/recall/SKILL.md`, `TestUpgradeBatch` suite) migrated in the same PR.
+- **`generate_summary` / `generate_snapshot_summary`** — now return
+  `tuple[str | None, str | None]` (text + fallback_reason). Reason is non-None
+  only on failure: `haiku_timeout`, `haiku_subprocess_error`, or `empty_output`.
+- **`upgrade_unsummarized_note`** — now returns
+  `tuple[str, float, str | None, str | None]` (status, elapsed_s, model_used,
+  fallback_reason). `model_used` is `"haiku-4.5"` on success; `None` on failure
+  paths. Sonnet/Opus/sub-agent tags reserved for downstream phases (#165, #167).
+
 ## [2.5.1] - 2026-05-16
 
 ### Changed

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1926,12 +1926,16 @@ def generate_snapshot_summary(
     metadata: dict,
     model: str = "haiku",
     timeout: int = 30,
-) -> str | None:
+) -> tuple[str | None, str | None]:
     """Call ``claude -p --model <model>`` with the snapshot-specific prompt.
 
-    Returns None on failure. Reuses the retry/timeout pattern of
-    generate_summary but with a tighter scope (no open-item dedup, no
-    importance scoring — snapshots don't carry those structural fields).
+    Returns ``(summary_text, fallback_reason)``:
+      * On success: ``(text, None)``
+      * On failure: ``(None, "haiku_timeout" | "haiku_subprocess_error" | "empty_output")``
+
+    Reuses the retry/timeout pattern of generate_summary but with a tighter
+    scope (no open-item dedup, no importance scoring — snapshots don't carry
+    those structural fields).
     """
     sampled_user = user_msgs[-10:] if len(user_msgs) > 10 else user_msgs
     sampled_asst = assistant_msgs[-10:] if len(assistant_msgs) > 10 else assistant_msgs
@@ -1942,6 +1946,7 @@ def generate_snapshot_summary(
     prompt = SNAPSHOT_SUMMARY_PROMPT.format(transcript=transcript)
 
     attempts = (timeout, timeout * 2)
+    last_reason: str | None = None
     for i, attempt_timeout in enumerate(attempts):
         try:
             result = subprocess.run(
@@ -1949,14 +1954,20 @@ def generate_snapshot_summary(
                 input=prompt, capture_output=True, text=True, timeout=attempt_timeout,
             )
             if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip()
+                return result.stdout.strip(), None
+            if result.returncode != 0:
+                last_reason = "haiku_subprocess_error"
+            else:
+                last_reason = "empty_output"
             print(f"[obsidian-brain] claude -p (snapshot) failed (rc={result.returncode})",
                   file=sys.stderr)
             break
         except FileNotFoundError:
+            last_reason = "haiku_subprocess_error"
             print("[obsidian-brain] claude CLI not found", file=sys.stderr)
             break
         except subprocess.TimeoutExpired:
+            last_reason = "haiku_timeout"
             if i < len(attempts) - 1:
                 print(f"[obsidian-brain] claude -p (snapshot) timed out at {attempt_timeout}s, retrying...",
                       file=sys.stderr)
@@ -1964,9 +1975,10 @@ def generate_snapshot_summary(
             print(f"[obsidian-brain] claude -p (snapshot) timed out at {attempt_timeout}s",
                   file=sys.stderr)
         except Exception as exc:  # noqa: BLE001
+            last_reason = "haiku_subprocess_error"
             print(f"[obsidian-brain] claude -p (snapshot) error: {exc}", file=sys.stderr)
             break
-    return None
+    return None, last_reason
 
 
 def generate_summary(
@@ -1975,11 +1987,17 @@ def generate_summary(
     metadata: dict,
     model: str = "haiku",
     timeout: int = 30,
-) -> str | None:
+) -> tuple[str | None, str | None]:
     """Call ``claude -p --model <model>`` to summarize the session.
 
+    Returns ``(summary_text, fallback_reason)``:
+      * On success: ``(text, None)``
+      * On failure: ``(None, "haiku_timeout" | "haiku_subprocess_error" | "empty_output")``
+
+    Reserved future reasons (populated by Phase 2 #167 validator, not here):
+      ``"missing_section"``, ``"importance_missing"``, ``"schema_loose"``.
+
     Samples first 10 + last 10 messages for large sessions.
-    Returns None on failure.
     """
     # Sample messages for large sessions
     if len(user_msgs) > 20:
@@ -2074,6 +2092,7 @@ Rate this session 1-10. 1-3: trivial (config, interrupted). 4-6: standard work. 
             prompt += f"- {item_text}\n"
 
     attempts = (timeout, timeout * 2)  # escalate on first timeout
+    last_reason: str | None = None
     for i, attempt_timeout in enumerate(attempts):
         try:
             result = subprocess.run(
@@ -2088,30 +2107,42 @@ Rate this session 1-10. 1-3: trivial (config, interrupted). 4-6: standard work. 
                 # Layer 2: Post-generation dedup pass (string-based, pre-write)
                 if existing_items:
                     summary_text = _dedup_summary_open_items(summary_text, existing_items)
-                return summary_text
+                return summary_text, None
+            if result.returncode != 0:
+                last_reason = "haiku_subprocess_error"
+                print(
+                    f"[obsidian-brain] claude -p failed (rc={result.returncode}): "
+                    f"{result.stderr[:200]}",
+                    file=sys.stderr,
+                )
+                break  # non-timeout failure, don't retry
+            last_reason = "empty_output"
             print(
                 f"[obsidian-brain] claude -p failed (rc={result.returncode}): "
                 f"{result.stderr[:200]}",
                 file=sys.stderr,
             )
-            break  # non-timeout failure, don't retry
+            break  # empty stdout, don't retry
         except FileNotFoundError:
+            last_reason = "haiku_subprocess_error"
             print(
                 "[obsidian-brain] claude CLI not found, summarization unavailable",
                 file=sys.stderr,
             )
             break  # won't succeed on retry
         except subprocess.TimeoutExpired as exc:
+            last_reason = "haiku_timeout"
             stderr_snippet = f" stderr: {exc.stderr[:200]}" if exc.stderr else ""
             if i < len(attempts) - 1:
                 print(f"[obsidian-brain] claude -p timed out at {attempt_timeout}s, retrying with {attempts[i+1]}s{stderr_snippet}", file=sys.stderr)
                 continue
             print(f"[obsidian-brain] claude -p timed out at {attempt_timeout}s, giving up{stderr_snippet}", file=sys.stderr)
         except Exception as exc:
+            last_reason = "haiku_subprocess_error"
             print(f"[obsidian-brain] claude -p error ({type(exc).__name__}): {exc}", file=sys.stderr)
             break  # unknown error, don't retry
 
-    return None
+    return None, last_reason
 
 
 # ---------------------------------------------------------------------------
@@ -4268,7 +4299,7 @@ def upgrade_unsummarized_note(
         gen_kwargs["timeout"] = summary_timeout
 
     if note_type == "claude-snapshot":
-        summary_text = generate_snapshot_summary(
+        summary_text, fallback_reason = generate_snapshot_summary(
             user_msgs, assistant_msgs, metadata, **gen_kwargs,
         )
     else:
@@ -4287,7 +4318,7 @@ def upgrade_unsummarized_note(
             # prepend it to its sampled transcript. New optional key; existing
             # callers unaffected (absent key → no-op).
             metadata["snapshot_preamble"] = preamble
-        summary_text = generate_summary(
+        summary_text, fallback_reason = generate_summary(
             user_msgs, assistant_msgs, metadata, **gen_kwargs,
         )
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -3117,13 +3117,13 @@ def upgrade_and_collect_corpus(
                 continue
 
             try:
-                result = upgrade_unsummarized_note(
+                status, _elapsed, _model, _reason = upgrade_unsummarized_note(
                     note_path=str(md_file),
                     vault_path=vault_path,
                     sessions_folder=sessions_folder,
                     project=meta.get("project", ""),
                 )
-                if result and not result.startswith("Failed"):
+                if not status.startswith("Failed"):
                     upgraded += 1
                     # Bust metadata cache for this note
                     session_id = meta.get("session_id", "")

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -22,6 +22,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 try:
@@ -4173,27 +4174,46 @@ def upgrade_unsummarized_note(
     project: str,
     summary_model: str = "haiku",
     summary_timeout: int | None = None,
-) -> str:
+) -> tuple[str, float, str | None, str | None]:
     """Upgrade an unsummarized session note with an AI summary.
 
     Orchestrates: find JSONL → parse transcript → decide source →
     generate summary → dedup open items → atomic write.
 
-    Returns a one-line status string for the model to relay.
+    Returns a 4-tuple ``(status, elapsed_s, model_used, fallback_reason)``:
 
-    Return contract: success strings begin with ``"Upgraded "``; all other
-    return values (including ``"Failed: ..."``, empty, or any unexpected
-    prefix) indicate failure. Callers routing on return value — notably
-    ``skills/recall/SKILL.md`` Step 2 Phase 1 — MUST check the ``"Upgraded "``
-    prefix as the positive path. Adding any new return prefix to this
-    function requires an audit of routing call sites.
+    - **status** (*str*) — one-line status string for the model to relay.
+      Success strings begin with ``"Upgraded "``; all other values (including
+      ``"Failed: ..."``) indicate failure. Callers routing on return value —
+      notably ``skills/recall/SKILL.md`` Step 2 Phase 1 — MUST check the
+      ``"Upgraded "`` prefix as the positive path.
+    - **elapsed_s** (*float*) — wall-clock seconds rounded to 2 decimal places.
+    - **model_used** (*str | None*) — model that produced the summary, or
+      ``None`` on failure paths that never reached summarization. Day-one
+      values: ``"haiku-4.5"`` on success, ``None`` on all failure paths.
+      Sonnet/Opus/sub-agent tags are reserved for Phase 2/3 instrumentation.
+    - **fallback_reason** (*str | None*) — non-``None`` when
+      ``generate_summary`` / ``generate_snapshot_summary`` used a fallback
+      strategy; threaded through from those functions unchanged.
+
+    Adding any new return prefix to the ``status`` field requires an audit
+    of routing call sites.
     """
+    _t0 = time.monotonic()
+
+    def _ret(
+        status: str,
+        model_used: str | None = None,
+        fallback_reason: str | None = None,
+    ) -> tuple[str, float, str | None, str | None]:
+        return status, round(time.monotonic() - _t0, 2), model_used, fallback_reason
+
     # Read the raw note
     try:
         with open(note_path, 'r', encoding='utf-8') as f:
             raw_lines = f.readlines()
     except OSError as exc:
-        return f"Failed: cannot read {os.path.basename(note_path)}: {exc}"
+        return _ret(f"Failed: cannot read {os.path.basename(note_path)}: {exc}")
 
     # Extract session_id from frontmatter
     session_id = None
@@ -4203,7 +4223,7 @@ def upgrade_unsummarized_note(
             session_id = stripped.split(':', 1)[1].strip().strip('"').strip("'")
             break
     if not session_id:
-        return f"Failed: no session_id in frontmatter of {os.path.basename(note_path)}"
+        return _ret(f"Failed: no session_id in frontmatter of {os.path.basename(note_path)}")
 
     # Find and parse the JSONL transcript
     jsonl_path = find_transcript_jsonl(session_id)
@@ -4268,7 +4288,7 @@ def upgrade_unsummarized_note(
                     assistant_msgs.append(stripped[14:].strip())
 
     if not user_msgs and not assistant_msgs:
-        return f"Failed: no conversation content in {os.path.basename(note_path)}"
+        return _ret(f"Failed: no conversation content in {os.path.basename(note_path)}")
 
     # Build metadata for generate_summary
     metadata: dict = {"project": project, "vault_path": vault_path, "sessions_folder": sessions_folder}
@@ -4323,12 +4343,17 @@ def upgrade_unsummarized_note(
         )
 
     if not summary_text:
-        return f"Failed: AI summarization returned empty for {os.path.basename(note_path)}"
+        return _ret(
+            f"Failed: AI summarization returned empty for {os.path.basename(note_path)}",
+            model_used=None,
+            fallback_reason=fallback_reason,
+        )
 
-    return upgrade_note_with_summary(
+    status = upgrade_note_with_summary(
         note_path, summary_text, vault_path, sessions_folder, project,
         source=source, warnings=warnings,
     )
+    return _ret(status, model_used="haiku-4.5", fallback_reason=None)
 
 
 def upgrade_batch(
@@ -4389,7 +4414,10 @@ def upgrade_batch(
         results: list[tuple[str, str]] = []
         for p, fut in zip(paths, futs):
             try:
-                results.append((p, fut.result()))
+                # Task 7 rewrites this loop to the dict shape; for now unpack
+                # the 4-tuple and preserve the existing (path, status) contract.
+                status, _elapsed, _model, _reason = fut.result()
+                results.append((p, status))
             except Exception as exc:  # noqa: BLE001 — per-note isolation
                 results.append((p, f"Failed: {type(exc).__name__}: {exc}"))
         return results

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -4364,27 +4364,29 @@ def upgrade_batch(
     max_workers: int = 10,
     summary_model: str = "haiku",
     summary_timeout: int | None = None,
-) -> list[tuple[str, str]]:
+) -> list[dict]:
     """Fan out upgrade_unsummarized_note() concurrently.
 
-    Returns a list of (path, status_string) tuples IN THE SAME ORDER AS `paths`
-    (not completion order), so callers that zipped inputs with outputs still work.
-    Individual-call exceptions are caught and converted to
-    "Failed: <exc_type>: <exc_msg>" status strings so one bad note never kills
-    the batch.
+    Returns a list of per-note dicts IN THE SAME ORDER AS ``paths`` (not
+    completion order). Each dict has the keys:
 
-    Raises ``ValueError`` if ``max_workers < 1`` — surface caller config bugs
-    at the boundary rather than silently normalizing to a single worker.
+      * ``path``  — vault note path (echoes input)
+      * ``status`` — one-line status string; success starts with ``"Upgraded "``
+      * ``elapsed_s`` — wall-time inside the worker, rounded to 2 dp
+      * ``model_used`` — see ``upgrade_unsummarized_note`` docstring
+      * ``fallback_reason`` — see ``upgrade_unsummarized_note`` docstring
 
-    Return contract: each ``(path, status)`` tuple carries the same per-entry
-    contract as ``upgrade_unsummarized_note`` — success statuses begin with
-    ``"Upgraded "``; anything else (including ``"Failed: ..."`` or unexpected
-    prefixes) indicates failure. See that function's docstring for details.
+    Side effect: appends one record per call to
+    ``~/.claude/obsidian-brain-summarizer-metrics.jsonl`` via
+    ``summarizer_metrics.append_metrics_record`` (issue #74). The sink never
+    raises, so telemetry failures cannot break this function.
 
-    `claude -p --model haiku` is subprocess-bound, so threads release the GIL
-    during the wait and achieve real parallelism. This lets a single Bash tool
-    call fan out N summaries without the Claude Code shell-pool serialization
-    that would otherwise linearize the work.
+    Per-note exceptions are caught and converted to dicts with
+    ``status="Failed: <exc_type>: <exc_msg>"``, ``elapsed_s=0.0``,
+    ``model_used=None``, ``fallback_reason=None`` so one bad note never
+    kills the batch.
+
+    Raises ``ValueError`` if ``max_workers < 1``.
     """
     if not paths:
         return []
@@ -4392,12 +4394,17 @@ def upgrade_batch(
     if max_workers < 1:
         raise ValueError(f"max_workers must be >= 1, got {max_workers}")
 
-    # Lazy-import so the module stays importable in environments where
-    # concurrent.futures might be stubbed (it's stdlib, so this should always
-    # succeed in CPython, but the lazy import also keeps hook startup cost low).
     from concurrent.futures import ThreadPoolExecutor
+    from datetime import datetime, timezone
+
+    _hooks_dir = os.path.dirname(os.path.abspath(__file__))
+    if _hooks_dir not in sys.path:
+        sys.path.insert(0, _hooks_dir)
+    import summarizer_metrics
 
     workers = min(max_workers, len(paths))
+    _wall_t0 = time.monotonic()
+
     with ThreadPoolExecutor(max_workers=workers) as ex:
         futs = [
             ex.submit(
@@ -4411,13 +4418,29 @@ def upgrade_batch(
             )
             for p in paths
         ]
-        results: list[tuple[str, str]] = []
+        results: list[dict] = []
         for p, fut in zip(paths, futs):
             try:
-                # Task 7 rewrites this loop to the dict shape; for now unpack
-                # the 4-tuple and preserve the existing (path, status) contract.
-                status, _elapsed, _model, _reason = fut.result()
-                results.append((p, status))
+                status, elapsed_s, model_used, fallback_reason = fut.result()
             except Exception as exc:  # noqa: BLE001 — per-note isolation
-                results.append((p, f"Failed: {type(exc).__name__}: {exc}"))
-        return results
+                status = f"Failed: {type(exc).__name__}: {exc}"
+                elapsed_s, model_used, fallback_reason = 0.0, None, None
+            results.append({
+                "path": p,
+                "status": status,
+                "elapsed_s": elapsed_s,
+                "model_used": model_used,
+                "fallback_reason": fallback_reason,
+            })
+
+    wall_s = round(time.monotonic() - _wall_t0, 2)
+
+    summarizer_metrics.append_metrics_record({
+        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "project": project,
+        "n_notes": len(results),
+        "wall_s": wall_s,
+        "notes": results,
+    })
+
+    return results

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1932,11 +1932,16 @@ def generate_snapshot_summary(
 
     Returns ``(summary_text, fallback_reason)``:
       * On success: ``(text, None)``
-      * On failure: ``(None, "haiku_timeout" | "haiku_subprocess_error" | "empty_output")``
+      * On failure: ``(None, "haiku_timeout" | "haiku_subprocess_error" | "empty_output" | "unknown_failure")``
 
     Reuses the retry/timeout pattern of generate_summary but with a tighter
     scope (no open-item dedup, no importance scoring — snapshots don't carry
     those structural fields).
+
+    Note: snapshot summaries are out of scope for the Phase 2 #167 validator
+    (which targets structured session summaries); reserved reasons such as
+    ``"missing_section"`` / ``"importance_missing"`` / ``"schema_loose"`` do
+    not apply here.
     """
     sampled_user = user_msgs[-10:] if len(user_msgs) > 10 else user_msgs
     sampled_asst = assistant_msgs[-10:] if len(assistant_msgs) > 10 else assistant_msgs
@@ -1979,7 +1984,7 @@ def generate_snapshot_summary(
             last_reason = "haiku_subprocess_error"
             print(f"[obsidian-brain] claude -p (snapshot) error: {exc}", file=sys.stderr)
             break
-    return None, last_reason
+    return None, last_reason or "unknown_failure"
 
 
 def generate_summary(
@@ -1993,7 +1998,7 @@ def generate_summary(
 
     Returns ``(summary_text, fallback_reason)``:
       * On success: ``(text, None)``
-      * On failure: ``(None, "haiku_timeout" | "haiku_subprocess_error" | "empty_output")``
+      * On failure: ``(None, "haiku_timeout" | "haiku_subprocess_error" | "empty_output" | "unknown_failure")``
 
     Reserved future reasons (populated by Phase 2 #167 validator, not here):
       ``"missing_section"``, ``"importance_missing"``, ``"schema_loose"``.
@@ -2143,7 +2148,7 @@ Rate this session 1-10. 1-3: trivial (config, interrupted). 4-6: standard work. 
             print(f"[obsidian-brain] claude -p error ({type(exc).__name__}): {exc}", file=sys.stderr)
             break  # unknown error, don't retry
 
-    return None, last_reason
+    return None, last_reason or "unknown_failure"
 
 
 # ---------------------------------------------------------------------------
@@ -4188,13 +4193,16 @@ def upgrade_unsummarized_note(
       notably ``skills/recall/SKILL.md`` Step 2 Phase 1 — MUST check the
       ``"Upgraded "`` prefix as the positive path.
     - **elapsed_s** (*float*) — wall-clock seconds rounded to 2 decimal places.
-    - **model_used** (*str | None*) — model that produced the summary, or
-      ``None`` on failure paths that never reached summarization. Day-one
-      values: ``"haiku-4.5"`` on success, ``None`` on all failure paths.
-      Sonnet/Opus/sub-agent tags are reserved for Phase 2/3 instrumentation.
-    - **fallback_reason** (*str | None*) — non-``None`` when
-      ``generate_summary`` / ``generate_snapshot_summary`` used a fallback
-      strategy; threaded through from those functions unchanged.
+    - **model_used** (*str | None*) — the resolved ``summary_model`` value on
+      success (default ``"haiku"``), or ``None`` on failure paths that never
+      reached summarization. Sonnet/Opus tags are reserved for Phase 3 #165.
+    - **fallback_reason** (*str | None*) — non-``None`` when summarization
+      failed or ``upgrade_batch``'s per-note worker caught an exception.
+      Day-one values: ``"haiku_timeout"``, ``"haiku_subprocess_error"``,
+      ``"empty_output"``, ``"unknown_failure"`` (from generate functions);
+      ``"worker_exception"`` (set by ``upgrade_batch`` when the future raises).
+      Threaded through from ``generate_summary`` / ``generate_snapshot_summary``
+      unchanged on normal failure paths.
 
     Adding any new return prefix to the ``status`` field requires an audit
     of routing call sites.
@@ -4353,7 +4361,9 @@ def upgrade_unsummarized_note(
         note_path, summary_text, vault_path, sessions_folder, project,
         source=source, warnings=warnings,
     )
-    return _ret(status, model_used="haiku-4.5", fallback_reason=None)
+    # summary_model is the CLI alias passed to claude -p --model;
+    # at Phase 1 this is always "haiku" but Phase 3 (#165) will widen the chain.
+    return _ret(status, model_used=summary_model, fallback_reason=None)
 
 
 def upgrade_batch(
@@ -4383,8 +4393,9 @@ def upgrade_batch(
 
     Per-note exceptions are caught and converted to dicts with
     ``status="Failed: <exc_type>: <exc_msg>"``, ``elapsed_s=0.0``,
-    ``model_used=None``, ``fallback_reason=None`` so one bad note never
-    kills the batch.
+    ``model_used=None``, ``fallback_reason="worker_exception"`` so one bad
+    note never kills the batch. The exception message is truncated to 500
+    characters to avoid JSONL blow-out.
 
     Raises ``ValueError`` if ``max_workers < 1``.
     """
@@ -4396,11 +4407,6 @@ def upgrade_batch(
 
     from concurrent.futures import ThreadPoolExecutor
     from datetime import datetime, timezone
-
-    _hooks_dir = os.path.dirname(os.path.abspath(__file__))
-    if _hooks_dir not in sys.path:
-        sys.path.insert(0, _hooks_dir)
-    import summarizer_metrics
 
     workers = min(max_workers, len(paths))
     _wall_t0 = time.monotonic()
@@ -4423,8 +4429,9 @@ def upgrade_batch(
             try:
                 status, elapsed_s, model_used, fallback_reason = fut.result()
             except Exception as exc:  # noqa: BLE001 — per-note isolation
-                status = f"Failed: {type(exc).__name__}: {exc}"
-                elapsed_s, model_used, fallback_reason = 0.0, None, None
+                exc_str = str(exc)[:500]
+                status = f"Failed: {type(exc).__name__}: {exc_str}"
+                elapsed_s, model_used, fallback_reason = 0.0, None, "worker_exception"
             results.append({
                 "path": p,
                 "status": status,
@@ -4435,12 +4442,22 @@ def upgrade_batch(
 
     wall_s = round(time.monotonic() - _wall_t0, 2)
 
-    summarizer_metrics.append_metrics_record({
-        "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "project": project,
-        "n_notes": len(results),
-        "wall_s": wall_s,
-        "notes": results,
-    })
+    try:
+        _hooks_dir = os.path.dirname(os.path.abspath(__file__))
+        if _hooks_dir not in sys.path:
+            sys.path.insert(0, _hooks_dir)
+        import summarizer_metrics
+        summarizer_metrics.append_metrics_record({
+            "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "project": project,
+            "n_notes": len(results),
+            "wall_s": wall_s,
+            "notes": results,
+        })
+    except Exception as exc:  # noqa: BLE001 — telemetry must never break recall
+        print(
+            f"[obsidian-brain] metrics sink unavailable ({type(exc).__name__}): {exc}",
+            file=sys.stderr,
+        )
 
     return results

--- a/hooks/summarizer_metrics.py
+++ b/hooks/summarizer_metrics.py
@@ -1,0 +1,38 @@
+"""Append-only JSONL telemetry sink for upgrade_batch() (issue #74).
+
+One JSON object per upgrade_batch() invocation. Owner-only (0o600). Rotates at
+100 KB to <name>.jsonl.1, overwriting any prior rotation. Never raises —
+instrumentation must not be able to break /recall.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+METRICS_PATH: Path = Path.home() / ".claude" / "obsidian-brain-summarizer-metrics.jsonl"
+ROTATE_BYTES: int = 100 * 1024  # 100 KB
+
+
+def append_metrics_record(record: dict) -> None:
+    """Append one record as a JSON line. Rotates at ROTATE_BYTES.
+    Swallows all errors after a single stderr warning per call."""
+    try:
+        parent = METRICS_PATH.parent
+        parent.mkdir(mode=0o700, exist_ok=True)
+
+        # Rotate first if the existing file is over the threshold. Check BEFORE
+        # append so the post-rotation file contains only this call's line.
+        if METRICS_PATH.exists() and METRICS_PATH.stat().st_size > ROTATE_BYTES:
+            rotated = METRICS_PATH.with_suffix(".jsonl.1")
+            os.replace(METRICS_PATH, rotated)  # atomic; overwrites any prior
+
+        line = json.dumps(record, separators=(",", ":"), ensure_ascii=False) + "\n"
+        new_file = not METRICS_PATH.exists()
+        with open(METRICS_PATH, "a", encoding="utf-8") as f:
+            f.write(line)
+        if new_file:
+            os.chmod(METRICS_PATH, 0o600)
+    except Exception as exc:  # noqa: BLE001 — instrumentation never raises
+        print(f"[obsidian-brain] summarizer_metrics append failed: {exc}", file=sys.stderr)

--- a/hooks/summarizer_metrics.py
+++ b/hooks/summarizer_metrics.py
@@ -1,8 +1,10 @@
 """Append-only JSONL telemetry sink for upgrade_batch() (issue #74).
 
 One JSON object per upgrade_batch() invocation. Owner-only (0o600). Rotates at
-100 KB to <name>.jsonl.1, overwriting any prior rotation. Never raises —
-instrumentation must not be able to break /recall.
+100 KB to <name>.jsonl.1, overwriting any prior rotation. Never raises
+``Exception`` — instrumentation must not be able to break /recall on routine
+I/O failures. (``KeyboardInterrupt`` / ``SystemExit`` still propagate, which is
+correct.)
 """
 from __future__ import annotations
 
@@ -35,4 +37,11 @@ def append_metrics_record(record: dict) -> None:
         if new_file:
             os.chmod(METRICS_PATH, 0o600)
     except Exception as exc:  # noqa: BLE001 — instrumentation never raises
-        print(f"[obsidian-brain] summarizer_metrics append failed: {exc}", file=sys.stderr)
+        try:
+            print(
+                f"[obsidian-brain] summarizer_metrics append failed "
+                f"({type(exc).__name__}): {exc}",
+                file=sys.stderr,
+            )
+        except Exception:
+            pass  # truly airtight; nothing left to log to

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -108,10 +108,12 @@ import sys, os, json
 from collections import Counter
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
 from obsidian_utils import upgrade_batch
+import time
 paths = json.loads(sys.stdin.read())
+_t0 = time.monotonic()
 results = upgrade_batch(paths, sys.argv[1], sys.argv[2], sys.argv[3])
 # results is list[dict] with keys: path, status, elapsed_s, model_used, fallback_reason
-total_s = round(sum(r["elapsed_s"] for r in results), 1)
+wall_s = round(time.monotonic() - _t0, 1)
 model_counts = Counter()
 for r in results:
     tag = r["model_used"] or "fallback"
@@ -119,7 +121,7 @@ for r in results:
 DASH = chr(45)
 breakdown = " / ".join(f"{n} {m.split(DASH)[0]}" for m, n in model_counts.most_common())
 print(json.dumps(results))
-print(f"[obsidian-brain] Step 2: upgraded {len(results)} note(s) in {total_s}s ({breakdown})", file=sys.stderr)
+print(f"[obsidian-brain] Step 2: upgraded {len(results)} note(s) in {wall_s}s wall ({breakdown})", file=sys.stderr)
 ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
 ```
 
@@ -127,7 +129,7 @@ Parse the returned JSON array. Each result dict has: `path`, `status`, `elapsed_
 - `status` starts with `Upgraded ` → mark as succeeded
 - anything else (including `Failed: ...`, empty, or unexpected prefix) → add to the Phase 2 fallback list
 
-The stderr line emits a per-model breakdown visible in the tool trace (e.g. `Step 2: upgraded 7 note(s) in 12.4s (5 haiku / 2 fallback)`).
+The stderr line emits a per-model breakdown visible in the tool trace (e.g. `Step 2: upgraded 7 note(s) in 2.8s wall (5 haiku / 2 fallback)`).
 
 If N <= 5: update each sub-task accordingly (succeeded or `Failed: <basename>`).
 If N > 5: update task #2 subject to `Upgrade N notes: M succeeded, F pending fallback`.

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -111,21 +111,26 @@ from obsidian_utils import upgrade_batch
 import time
 paths = json.loads(sys.stdin.read())
 _t0 = time.monotonic()
-results = upgrade_batch(paths, sys.argv[1], sys.argv[2], sys.argv[3])
-# results is list[dict] with keys: path, status, elapsed_s, model_used, fallback_reason
-wall_s = round(time.monotonic() - _t0, 1)
-model_counts = Counter()
-for r in results:
-    tag = r["model_used"] or "fallback"
-    model_counts[tag] += 1
-DASH = chr(45)
-breakdown = " / ".join(f"{n} {m.split(DASH)[0]}" for m, n in model_counts.most_common())
-print(json.dumps(results))
-print(f"[obsidian-brain] Step 2: upgraded {len(results)} note(s) in {wall_s}s wall ({breakdown})", file=sys.stderr)
+try:
+    results = upgrade_batch(paths, sys.argv[1], sys.argv[2], sys.argv[3])
+    # results is list[dict] with keys: path, status, elapsed_s, model_used, fallback_reason
+    wall_s = round(time.monotonic() - _t0, 1)
+    model_counts = Counter()
+    for r in results:
+        tag = r["model_used"] or "fallback"
+        model_counts[tag] += 1
+    DASH = chr(45)
+    breakdown = " / ".join(f"{n} {m.split(DASH)[0]}" for m, n in model_counts.most_common())
+    print(json.dumps(results))
+    print(f"[obsidian-brain] Step 2: upgraded {len(results)} note(s) in {wall_s}s wall ({breakdown})", file=sys.stderr)
+except Exception as exc:
+    print(json.dumps({"error": f"{type(exc).__name__}: {exc}", "results": []}))
+    print(f"[obsidian-brain] upgrade_batch failed: {exc}", file=sys.stderr)
+    sys.exit(1)
 ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
 ```
 
-Parse the returned JSON array. Each result dict has: `path`, `status`, `elapsed_s`, `model_used` (`haiku-4.5` | `subagent-*` | `None`), `fallback_reason` (`haiku_timeout` | `empty_output` | `haiku_subprocess_error` | `None`). For each entry:
+Parse the returned JSON. If the top-level object contains an `"error"` key, `upgrade_batch` itself failed — treat all notes as failed and fall back to the Phase 2 sub-agent path for each. Otherwise, parse the array normally. Each result dict has: `path`, `status`, `elapsed_s`, `model_used` (`haiku-4.5` on success, `None` on failure; `sonnet-4.6` / `opus-*` reserved for Phase 3 #165), `fallback_reason` (`haiku_timeout` | `empty_output` | `haiku_subprocess_error` | `None`). For each entry:
 - `status` starts with `Upgraded ` → mark as succeeded
 - anything else (including `Failed: ...`, empty, or unexpected prefix) → add to the Phase 2 fallback list
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -105,17 +105,29 @@ If N <= 5, create a sub-task for each note (subject `"Upgrade: <basename>"`, act
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 printf '%s' "$UNSUMMARIZED_PATHS_JSON" | python3 -c '
 import sys, os, json
+from collections import Counter
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
 from obsidian_utils import upgrade_batch
 paths = json.loads(sys.stdin.read())
 results = upgrade_batch(paths, sys.argv[1], sys.argv[2], sys.argv[3])
-print(json.dumps([{"path": p, "status": s} for p, s in results]))
+# results is list[dict] with keys: path, status, elapsed_s, model_used, fallback_reason
+total_s = round(sum(r["elapsed_s"] for r in results), 1)
+model_counts = Counter()
+for r in results:
+    tag = r["model_used"] or "fallback"
+    model_counts[tag] += 1
+DASH = chr(45)
+breakdown = " / ".join(f"{n} {m.split(DASH)[0]}" for m, n in model_counts.most_common())
+print(json.dumps(results))
+print(f"[obsidian-brain] Step 2: upgraded {len(results)} note(s) in {total_s}s ({breakdown})", file=sys.stderr)
 ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
 ```
 
-Parse the returned JSON array. For each entry:
+Parse the returned JSON array. Each result dict has: `path`, `status`, `elapsed_s`, `model_used` (`haiku-4.5` | `subagent-*` | `None`), `fallback_reason` (`haiku_timeout` | `empty_output` | `haiku_subprocess_error` | `None`). For each entry:
 - `status` starts with `Upgraded ` → mark as succeeded
 - anything else (including `Failed: ...`, empty, or unexpected prefix) → add to the Phase 2 fallback list
+
+The stderr line emits a per-model breakdown visible in the tool trace (e.g. `Step 2: upgraded 7 note(s) in 12.4s (5 haiku / 2 fallback)`).
 
 If N <= 5: update each sub-task accordingly (succeeded or `Failed: <basename>`).
 If N > 5: update task #2 subject to `Upgrade N notes: M succeeded, F pending fallback`.

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -193,7 +193,7 @@ python3 -c '
 import sys, os
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
 from obsidian_utils import upgrade_unsummarized_note
-status = upgrade_unsummarized_note(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
+status, *_ = upgrade_unsummarized_note(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
 print(status)
 ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
 ```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,12 @@
 # tests/conftest.py
 """Shared fixtures for obsidian-brain test suite."""
 
+from __future__ import annotations
+
 import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -170,3 +173,18 @@ def sample_jsonl(tmp_path):
         encoding="utf-8",
     )
     return jsonl_path
+
+
+@pytest.fixture(autouse=True)
+def _isolate_summarizer_sink_globally(tmp_path_factory, monkeypatch):
+    """Belt-and-suspenders: redirect summarizer_metrics.METRICS_PATH to a tmp
+    path for every test in the suite. Prevents accidental pollution of
+    ~/.claude/obsidian-brain-summarizer-metrics.jsonl when a future test
+    forgets the per-class fixture."""
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+    try:
+        import summarizer_metrics
+    except ImportError:
+        return  # sink module not present in some test contexts
+    safe_path = tmp_path_factory.mktemp("metrics") / "summarizer-metrics.jsonl"
+    monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", safe_path)

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -2126,7 +2126,7 @@ class TestUpgradeBatch:
                 "## Errors Encountered\n- None.\n\n"
                 "## Open Questions / Next Steps\n- [ ] None.\n\n"
                 "IMPORTANCE: 5\n"
-            )
+            ), None
 
         monkeypatch.setattr(
             obsidian_utils, "generate_summary", fake_generate_summary
@@ -2429,3 +2429,106 @@ def test_get_session_context_cache_key_isolates_distinct_worktrees(tmp_path, mon
     )
     # And canonical project naming must agree on both calls
     assert ctx1["project"] == ctx2["project"] == "obsidian-brain"
+
+
+# ===========================================================================
+# Task 4: generate_summary returns (text, fallback_reason)
+# ===========================================================================
+
+
+class TestGenerateSummaryReturnsFallbackReason:
+    """generate_summary returns (summary, fallback_reason); reason populated only on failure."""
+
+    def test_success_returns_summary_and_none_reason(self, monkeypatch):
+        import obsidian_utils
+
+        class FakeResult:
+            returncode = 0
+            stdout = "## Summary\nOK\n## Importance\n5\n"
+            stderr = ""
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", lambda *a, **kw: FakeResult())
+
+        summary, reason = obsidian_utils.generate_summary(
+            ["hello"], ["hi"], {"project": "t"}, model="haiku", timeout=30,
+        )
+        assert summary.startswith("## Summary")
+        assert reason is None
+
+    def test_timeout_returns_none_and_haiku_timeout(self, monkeypatch):
+        import obsidian_utils
+
+        def fake_run(*a, **kw):
+            raise obsidian_utils.subprocess.TimeoutExpired(cmd=a, timeout=kw["timeout"])
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", fake_run)
+        summary, reason = obsidian_utils.generate_summary(
+            ["hello"], ["hi"], {"project": "t"}, model="haiku", timeout=1,
+        )
+        assert summary is None
+        assert reason == "haiku_timeout"
+
+    def test_nonzero_rc_returns_none_and_subprocess_error(self, monkeypatch):
+        import obsidian_utils
+
+        class FakeResult:
+            returncode = 2
+            stdout = ""
+            stderr = "boom"
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", lambda *a, **kw: FakeResult())
+        summary, reason = obsidian_utils.generate_summary(
+            ["hello"], ["hi"], {"project": "t"}, model="haiku", timeout=30,
+        )
+        assert summary is None
+        assert reason == "haiku_subprocess_error"
+
+    def test_empty_stdout_returns_none_and_empty_output(self, monkeypatch):
+        import obsidian_utils
+
+        class FakeResult:
+            returncode = 0
+            stdout = "   "
+            stderr = ""
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", lambda *a, **kw: FakeResult())
+        summary, reason = obsidian_utils.generate_summary(
+            ["hello"], ["hi"], {"project": "t"}, model="haiku", timeout=30,
+        )
+        assert summary is None
+        assert reason == "empty_output"
+
+
+# ===========================================================================
+# Task 5: generate_snapshot_summary returns (text, fallback_reason)
+# ===========================================================================
+
+
+class TestGenerateSnapshotSummaryReturnsFallbackReason:
+    def test_success_returns_summary_and_none_reason(self, monkeypatch):
+        import obsidian_utils
+
+        class FakeResult:
+            returncode = 0
+            stdout = "snapshot OK"
+            stderr = ""
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", lambda *a, **kw: FakeResult())
+        summary, reason = obsidian_utils.generate_snapshot_summary(
+            ["u"], ["a"], {"project": "t"}, model="haiku", timeout=30,
+        )
+        assert summary == "snapshot OK"
+        assert reason is None
+
+    def test_timeout_returns_none_and_haiku_timeout(self, monkeypatch):
+        import obsidian_utils
+
+        def fake_run(*a, **kw):
+            raise obsidian_utils.subprocess.TimeoutExpired(cmd=a, timeout=kw["timeout"])
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", fake_run)
+        summary, reason = obsidian_utils.generate_snapshot_summary(
+            ["u"], ["a"], {"project": "t"}, model="haiku", timeout=1,
+        )
+        assert summary is None
+        assert reason == "haiku_timeout"

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -1901,20 +1901,8 @@ class TestUpgradeBatch:
     model_used, fallback_reason.
     """
 
-    @pytest.fixture(autouse=True)
-    def _isolate_summarizer_sink(self, tmp_path, monkeypatch):
-        """Prevent the upgrade_batch test class from writing to ~/.claude."""
-        import sys
-        from pathlib import Path
-        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
-        import summarizer_metrics
-        monkeypatch.setattr(
-            summarizer_metrics, "METRICS_PATH",
-            tmp_path / "test-metrics.jsonl",
-        )
-
-    def test_upgrade_batch_empty_list_returns_empty(self, monkeypatch):
-        """Empty input: return [] immediately and never invoke the wrapped fn."""
+    def test_upgrade_batch_empty_list_returns_empty(self, monkeypatch, tmp_path):
+        """Empty input: return [] immediately and never invoke the wrapped fn or the sink."""
         calls = []
 
         def fake_impl(*args, **kwargs):
@@ -1923,16 +1911,21 @@ class TestUpgradeBatch:
 
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
 
+        metrics_path = tmp_path / "test-metrics.jsonl"
+        import summarizer_metrics
+        monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
         result = obsidian_utils.upgrade_batch(
             [], "/vault", "sessions", "proj",
         )
         assert result == []
         assert calls == []
+        assert not metrics_path.exists(), "empty batch must not write a sink record"
 
     def test_upgrade_batch_n1(self, monkeypatch):
         """Single path: single dict with path and status returned."""
         def fake_impl(note_path, *args, **kwargs):
-            return f"Summarized: {os.path.basename(note_path)}", 0.1, "haiku-4.5", None
+            return f"Summarized: {os.path.basename(note_path)}", 0.1, "haiku", None
 
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
 
@@ -1958,7 +1951,7 @@ class TestUpgradeBatch:
 
         def fake_impl(note_path, *args, **kwargs):
             _time.sleep(sleeps[os.path.basename(note_path)])
-            return f"done:{os.path.basename(note_path)}", 0.1, "haiku-4.5", None
+            return f"done:{os.path.basename(note_path)}", 0.1, "haiku", None
 
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
 
@@ -2592,5 +2585,5 @@ class TestUpgradeUnsummarizedNoteReturnsTuple:
         status, elapsed_s, model_used, fallback_reason = result
         assert status.startswith("Upgraded ")
         assert elapsed_s >= 0
-        assert model_used == "haiku-4.5"
+        assert model_used == "haiku"
         assert fallback_reason is None

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -1917,7 +1917,7 @@ class TestUpgradeBatch:
     def test_upgrade_batch_n1(self, monkeypatch):
         """Single path: single (path, status) tuple returned."""
         def fake_impl(note_path, *args, **kwargs):
-            return f"Summarized: {os.path.basename(note_path)}"
+            return f"Summarized: {os.path.basename(note_path)}", 0.1, "haiku-4.5", None
 
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
 
@@ -1941,7 +1941,7 @@ class TestUpgradeBatch:
 
         def fake_impl(note_path, *args, **kwargs):
             _time.sleep(sleeps[os.path.basename(note_path)])
-            return f"done:{os.path.basename(note_path)}"
+            return f"done:{os.path.basename(note_path)}", 0.1, "haiku-4.5", None
 
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
 
@@ -1968,7 +1968,7 @@ class TestUpgradeBatch:
 
         def fake_impl(note_path, *args, **kwargs):
             barrier.wait()  # raises BrokenBarrierError if < N threads ever gather
-            return f"Upgraded {os.path.basename(note_path)} (source: JSONL)"
+            return f"Upgraded {os.path.basename(note_path)} (source: JSONL)", 0.1, "haiku-4.5", None
 
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
         paths = [f"/vault/sessions/note{i}.md" for i in range(N)]
@@ -1983,7 +1983,7 @@ class TestUpgradeBatch:
         def fake_impl(note_path, *args, **kwargs):
             if os.path.basename(note_path) == "three.md":
                 raise RuntimeError("boom")
-            return f"ok:{os.path.basename(note_path)}"
+            return f"ok:{os.path.basename(note_path)}", 0.1, "haiku-4.5", None
 
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
 
@@ -2013,7 +2013,7 @@ class TestUpgradeBatch:
 
         def fake_impl(note_path, *args, **kwargs):
             barrier.wait()
-            return f"Upgraded {os.path.basename(note_path)} (source: JSONL)"
+            return f"Upgraded {os.path.basename(note_path)} (source: JSONL)", 0.1, "haiku-4.5", None
 
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
         paths = [f"/vault/sessions/a{i}.md" for i in range(N)]
@@ -2030,7 +2030,7 @@ class TestUpgradeBatch:
                       summary_model, summary_timeout):
             received["model"] = summary_model
             received["timeout"] = summary_timeout
-            return f"ok:{os.path.basename(note_path)}"
+            return f"ok:{os.path.basename(note_path)}", 0.1, "haiku-4.5", None
 
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
         results = obsidian_utils.upgrade_batch(
@@ -2047,7 +2047,7 @@ class TestUpgradeBatch:
     def test_upgrade_batch_rejects_invalid_max_workers(self, monkeypatch):
         monkeypatch.setattr(
             obsidian_utils, "upgrade_unsummarized_note",
-            lambda *a, **k: "Upgraded test.md (source: ...)",
+            lambda *a, **k: ("Upgraded test.md (source: ...)", 0.1, "haiku-4.5", None),
         )
         for bad in (0, -1, -100):
             with pytest.raises(ValueError, match="max_workers must be >= 1"):
@@ -2066,7 +2066,7 @@ class TestUpgradeBatch:
 
         monkeypatch.setattr(
             obsidian_utils, "upgrade_unsummarized_note",
-            lambda note_path, *a, **k: f"Upgraded {os.path.basename(note_path)} (source: JSONL)",
+            lambda note_path, *a, **k: (f"Upgraded {os.path.basename(note_path)} (source: JSONL)", 0.1, "haiku-4.5", None),
         )
         paths = [
             "/vault/sessions/a.md",
@@ -2532,3 +2532,44 @@ class TestGenerateSnapshotSummaryReturnsFallbackReason:
         )
         assert summary is None
         assert reason == "haiku_timeout"
+
+
+# ===========================================================================
+# Section: upgrade_unsummarized_note — 4-tuple return contract
+# ===========================================================================
+
+
+class TestUpgradeUnsummarizedNoteReturnsTuple:
+    """upgrade_unsummarized_note returns (status, elapsed_s, model_used, fallback_reason)."""
+
+    def test_success_returns_full_tuple(self, monkeypatch, tmp_path):
+        import obsidian_utils
+
+        # Stub the heavy lifting — we're testing wiring, not generation
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+        monkeypatch.setattr(
+            obsidian_utils, "generate_summary",
+            lambda *a, **kw: ("## Summary\nOK", None),
+        )
+        monkeypatch.setattr(
+            obsidian_utils, "upgrade_note_with_summary",
+            lambda *a, **kw: "Upgraded test.md (source: raw note)",
+        )
+
+        # Minimal valid note
+        note = tmp_path / "test.md"
+        note.write_text(
+            "---\nsession_id: abc123\n---\n"
+            "## Conversation (raw)\n**User:** hi\n**Assistant:** hello\n"
+        )
+
+        result = obsidian_utils.upgrade_unsummarized_note(
+            str(note), str(tmp_path), "claude-sessions", "obsidian-brain",
+        )
+        assert isinstance(result, tuple)
+        assert len(result) == 4
+        status, elapsed_s, model_used, fallback_reason = result
+        assert status.startswith("Upgraded ")
+        assert elapsed_s >= 0
+        assert model_used == "haiku-4.5"
+        assert fallback_reason is None

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -1890,13 +1890,28 @@ def test_get_session_id_fast_slow_path_returns_without_writing(tmp_path, monkeyp
 
 
 class TestUpgradeBatch:
-    """Tests for upgrade_batch() — GH #69.
+    """Tests for upgrade_batch() — GH #69, instrumentation GH #74.
 
     `upgrade_unsummarized_note` is monkeypatched with fast fakes so none of
     these tests touch the filesystem, load a vault config, or shell out to
     `claude -p`. That isolation also means the `vault_path`/`sessions_folder`
     args are inert placeholder strings.
+
+    upgrade_batch() now returns list[dict] with keys: path, status, elapsed_s,
+    model_used, fallback_reason.
     """
+
+    @pytest.fixture(autouse=True)
+    def _isolate_summarizer_sink(self, tmp_path, monkeypatch):
+        """Prevent the upgrade_batch test class from writing to ~/.claude."""
+        import sys
+        from pathlib import Path
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+        import summarizer_metrics
+        monkeypatch.setattr(
+            summarizer_metrics, "METRICS_PATH",
+            tmp_path / "test-metrics.jsonl",
+        )
 
     def test_upgrade_batch_empty_list_returns_empty(self, monkeypatch):
         """Empty input: return [] immediately and never invoke the wrapped fn."""
@@ -1915,7 +1930,7 @@ class TestUpgradeBatch:
         assert calls == []
 
     def test_upgrade_batch_n1(self, monkeypatch):
-        """Single path: single (path, status) tuple returned."""
+        """Single path: single dict with path and status returned."""
         def fake_impl(note_path, *args, **kwargs):
             return f"Summarized: {os.path.basename(note_path)}", 0.1, "haiku-4.5", None
 
@@ -1924,7 +1939,9 @@ class TestUpgradeBatch:
         result = obsidian_utils.upgrade_batch(
             ["/vault/sessions/one.md"], "/vault", "sessions", "proj",
         )
-        assert result == [("/vault/sessions/one.md", "Summarized: one.md")]
+        assert len(result) == 1
+        assert result[0]["path"] == "/vault/sessions/one.md"
+        assert result[0]["status"] == "Summarized: one.md"
 
     def test_upgrade_batch_n5_preserves_input_order(self, monkeypatch):
         """5 paths with variable sleeps: return order matches input, not completion order."""
@@ -1949,8 +1966,8 @@ class TestUpgradeBatch:
         result = obsidian_utils.upgrade_batch(paths, "/vault", "sessions", "proj")
 
         assert len(result) == 5
-        assert [p for p, _ in result] == paths, "input order must be preserved"
-        assert [status for _, status in result] == [
+        assert [r["path"] for r in result] == paths, "input order must be preserved"
+        assert [r["status"] for r in result] == [
             "done:a.md", "done:b.md", "done:c.md", "done:d.md", "done:e.md",
         ]
 
@@ -1976,7 +1993,7 @@ class TestUpgradeBatch:
             paths, "/vault", "sessions", "proj", max_workers=N,
         )
         assert len(results) == N
-        assert all(s.startswith("Upgraded ") for _, s in results)
+        assert all(r["status"].startswith("Upgraded ") for r in results)
 
     def test_upgrade_batch_captures_exceptions_per_note(self, monkeypatch):
         """One raising impl does not kill the batch; failure becomes a status string."""
@@ -1992,12 +2009,13 @@ class TestUpgradeBatch:
         result = obsidian_utils.upgrade_batch(paths, "/vault", "sessions", "proj")
 
         assert len(result) == 5
-        assert [p for p, _ in result] == paths
-        assert result[0][1] == "ok:one.md"
-        assert result[1][1] == "ok:two.md"
-        assert result[2] == ("/vault/sessions/three.md", "Failed: RuntimeError: boom")
-        assert result[3][1] == "ok:four.md"
-        assert result[4][1] == "ok:five.md"
+        assert [r["path"] for r in result] == paths
+        assert result[0]["status"] == "ok:one.md"
+        assert result[1]["status"] == "ok:two.md"
+        assert result[2]["path"] == "/vault/sessions/three.md"
+        assert result[2]["status"] == "Failed: RuntimeError: boom"
+        assert result[3]["status"] == "ok:four.md"
+        assert result[4]["status"] == "ok:five.md"
 
     def test_upgrade_batch_max_workers_caps_at_input_size(self, monkeypatch):
         """N=3 < max_workers=10: min() guard still yields real parallelism.
@@ -2021,7 +2039,7 @@ class TestUpgradeBatch:
             paths, "/vault", "sessions", "proj", max_workers=10,
         )
         assert len(results) == N
-        assert all(s.startswith("Upgraded ") for _, s in results)
+        assert all(r["status"].startswith("Upgraded ") for r in results)
 
     def test_upgrade_batch_forwards_model_and_timeout(self, monkeypatch):
         received = {}
@@ -2041,7 +2059,9 @@ class TestUpgradeBatch:
             summary_model="claude-3-5-haiku",
             summary_timeout=30,
         )
-        assert results == [("/vault/sessions/a.md", "ok:a.md")]
+        assert len(results) == 1
+        assert results[0]["path"] == "/vault/sessions/a.md"
+        assert results[0]["status"] == "ok:a.md"
         assert received == {"model": "claude-3-5-haiku", "timeout": 30}
 
     def test_upgrade_batch_rejects_invalid_max_workers(self, monkeypatch):
@@ -2057,10 +2077,11 @@ class TestUpgradeBatch:
                 )
 
     def test_upgrade_batch_skill_md_json_round_trip(self, monkeypatch):
-        """Pins the exact expression used in skills/recall/SKILL.md Phase 1.
+        """Verifies that path and status are accessible by dict key.
 
-        If the tuple contract ever changes (e.g. to list[dict]), this test
-        fails BEFORE production /recall breaks.
+        The shape has migrated from (path, status) tuples to list[dict].
+        Serialization using the new dict-key access pattern is verified here;
+        SKILL.md Step 2 will be updated in Task 9 to match.
         """
         import json
 
@@ -2075,8 +2096,8 @@ class TestUpgradeBatch:
         ]
         results = obsidian_utils.upgrade_batch(paths, "/vault", "sessions", "proj")
 
-        # This is the exact expression from skills/recall/SKILL.md line ~117
-        serialized = json.dumps([{"path": p, "status": s} for p, s in results])
+        # Serialize using dict-key access (new shape)
+        serialized = json.dumps([{"path": r["path"], "status": r["status"]} for r in results])
         parsed = json.loads(serialized)
         assert parsed == [
             {"path": "/vault/sessions/a.md", "status": "Upgraded a.md (source: JSONL)"},
@@ -2142,9 +2163,9 @@ class TestUpgradeBatch:
         )
 
         assert len(results) == 1
-        path_result, status = results[0]
-        assert path_result == str(note_path)
-        assert status.startswith("Upgraded "), f"expected success, got: {status}"
+        assert set(results[0].keys()) == {"path", "status", "elapsed_s", "model_used", "fallback_reason"}
+        assert results[0]["path"] == str(note_path)
+        assert results[0]["status"].startswith("Upgraded "), f"expected success, got: {results[0]['status']}"
 
         # Verify the note was actually rewritten with a summary
         updated = note_path.read_text()

--- a/tests/test_snapshot_e2e.py
+++ b/tests/test_snapshot_e2e.py
@@ -286,9 +286,10 @@ def test_snapshot_e2e_pipeline(tmp_path, monkeypatch):
 
     monkeypatch.setattr("obsidian_utils.subprocess.run", fake_run)
 
-    status = obsidian_utils.upgrade_unsummarized_note(
+    _status_tuple = obsidian_utils.upgrade_unsummarized_note(
         str(session_path), str(vault), "claude-sessions", PROJECT
     )
+    status = _status_tuple[0]
     assert status.startswith("Upgraded "), (
         f"upgrade_unsummarized_note did not succeed: {status!r}"
     )
@@ -311,9 +312,10 @@ def test_snapshot_e2e_pipeline(tmp_path, monkeypatch):
     # snapshots through generate_snapshot_summary (a distinct code path from
     # the generate_summary used for sessions above). Without this, the
     # snapshot-type routing branch is never exercised by the E2E test.
-    snap_status = obsidian_utils.upgrade_unsummarized_note(
+    _snap_status_tuple = obsidian_utils.upgrade_unsummarized_note(
         str(snapshot_path), str(vault), "claude-sessions", PROJECT
     )
+    snap_status = _snap_status_tuple[0]
     assert snap_status.startswith("Upgraded "), (
         f"upgrade_unsummarized_note on snapshot did not succeed: {snap_status!r}"
     )

--- a/tests/test_snapshot_summarization.py
+++ b/tests/test_snapshot_summarization.py
@@ -171,11 +171,11 @@ def test_snapshot_routes_through_snapshot_prompt(tmp_path):
         return (
             "## Summary\nIn-flight work on X interrupted by /compact.\n\n"
             "## Key context that may be lost (summary)\n- Open decision: approach A vs B\n"
-        )
+        ), None
 
     def fake_session_summary(*args, **kwargs):
         calls.append(("session", args, kwargs))
-        return "## Summary\nshould-not-be-used\n"
+        return "## Summary\nshould-not-be-used\n", None
 
     with patch("hooks.obsidian_utils.generate_snapshot_summary", fake_snapshot_summary), \
          patch("hooks.obsidian_utils.generate_summary", fake_session_summary):
@@ -205,7 +205,7 @@ def test_session_routes_through_session_prompt(tmp_path):
 
     def fake_snapshot_summary(*args, **kwargs):
         calls.append(("snapshot", args, kwargs))
-        return "## Summary\nshould-not-be-used\n"
+        return "## Summary\nshould-not-be-used\n", None
 
     def fake_session_summary(*args, **kwargs):
         calls.append(("session", args, kwargs))
@@ -213,7 +213,7 @@ def test_session_routes_through_session_prompt(tmp_path):
             "## Summary\nSession work.\n\n## Key Decisions\n- None noted.\n\n"
             "## Changes Made\n- None noted.\n\n## Errors Encountered\n- None.\n\n"
             "## Open Questions / Next Steps\n- [ ] None.\n\n## Importance\n5\n"
-        )
+        ), None
 
     with patch("hooks.obsidian_utils.generate_snapshot_summary", fake_snapshot_summary), \
          patch("hooks.obsidian_utils.generate_summary", fake_session_summary):

--- a/tests/test_snapshot_summarization.py
+++ b/tests/test_snapshot_summarization.py
@@ -181,7 +181,7 @@ def test_snapshot_routes_through_snapshot_prompt(tmp_path):
          patch("hooks.obsidian_utils.generate_summary", fake_session_summary):
         result = upgrade_unsummarized_note(str(snap_path), str(vault), "claude-sessions", "demo")
 
-    assert not result.startswith("Failed"), result
+    assert not result[0].startswith("Failed"), result[0]
     types_called = [c[0] for c in calls]
     assert types_called == ["snapshot"]
     # File now contains the snapshot-shaped summary
@@ -219,7 +219,7 @@ def test_session_routes_through_session_prompt(tmp_path):
          patch("hooks.obsidian_utils.generate_summary", fake_session_summary):
         result = upgrade_unsummarized_note(str(sess_path), str(vault), "claude-sessions", "demo")
 
-    assert not result.startswith("Failed"), result
+    assert not result[0].startswith("Failed"), result[0]
     types_called = [c[0] for c in calls]
     assert types_called == ["session"]
 

--- a/tests/test_summarizer_metrics.py
+++ b/tests/test_summarizer_metrics.py
@@ -1,0 +1,79 @@
+"""Tests for hooks/summarizer_metrics.py — JSONL telemetry sink for upgrade_batch()."""
+from __future__ import annotations
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "hooks"))
+import summarizer_metrics  # noqa: E402
+
+
+def test_append_creates_file_with_0600_perms(tmp_path, monkeypatch):
+    """First call creates the .jsonl file with owner-only perms and a valid line."""
+    metrics_path = tmp_path / "summarizer-metrics.jsonl"
+    monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
+    record = {
+        "ts": "2026-05-16T08:42:13Z",
+        "project": "obsidian-brain",
+        "session_id": "9367",
+        "n_notes": 1,
+        "wall_s": 1.8,
+        "notes": [
+            {"path": "/v/a.md", "status": "Upgraded a.md",
+             "elapsed_s": 1.8, "model_used": "haiku-4.5", "fallback_reason": None}
+        ],
+    }
+    summarizer_metrics.append_metrics_record(record)
+
+    assert metrics_path.exists()
+    assert oct(metrics_path.stat().st_mode)[-3:] == "600"
+    lines = metrics_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["n_notes"] == 1
+    assert parsed["notes"][0]["model_used"] == "haiku-4.5"
+
+
+def test_rotates_when_file_exceeds_threshold(tmp_path, monkeypatch):
+    """When file size > ROTATE_BYTES, next append rotates to .jsonl.1 and starts fresh."""
+    metrics_path = tmp_path / "summarizer-metrics.jsonl"
+    monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+    monkeypatch.setattr(summarizer_metrics, "ROTATE_BYTES", 500)  # tiny threshold
+
+    # Fill above threshold with a few records (~115 bytes each x 5 = ~575 bytes)
+    for i in range(5):
+        summarizer_metrics.append_metrics_record({"i": i, "pad": "x" * 100})
+
+    assert metrics_path.stat().st_size > 200, "precondition: file is above threshold"
+
+    # Next append should rotate
+    summarizer_metrics.append_metrics_record({"after_rotate": True})
+
+    rotated = metrics_path.with_suffix(".jsonl.1")
+    assert rotated.exists(), "previous file should be moved to .jsonl.1"
+    # Fresh file contains only the post-rotation line
+    lines = metrics_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {"after_rotate": True}
+    assert oct(metrics_path.stat().st_mode)[-3:] == "600"
+
+
+def test_write_failure_does_not_raise(tmp_path, monkeypatch, capsys):
+    """If the sink can't write, it must log to stderr and return None — never raise."""
+    # Point METRICS_PATH inside a non-existent parent that cannot be created
+    # (parent of parent is a file, not a dir, so mkdir will fail).
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a dir")
+    metrics_path = blocker / "subdir" / "metrics.jsonl"
+    monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
+    # Must not raise
+    result = summarizer_metrics.append_metrics_record({"k": "v"})
+    assert result is None
+
+    err = capsys.readouterr().err
+    assert "summarizer_metrics append failed" in err

--- a/tests/test_summarizer_metrics.py
+++ b/tests/test_summarizer_metrics.py
@@ -77,3 +77,41 @@ def test_write_failure_does_not_raise(tmp_path, monkeypatch, capsys):
 
     err = capsys.readouterr().err
     assert "summarizer_metrics append failed" in err
+
+
+def test_does_not_rotate_at_exact_threshold(tmp_path, monkeypatch):
+    """Strict > predicate: file at exactly ROTATE_BYTES should NOT rotate on next append."""
+    metrics_path = tmp_path / "summarizer-metrics.jsonl"
+    monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+    monkeypatch.setattr(summarizer_metrics, "ROTATE_BYTES", 100)
+
+    # Pre-seed file to exactly ROTATE_BYTES bytes using a valid JSONL line
+    # (padded to exactly 100 bytes including the trailing newline).
+    pad = "x" * (98 - len('{"seed":true}'))
+    seed_line = f'{{"seed":true,"pad":"{pad}"}}\n'
+    # Adjust to hit exactly 100 bytes
+    seed_line = ("x" * 99 + "\n")  # 100 bytes, valid text, not valid JSON but doesn't matter
+    assert len(seed_line.encode("utf-8")) == 100
+    metrics_path.write_text(seed_line, encoding="utf-8")
+
+    summarizer_metrics.append_metrics_record({"new": "line"})
+
+    rotated = metrics_path.with_suffix(".jsonl.1")
+    assert not rotated.exists(), "should not rotate when size == ROTATE_BYTES (strict >)"
+    # The new record must be in the main file (two lines total)
+    lines = metrics_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[-1]) == {"new": "line"}
+
+
+def test_non_json_serializable_record_does_not_raise(tmp_path, monkeypatch, capsys):
+    """A non-JSON-serializable record must never raise — log to stderr and return None."""
+    metrics_path = tmp_path / "summarizer-metrics.jsonl"
+    monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
+    # An `object()` is not JSON-serializable; json.dumps raises TypeError
+    result = summarizer_metrics.append_metrics_record({"k": object()})
+    assert result is None
+    err = capsys.readouterr().err
+    assert "summarizer_metrics append failed" in err
+    assert "TypeError" in err

--- a/tests/test_upgrade_batch_telemetry.py
+++ b/tests/test_upgrade_batch_telemetry.py
@@ -37,7 +37,7 @@ def test_upgrade_batch_returns_dicts_with_all_five_fields(monkeypatch, tmp_path,
     )
 
     def fake_uun(path, *a, **kw):
-        return (f"Upgraded {os.path.basename(path)}", 0.5, "haiku-4.5", None)
+        return (f"Upgraded {os.path.basename(path)}", 0.5, "haiku", None)
 
     monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_uun)
 
@@ -54,7 +54,7 @@ def test_upgrade_batch_returns_dicts_with_all_five_fields(monkeypatch, tmp_path,
         assert set(r.keys()) == {"path", "status", "elapsed_s", "model_used", "fallback_reason"}
         assert r["status"].startswith("Upgraded ")
         assert r["elapsed_s"] >= 0
-        assert r["model_used"] == "haiku-4.5"
+        assert r["model_used"] == "haiku"
         assert r["fallback_reason"] is None
     assert result[0]["path"] == str(p1)
     assert result[1]["path"] == str(p2)
@@ -66,7 +66,7 @@ def test_upgrade_batch_writes_telemetry_record(monkeypatch, tmp_path, fake_note)
     monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
 
     def fake_uun(path, *a, **kw):
-        return (f"Upgraded {os.path.basename(path)}", 0.5, "haiku-4.5", None)
+        return (f"Upgraded {os.path.basename(path)}", 0.5, "haiku", None)
 
     monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_uun)
 
@@ -84,7 +84,7 @@ def test_upgrade_batch_writes_telemetry_record(monkeypatch, tmp_path, fake_note)
     assert "ts" in rec
     assert rec["wall_s"] >= 0
     assert len(rec["notes"]) == 1
-    assert rec["notes"][0]["model_used"] == "haiku-4.5"
+    assert rec["notes"][0]["model_used"] == "haiku"
 
 
 def test_upgrade_batch_per_note_failure_captured_with_reason(monkeypatch, tmp_path, fake_note):

--- a/tests/test_upgrade_batch_telemetry.py
+++ b/tests/test_upgrade_batch_telemetry.py
@@ -1,0 +1,114 @@
+"""Tests for upgrade_batch() return shape + telemetry sink wiring (issue #74)."""
+from __future__ import annotations
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "hooks"))
+import obsidian_utils  # noqa: E402
+import summarizer_metrics  # noqa: E402
+
+
+@pytest.fixture
+def fake_note(tmp_path):
+    """Return a factory producing a minimal valid session note in tmp_path/claude-sessions/."""
+    sess_dir = tmp_path / "claude-sessions"
+    sess_dir.mkdir()
+
+    def _make(name: str = "n.md", session_id: str = "abc"):
+        p = sess_dir / name
+        p.write_text(
+            f"---\nsession_id: {session_id}\nproject: obsidian-brain\n---\n"
+            "## Conversation (raw)\n**User:** hi\n**Assistant:** hello\n"
+        )
+        return p
+    return _make
+
+
+def test_upgrade_batch_returns_dicts_with_all_five_fields(monkeypatch, tmp_path, fake_note):
+    """Happy-path: returns list[dict] with path, status, elapsed_s, model_used, fallback_reason."""
+    monkeypatch.setattr(
+        summarizer_metrics, "METRICS_PATH",
+        tmp_path / "metrics.jsonl",
+    )
+
+    def fake_uun(path, *a, **kw):
+        return (f"Upgraded {os.path.basename(path)}", 0.5, "haiku-4.5", None)
+
+    monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_uun)
+
+    p1 = fake_note("a.md", "s1")
+    p2 = fake_note("b.md", "s2")
+
+    result = obsidian_utils.upgrade_batch(
+        [str(p1), str(p2)], str(tmp_path), "claude-sessions", "obsidian-brain",
+    )
+
+    assert isinstance(result, list)
+    assert len(result) == 2
+    for r in result:
+        assert set(r.keys()) == {"path", "status", "elapsed_s", "model_used", "fallback_reason"}
+        assert r["status"].startswith("Upgraded ")
+        assert r["elapsed_s"] >= 0
+        assert r["model_used"] == "haiku-4.5"
+        assert r["fallback_reason"] is None
+    assert result[0]["path"] == str(p1)
+    assert result[1]["path"] == str(p2)
+
+
+def test_upgrade_batch_writes_telemetry_record(monkeypatch, tmp_path, fake_note):
+    """Telemetry sink gets exactly one record per upgrade_batch call, with embedded per-note array."""
+    metrics_path = tmp_path / "metrics.jsonl"
+    monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
+    def fake_uun(path, *a, **kw):
+        return (f"Upgraded {os.path.basename(path)}", 0.5, "haiku-4.5", None)
+
+    monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_uun)
+
+    p1 = fake_note("a.md", "s1")
+    obsidian_utils.upgrade_batch(
+        [str(p1)], str(tmp_path), "claude-sessions", "obsidian-brain",
+    )
+
+    assert metrics_path.exists()
+    lines = metrics_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["project"] == "obsidian-brain"
+    assert rec["n_notes"] == 1
+    assert "ts" in rec
+    assert rec["wall_s"] >= 0
+    assert len(rec["notes"]) == 1
+    assert rec["notes"][0]["model_used"] == "haiku-4.5"
+
+
+def test_upgrade_batch_per_note_failure_captured_with_reason(monkeypatch, tmp_path, fake_note):
+    """A note that failed with fallback_reason carries it through into the dict + telemetry."""
+    metrics_path = tmp_path / "metrics.jsonl"
+    monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
+    def fake_uun(path, *a, **kw):
+        return (
+            f"Failed: AI summarization returned empty for {os.path.basename(path)}",
+            1.2, None, "haiku_timeout",
+        )
+
+    monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_uun)
+
+    p1 = fake_note("a.md", "s1")
+    result = obsidian_utils.upgrade_batch(
+        [str(p1)], str(tmp_path), "claude-sessions", "obsidian-brain",
+    )
+
+    assert len(result) == 1
+    assert result[0]["status"].startswith("Failed:")
+    assert result[0]["model_used"] is None
+    assert result[0]["fallback_reason"] == "haiku_timeout"
+
+    rec = json.loads(metrics_path.read_text(encoding="utf-8").splitlines()[0])
+    assert rec["notes"][0]["fallback_reason"] == "haiku_timeout"


### PR DESCRIPTION
## Summary
- Plumbs `elapsed_s`, `model_used`, `fallback_reason` through `generate_summary` → `upgrade_unsummarized_note` → `upgrade_batch`.
- New module `hooks/summarizer_metrics.py` appends one record per `upgrade_batch()` invocation to `~/.claude/obsidian-brain-summarizer-metrics.jsonl` (100 KB rotation, owner-only, never raises).
- `skills/recall/SKILL.md` Step 2 emits a per-model breakdown in its status line (e.g., `Step 2: upgraded 7 note(s) in 12.4s (5 haiku / 2 fallback)`).
- Foundation for measuring the cost-reduction work tracked in #169 (#165, #166, #167).

## Scope clarifications (vs spec)
- `model_used` reflects the resolved `summary_model` CLI alias (default `"haiku"`); `None` on failure paths. `sonnet-4.6` / `opus-*` reserved for Phase 3 (#165).
- `fallback_reason` enum reserves `"missing_section"` / `"importance_missing"` / `"schema_loose"` for Phase 2 (#167); day-one values are `"haiku_timeout"` / `"empty_output"` / `"haiku_subprocess_error"`.

## Backward-incompatible API changes
- `upgrade_batch()`: `list[tuple[path, status]]` → `list[dict]` with 5 keys.
- `generate_summary()` / `generate_snapshot_summary()`: `str | None` → `tuple[str | None, str | None]`.
- `upgrade_unsummarized_note()`: `str` → `tuple[str, float, str | None, str | None]`.

All in-tree callers (`upgrade_and_collect_corpus`, `skills/standup/SKILL.md`, `skills/recall/SKILL.md`, 10 `TestUpgradeBatch` tests, plus snapshot test fakes) migrated in the same PR.

## Test plan
- [x] `tests/test_summarizer_metrics.py` — 3 tests (create+perms, rotate, never-raise)
- [x] `tests/test_upgrade_batch_telemetry.py` — 3 tests (return shape, sink write, fallback_reason propagation)
- [x] `TestGenerateSummaryReturnsFallbackReason` (4 tests) + `TestGenerateSnapshotSummaryReturnsFallbackReason` (2 tests)
- [x] `TestUpgradeUnsummarizedNoteReturnsTuple` (1 test)
- [x] 10 existing `test_upgrade_batch_*` tests migrated to dict-key access (sink-isolation fixture prevents `~/.claude` pollution)
- [x] Live synthetic smoke against the real telemetry path — record landed with all 5 keys, perms `0o600`
- [x] Full suite: **1211 passed, 0 failed** (was 1198 before this PR)

## Commits
- `aca90fa` — sink module (Tasks 1-3)
- `24cc2e2` — generate_summary tuple return (Tasks 4-5)
- `f87e9e6` + `c90797e` — upgrade_unsummarized_note 4-tuple + 2 missed-caller fixes (Task 6)
- `783531b` — upgrade_batch list[dict] + telemetry + test migration (Tasks 7-8)
- `4935305` — SKILL.md per-model breakdown (Task 9)
- `6e10d21` — CHANGELOG (Task 11)

Closes #74. Part of #169.
