### PR TITLE
feat(metrics): route /standup + upgrade_and_collect_corpus through telemetry sink (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (default `"haiku"`); `None` on failure paths. `sonnet-4.6` / `opus-*` tags
   reserved for Phase 3 (#165).
 - `upgrade_and_collect_corpus` and the `/standup` summarizer path now route
-  through `upgrade_batch`, so every Haiku summarization writes a record to
-  `~/.claude/obsidian-brain-summarizer-metrics.jsonl`. Closes telemetry gap
-  from #182 (follow-up to #74).
+  through `upgrade_batch`, so each Haiku summarization is included in a
+  metrics record written to `~/.claude/obsidian-brain-summarizer-metrics.jsonl`
+  (one JSONL record per `upgrade_batch` call, with `n_notes` reflecting the
+  group size — the corpus pass groups by project, `/standup` is `n_notes=1`).
+  Closes telemetry gap from #182 (follow-up to #74).
 
 ## [2.5.1] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fallback_reason). `model_used` reflects the resolved `summary_model` parameter
   (default `"haiku"`); `None` on failure paths. `sonnet-4.6` / `opus-*` tags
   reserved for Phase 3 (#165).
+- `upgrade_and_collect_corpus` and the `/standup` summarizer path now route
+  through `upgrade_batch`, so every Haiku summarization writes a record to
+  `~/.claude/obsidian-brain-summarizer-metrics.jsonl`. Closes telemetry gap
+  from #182 (follow-up to #74).
 
 ## [2.5.1] - 2026-05-16
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -3090,23 +3090,22 @@ def upgrade_and_collect_corpus(
     upgraded = 0
     failed = 0
 
-    # --- Phase 1: upgrade unsummarized notes ---
+    # --- Phase 1: upgrade unsummarized notes (group-by-project + batch) ---
+    from collections import defaultdict
+    candidates_by_project: dict[str, list[tuple[str, str]]] = defaultdict(list)
+
     sessions_dir = vault_root / sessions_folder
     if sessions_dir.is_dir():
+        # Pass A: collect candidates, grouped by frontmatter project
         for md_file in sessions_dir.iterdir():
             if md_file.suffix != ".md":
                 continue
-
-            # Path containment
             resolved = md_file.resolve()
             if not resolved.is_relative_to(vault_root):
                 continue
-
             meta = read_note_metadata(str(md_file))
             if not meta:
                 continue
-
-            # Date filter
             date_str = meta.get("date", "")
             if not date_str:
                 continue
@@ -3116,29 +3115,27 @@ def upgrade_and_collect_corpus(
                 continue
             if note_date < cutoff:
                 continue
-
-            # Only upgrade auto-logged notes
             if meta.get("status") != "auto-logged":
                 continue
+            candidates_by_project[meta.get("project", "")].append(
+                (str(md_file), meta.get("session_id", ""))
+            )
 
-            try:
-                status, _elapsed, _model, _reason = upgrade_unsummarized_note(
-                    note_path=str(md_file),
-                    vault_path=vault_path,
-                    sessions_folder=sessions_folder,
-                    project=meta.get("project", ""),
-                )
-                if not status.startswith("Failed"):
+        # Pass B: one upgrade_batch call per project group
+        for project_name, group in candidates_by_project.items():
+            if not group:
+                continue
+            paths = [p for p, _ in group]
+            results = upgrade_batch(
+                paths, vault_path, sessions_folder, project_name,
+            )
+            for (_path, session_id), result in zip(group, results):
+                if not result["status"].startswith("Failed"):
                     upgraded += 1
-                    # Bust metadata cache for this note
-                    session_id = meta.get("session_id", "")
                     if session_id:
                         cache_invalidate(session_id)
                 else:
                     failed += 1
-            except Exception as exc:
-                failed += 1
-                print(f"[obsidian-brain] upgrade failed for {md_file.name}: {exc}", file=sys.stderr)
 
     # --- Phase 2: collect corpus (now includes freshly upgraded notes) ---
     corpus_json = collect_vault_corpus(

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -3134,12 +3134,16 @@ def upgrade_and_collect_corpus(
                 paths, vault_path, sessions_folder, project_name,
                 max_workers=1,
             )
-            for (_path, session_id), result in zip(group, results):
+            for (path, session_id), result in zip(group, results):
                 if result["status"].startswith("Upgraded "):
                     upgraded += 1
                     if session_id:
                         cache_invalidate(session_id)
                 else:
+                    print(
+                        f"[obsidian-brain] upgrade failed for {path}: {result['status']}",
+                        file=sys.stderr,
+                    )
                     failed += 1
 
     # --- Phase 2: collect corpus (now includes freshly upgraded notes) ---

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -3123,16 +3123,19 @@ def upgrade_and_collect_corpus(
                 (str(md_file), meta.get("session_id", ""))
             )
 
-        # Pass B: one upgrade_batch call per project group
+        # Pass B: one upgrade_batch call per project group.
+        # max_workers=1: dedup_note_open_items runs after each note write and
+        # scans sibling notes; parallel workers in the same project could each
+        # see the other's freshly written open item as a duplicate and both
+        # remove their copy. Serial dispatch preserves the pre-#182 semantics.
         for project_name, group in candidates_by_project.items():
-            if not group:
-                continue
             paths = [p for p, _ in group]
             results = upgrade_batch(
                 paths, vault_path, sessions_folder, project_name,
+                max_workers=1,
             )
             for (_path, session_id), result in zip(group, results):
-                if not result["status"].startswith("Failed"):
+                if result["status"].startswith("Upgraded "):
                     upgraded += 1
                     if session_id:
                         cache_invalidate(session_id)

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -3076,7 +3076,9 @@ def upgrade_and_collect_corpus(
     """Upgrade unsummarized notes then collect corpus in a single pass.
 
     1. Scan sessions folder for notes with ``status: auto-logged`` within
-       the date window and attempt ``upgrade_unsummarized_note()`` on each.
+       the date window, group by frontmatter ``project``, and dispatch each
+       group through ``upgrade_batch()`` (which writes one telemetry record
+       per call to the summarizer metrics sink).
     2. Call ``collect_vault_corpus()`` to build the full corpus (including
        freshly upgraded notes).  ``include_types`` / ``exclude_types`` are
        forwarded verbatim — see ``collect_vault_corpus`` docstring for details.

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -192,15 +192,15 @@ cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 python3 -c '
 import sys, os
 import glob; sys.path.insert(0, max(glob.glob(os.path.expanduser("~/.claude/plugins/cache/*/obsidian-brain/*/hooks")), default="hooks"))
-from obsidian_utils import upgrade_unsummarized_note
-status, *_ = upgrade_unsummarized_note(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4])
-print(status)
+from obsidian_utils import upgrade_batch
+results = upgrade_batch([sys.argv[1]], sys.argv[2], sys.argv[3], sys.argv[4])
+print(results[0]["status"])
 ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
 ```
 
 The function returns a one-line status. If the status starts with `Failed:`, note the failure and fall back to the manual procedure below for that note. Collect results from all sub-agents before proceeding.
 
-For each file in `UNSUMMARIZED`, if `upgrade_unsummarized_note()` is unavailable or returns a `Failed:` status, fall back to the manual upgrade procedure:
+For each file in `UNSUMMARIZED`, if `upgrade_batch()` is unavailable or returns a `Failed:` status, fall back to the manual upgrade procedure:
 
 1. **Read the full file** using the Read tool.
 2. **Extract frontmatter** — preserve it exactly as-is (everything between the opening `---` and closing `---`).

--- a/skills/standup/SKILL.md
+++ b/skills/standup/SKILL.md
@@ -198,9 +198,9 @@ print(results[0]["status"])
 ' "$NOTE_PATH" "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
 ```
 
-The function returns a one-line status. If the status starts with `Failed:`, note the failure and fall back to the manual procedure below for that note. Collect results from all sub-agents before proceeding.
+The snippet prints a one-line status from `results[0]["status"]`. If that printed status starts with `Failed:`, note the failure and fall back to the manual procedure below for that note. Collect results from all sub-agents before proceeding.
 
-For each file in `UNSUMMARIZED`, if `upgrade_batch()` is unavailable or returns a `Failed:` status, fall back to the manual upgrade procedure:
+For each file in `UNSUMMARIZED`, if `upgrade_batch()` is unavailable or the printed `results[0]["status"]` starts with `Failed:`, fall back to the manual upgrade procedure:
 
 1. **Read the full file** using the Read tool.
 2. **Extract frontmatter** — preserve it exactly as-is (everything between the opening `---` and closing `---`).

--- a/tests/test_collect_vault_corpus.py
+++ b/tests/test_collect_vault_corpus.py
@@ -658,8 +658,8 @@ class TestUpgradeAndCollectCorpus:
 
 
 class TestUpgradeErrorLogging:
-    def test_failed_upgrade_surfaces_as_failed_status(self, tmp_vault, tmp_path):
-        """upgrade_and_collect_corpus surfaces worker exception as Failed: status (was stderr before #182)."""
+    def test_failed_upgrade_surfaces_as_failed_status_and_stderr(self, tmp_vault, tmp_path, capsys):
+        """upgrade_and_collect_corpus surfaces worker exception as Failed: status AND logs to stderr."""
         sess = tmp_vault / "claude-sessions"
         _write_note(sess / f"{_today_str()}-fail-0001.md",
             {"date": _today_str(), "project": "p", "type": "claude-session",
@@ -670,3 +670,40 @@ class TestUpgradeErrorLogging:
             status = obsidian_utils.upgrade_and_collect_corpus(
                 str(tmp_vault), "claude-sessions", "claude-insights", 30, str(output))
         assert status == "OK:1:0:1"
+        captured = capsys.readouterr()
+        assert "[obsidian-brain] upgrade failed" in captured.err
+        assert "haiku timeout" in captured.err
+
+    def test_corpus_pass_uses_max_workers_one_per_group(self, tmp_vault, tmp_path, monkeypatch):
+        """Regression guard: corpus pass MUST invoke upgrade_batch with max_workers=1
+        per project group, otherwise the dedup_note_open_items race re-emerges."""
+        recorded_kwargs = []
+
+        def recording_upgrade_batch(paths, vault_path, sessions_folder, project, **kwargs):
+            recorded_kwargs.append(kwargs)
+            return [
+                {"path": p, "status": f"Upgraded {os.path.basename(p)}",
+                 "elapsed_s": 0.1, "model_used": "haiku", "fallback_reason": None}
+                for p in paths
+            ]
+
+        monkeypatch.setattr(obsidian_utils, "upgrade_batch", recording_upgrade_batch)
+
+        sess = tmp_vault / "claude-sessions"
+        for proj in ("alpha", "beta"):
+            _write_note(
+                sess / f"{_today_str()}-{proj}-0001.md",
+                {"date": _today_str(), "project": proj, "type": "claude-session",
+                 "status": "auto-logged", "session_id": f"{proj}-sid"},
+                f"# {proj}\n\n## Summary\nAI summary unavailable",
+            )
+
+        output = tmp_path / "corpus.json"
+        obsidian_utils.upgrade_and_collect_corpus(
+            str(tmp_vault), "claude-sessions", "claude-insights", 30, str(output))
+
+        assert len(recorded_kwargs) == 2, f"expected 2 per-project calls, got {len(recorded_kwargs)}"
+        for kw in recorded_kwargs:
+            assert kw.get("max_workers") == 1, (
+                f"corpus pass must pin max_workers=1 to avoid dedup race; got {kw}"
+            )

--- a/tests/test_collect_vault_corpus.py
+++ b/tests/test_collect_vault_corpus.py
@@ -596,8 +596,7 @@ class TestUpgradeAndCollectCorpus:
         status = obsidian_utils.upgrade_and_collect_corpus(
             str(tmp_vault), "claude-sessions", "claude-insights", 30, str(output))
 
-        assert status.startswith("OK:")
-        assert ":3:0" in status
+        assert status == "OK:3:3:0"
 
         lines = metrics_path.read_text(encoding="utf-8").splitlines()
         assert len(lines) == 1, f"expected 1 sink record, got {len(lines)}"

--- a/tests/test_collect_vault_corpus.py
+++ b/tests/test_collect_vault_corpus.py
@@ -670,4 +670,4 @@ class TestUpgradeErrorLogging:
         with patch("obsidian_utils.upgrade_unsummarized_note", side_effect=RuntimeError("haiku timeout")):
             status = obsidian_utils.upgrade_and_collect_corpus(
                 str(tmp_vault), "claude-sessions", "claude-insights", 30, str(output))
-        assert ":1" in status
+        assert status == "OK:1:0:1"

--- a/tests/test_collect_vault_corpus.py
+++ b/tests/test_collect_vault_corpus.py
@@ -1,5 +1,6 @@
 """Tests for collect_vault_corpus() — vault data collection for /emerge."""
 
+import datetime
 import json
 import os
 import sys
@@ -565,19 +566,108 @@ class TestUpgradeAndCollectCorpus:
         assert parts[3] == "0"  # failed
 
 
-class TestUpgradeErrorLogging:
-    def test_failed_upgrade_logged_to_stderr(self, tmp_vault, tmp_path, capsys):
-        """upgrade_and_collect_corpus logs failed upgrade to stderr."""
+    def test_corpus_pass_emits_one_record_per_project_group(self, tmp_vault, tmp_path, monkeypatch):
+        """Three auto-logged notes in window, all project=foo → one batch record, n_notes=3."""
+        import summarizer_metrics
+        metrics_path = tmp_path / "metrics.jsonl"
+        monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
+        def fake_uun(path, *a, **kw):
+            return (f"Upgraded {os.path.basename(path)}", 0.4, "haiku", None)
+        monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_uun)
+
         sess = tmp_vault / "claude-sessions"
-        # Write an auto-logged note that will trigger upgrade
+        for i in range(3):
+            _write_note(
+                sess / f"{_today_str()}-foo-{i:04x}.md",
+                {"date": _today_str(), "project": "foo", "type": "claude-session",
+                 "status": "auto-logged", "session_id": f"sid-{i}"},
+                f"# T{i}\n\n## Summary\nAI summary unavailable",
+            )
+        old_date = (datetime.date.today() - datetime.timedelta(days=365)).isoformat()
+        _write_note(
+            sess / f"{old_date}-foo-stale.md",
+            {"date": old_date, "project": "foo", "type": "claude-session",
+             "status": "auto-logged", "session_id": "sid-stale"},
+            "# Stale\n\n## Summary\nAI summary unavailable",
+        )
+
+        output = tmp_path / "corpus.json"
+        status = obsidian_utils.upgrade_and_collect_corpus(
+            str(tmp_vault), "claude-sessions", "claude-insights", 30, str(output))
+
+        assert status.startswith("OK:")
+        assert ":3:0" in status
+
+        lines = metrics_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1, f"expected 1 sink record, got {len(lines)}"
+        rec = json.loads(lines[0])
+        assert rec["project"] == "foo"
+        assert rec["n_notes"] == 3
+
+    def test_corpus_pass_emits_separate_records_per_project(self, tmp_vault, tmp_path, monkeypatch):
+        """Two notes for project=foo + two for project=bar → two sink records."""
+        import summarizer_metrics
+        metrics_path = tmp_path / "metrics.jsonl"
+        monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
+        def fake_uun(path, *a, **kw):
+            return (f"Upgraded {os.path.basename(path)}", 0.4, "haiku", None)
+        monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_uun)
+
+        sess = tmp_vault / "claude-sessions"
+        for proj in ("foo", "bar"):
+            for i in range(2):
+                _write_note(
+                    sess / f"{_today_str()}-{proj}-{i:04x}.md",
+                    {"date": _today_str(), "project": proj, "type": "claude-session",
+                     "status": "auto-logged", "session_id": f"{proj}-sid-{i}"},
+                    f"# {proj.upper()}{i}\n\n## Summary\nAI summary unavailable",
+                )
+
+        output = tmp_path / "corpus.json"
+        obsidian_utils.upgrade_and_collect_corpus(
+            str(tmp_vault), "claude-sessions", "claude-insights", 30, str(output))
+
+        lines = metrics_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        recs = sorted([json.loads(L) for L in lines], key=lambda r: r["project"])
+        assert recs[0]["project"] == "bar"
+        assert recs[0]["n_notes"] == 2
+        assert recs[1]["project"] == "foo"
+        assert recs[1]["n_notes"] == 2
+
+    def test_corpus_pass_no_candidates_emits_no_record(self, tmp_vault, tmp_path, monkeypatch):
+        """All notes already summarized → no upgrade_batch call → no sink record."""
+        import summarizer_metrics
+        metrics_path = tmp_path / "metrics.jsonl"
+        monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
+        sess = tmp_vault / "claude-sessions"
+        _write_note(
+            sess / f"{_today_str()}-done-0001.md",
+            {"date": _today_str(), "project": "foo", "type": "claude-session",
+             "status": "summarized"},
+            "# Done\n\n## Summary\nReal summary present.",
+        )
+
+        output = tmp_path / "corpus.json"
+        obsidian_utils.upgrade_and_collect_corpus(
+            str(tmp_vault), "claude-sessions", "claude-insights", 30, str(output))
+
+        assert not metrics_path.exists() or metrics_path.read_text(encoding="utf-8") == ""
+
+
+class TestUpgradeErrorLogging:
+    def test_failed_upgrade_surfaces_as_failed_status(self, tmp_vault, tmp_path):
+        """upgrade_and_collect_corpus surfaces worker exception as Failed: status (was stderr before #182)."""
+        sess = tmp_vault / "claude-sessions"
         _write_note(sess / f"{_today_str()}-fail-0001.md",
-            {"date": _today_str(), "project": "p", "type": "claude-session", "status": "auto-logged"},
+            {"date": _today_str(), "project": "p", "type": "claude-session",
+             "status": "auto-logged", "session_id": "fail-sid"},
             "# Fail\n\n## Summary\nAI summary unavailable")
         output = tmp_path / "corpus.json"
-        # Mock upgrade to raise
         with patch("obsidian_utils.upgrade_unsummarized_note", side_effect=RuntimeError("haiku timeout")):
             status = obsidian_utils.upgrade_and_collect_corpus(
                 str(tmp_vault), "claude-sessions", "claude-insights", 30, str(output))
-        assert ":1" in status  # 1 failed
-        captured = capsys.readouterr()
-        assert "haiku timeout" in captured.err
+        assert ":1" in status

--- a/tests/test_upgrade_batch_telemetry.py
+++ b/tests/test_upgrade_batch_telemetry.py
@@ -112,3 +112,29 @@ def test_upgrade_batch_per_note_failure_captured_with_reason(monkeypatch, tmp_pa
 
     rec = json.loads(metrics_path.read_text(encoding="utf-8").splitlines()[0])
     assert rec["notes"][0]["fallback_reason"] == "haiku_timeout"
+
+
+def test_single_element_batch_emits_record(monkeypatch, tmp_path, fake_note):
+    """The /standup call shape — upgrade_batch([single_path], ...) — emits exactly one record with n_notes=1."""
+    metrics_path = tmp_path / "metrics.jsonl"
+    monkeypatch.setattr(summarizer_metrics, "METRICS_PATH", metrics_path)
+
+    def fake_uun(path, *a, **kw):
+        return (f"Upgraded {os.path.basename(path)}", 0.3, "haiku", None)
+    monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_uun)
+
+    p1 = fake_note("standup-note.md", "s-standup")
+    result = obsidian_utils.upgrade_batch(
+        [str(p1)], str(tmp_path), "claude-sessions", "obsidian-brain",
+    )
+
+    assert len(result) == 1
+    assert result[0]["status"].startswith("Upgraded ")
+    assert result[0]["path"] == str(p1)
+
+    lines = metrics_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["project"] == "obsidian-brain"
+    assert rec["n_notes"] == 1
+    assert len(rec["notes"]) == 1


### PR DESCRIPTION
## Summary
- Routes `upgrade_and_collect_corpus` (multi-note loop) and `/standup` (single-note heredoc) through `upgrade_batch` so every Haiku summarization records to `~/.claude/obsidian-brain-summarizer-metrics.jsonl`.
- Group-by-project in the corpus pass preserves per-project semantics that `upgrade_unsummarized_note` relies on (`dedup_open_items`, `apply_summary_to_note`).
- Closes the two production telemetry gaps left after PR #180.

## Why
PR #180 added telemetry to `upgrade_batch`. Two paths bypassed it, so any jq analysis of the metrics file systematically undercounts Haiku usage. Phase 3 cost-reduction work (#165) would validate against an incomplete dataset.

## Test plan
- New test: `test_single_element_batch_emits_record` (covers `/standup` call shape)
- New tests: `test_corpus_pass_emits_one_record_per_project_group`, `test_corpus_pass_emits_separate_records_per_project`, `test_corpus_pass_no_candidates_emits_no_record`
- Updated test: `test_failed_upgrade_surfaces_as_failed_status` (was stderr-based, now Failed: status-based)
- Full pytest passes locally (1217 passed)
- Post-merge dogfood: run `/standup` against real vault, verify new record appears with `n_notes=1`

Refs: #74, #169, #182. Spec: `docs/superpowers/specs/2026-05-16-issue-182-route-standup-corpus-through-telemetry-sink-design.md`.
