### PR TITLE
feat(summarizer): pre-summarization fallback_reason taxonomy (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The `/recall` status line now reports total wall time and a per-model breakdown
   (e.g., `Step 2: upgraded 7 note(s) in 12.4s wall (5 haiku / 2 fallback)`). Foundation
   for the cost-reduction work tracked in #169. (#74)
-- `fallback_reason` populated on pre-summarization failures in `upgrade_unsummarized_note`: `unreadable_note`, `no_session_id`, `no_conversation_content`. Full taxonomy (8 active + 3 reserved Phase 2 validator values, #167) now documented in the function's docstring. Closes #183.
+- `fallback_reason` populated on pre-summarization failures in `upgrade_unsummarized_note`: `unreadable_note`, `no_session_id`, `no_conversation_content`. Full taxonomy (including Phase 2 validator reserved values, #167/#84) documented in the function's docstring. Closes #183.
 
 ### Changed
 - **`upgrade_batch()` return shape** — was `list[tuple[path, status]]`, now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The `/recall` status line now reports total wall time and a per-model breakdown
   (e.g., `Step 2: upgraded 7 note(s) in 12.4s wall (5 haiku / 2 fallback)`). Foundation
   for the cost-reduction work tracked in #169. (#74)
+- `fallback_reason` populated on pre-summarization failures in `upgrade_unsummarized_note`: `unreadable_note`, `no_session_id`, `no_conversation_content`. Full taxonomy (8 active + 3 reserved Phase 2 validator values, #167) now documented in the function's docstring. Closes #183.
 
 ### Changed
 - **`upgrade_batch()` return shape** — was `list[tuple[path, status]]`, now

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -4308,7 +4308,10 @@ def upgrade_unsummarized_note(
                     assistant_msgs.append(stripped[14:].strip())
 
     if not user_msgs and not assistant_msgs:
-        return _ret(f"Failed: no conversation content in {os.path.basename(note_path)}")
+        return _ret(
+            f"Failed: no conversation content in {os.path.basename(note_path)}",
+            fallback_reason="no_conversation_content",
+        )
 
     # Build metadata for generate_summary
     metadata: dict = {"project": project, "vault_path": vault_path, "sessions_folder": sessions_folder}

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -2000,7 +2000,8 @@ def generate_summary(
       * On success: ``(text, None)``
       * On failure: ``(None, "haiku_timeout" | "haiku_subprocess_error" | "empty_output" | "unknown_failure")``
 
-    Reserved future reasons (populated by Phase 2 #167 validator, not here):
+    Reserved future reasons (will be populated downstream by the Phase 2 #167/#84
+    validator, not returned by this function):
       ``"missing_section"``, ``"importance_missing"``, ``"schema_loose"``.
 
     Samples first 10 + last 10 messages for large sessions.
@@ -4211,23 +4212,23 @@ def upgrade_unsummarized_note(
         ``"no_session_id"``           — frontmatter is missing the ``session_id:`` field
         ``"no_conversation_content"`` — neither JSONL nor raw-note section yielded messages
 
-      Haiku pipeline (set inside ``generate_summary`` / ``generate_snapshot_summary``):
+      Summarizer subprocess (set inside ``generate_summary`` / ``generate_snapshot_summary``):
         ``"haiku_timeout"``           — ``claude -p`` exceeded the per-call timeout
         ``"haiku_subprocess_error"``  — ``claude -p`` returned non-zero or unexpected I/O
         ``"empty_output"``            — model returned empty / whitespace-only text
-        ``"unknown_failure"``         — defensive default when no specific reason was captured
+        ``"unknown_failure"``         — defensive default returned by ``generate_summary`` / ``generate_snapshot_summary`` when the retry loop exits without setting ``last_reason`` (should be unreachable)
 
       Worker wrapper (set by ``upgrade_batch`` when a future raises):
         ``"worker_exception"``        — per-note worker raised an uncaught exception
 
-      Reserved for the Phase 2 validator (#167) — declared here for stability,
+      Reserved for the Phase 2 validator (#167/#84) — declared here for stability,
       not yet emitted by this function:
         ``"missing_section"``         — summary lacks a required H2 section
         ``"importance_missing"``      — IMPORTANCE: N line absent or unparseable
         ``"schema_loose"``            — summary structurally valid but fails strict schema
 
       Callers MUST treat any non-``None`` value as a failure classifier. Adding a
-      new value requires updating both this docstring and the validator (#167).
+      new value requires updating both this docstring and the validator (#167/#84).
 
     Adding any new return prefix to the ``status`` field requires an audit
     of routing call sites.
@@ -4245,7 +4246,7 @@ def upgrade_unsummarized_note(
     try:
         with open(note_path, 'r', encoding='utf-8') as f:
             raw_lines = f.readlines()
-    except OSError as exc:
+    except (OSError, UnicodeDecodeError) as exc:
         return _ret(
             f"Failed: cannot read {os.path.basename(note_path)}: {exc}",
             fallback_reason="unreadable_note",

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -4227,7 +4227,10 @@ def upgrade_unsummarized_note(
         with open(note_path, 'r', encoding='utf-8') as f:
             raw_lines = f.readlines()
     except OSError as exc:
-        return _ret(f"Failed: cannot read {os.path.basename(note_path)}: {exc}")
+        return _ret(
+            f"Failed: cannot read {os.path.basename(note_path)}: {exc}",
+            fallback_reason="unreadable_note",
+        )
 
     # Extract session_id from frontmatter
     session_id = None

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -4240,7 +4240,10 @@ def upgrade_unsummarized_note(
             session_id = stripped.split(':', 1)[1].strip().strip('"').strip("'")
             break
     if not session_id:
-        return _ret(f"Failed: no session_id in frontmatter of {os.path.basename(note_path)}")
+        return _ret(
+            f"Failed: no session_id in frontmatter of {os.path.basename(note_path)}",
+            fallback_reason="no_session_id",
+        )
 
     # Find and parse the JSONL transcript
     jsonl_path = find_transcript_jsonl(session_id)

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -4204,11 +4204,18 @@ def upgrade_unsummarized_note(
       success (default ``"haiku"``), or ``None`` on failure paths that never
       reached summarization. Sonnet/Opus tags are reserved for Phase 3 #165.
     - **fallback_reason** (*str | None*) — non-``None`` when summarization
-      failed or a worker / pre-summarization check caught a problem.
-      ``None`` only on the success path. Full taxonomy:
+      itself failed or a worker / pre-summarization check caught a problem.
+      ``None`` indicates that summarization succeeded; it does NOT by itself
+      confirm overall success. Callers MUST also check
+      ``status.startswith("Upgraded ")`` — ``upgrade_note_with_summary`` can
+      still return a ``"Failed: ..."`` status (malformed summary, atomic write
+      error, post-write verification failure, etc.) even after the model
+      returned a result, and those post-summarization failures currently flow
+      through with ``fallback_reason=None``. Classifying them is tracked as a
+      Phase 2 prep follow-up. Full taxonomy of populated values:
 
       Pre-summarization (this function, before any model call):
-        ``"unreadable_note"``         — OSError reading the note (perms, encoding, ENOENT)
+        ``"unreadable_note"``         — OSError or UnicodeDecodeError reading the note (perms, encoding, ENOENT, bad UTF-8)
         ``"no_session_id"``           — frontmatter is missing the ``session_id:`` field
         ``"no_conversation_content"`` — neither JSONL nor raw-note section yielded messages
 

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -4203,12 +4203,31 @@ def upgrade_unsummarized_note(
       success (default ``"haiku"``), or ``None`` on failure paths that never
       reached summarization. Sonnet/Opus tags are reserved for Phase 3 #165.
     - **fallback_reason** (*str | None*) — non-``None`` when summarization
-      failed or ``upgrade_batch``'s per-note worker caught an exception.
-      Day-one values: ``"haiku_timeout"``, ``"haiku_subprocess_error"``,
-      ``"empty_output"``, ``"unknown_failure"`` (from generate functions);
-      ``"worker_exception"`` (set by ``upgrade_batch`` when the future raises).
-      Threaded through from ``generate_summary`` / ``generate_snapshot_summary``
-      unchanged on normal failure paths.
+      failed or a worker / pre-summarization check caught a problem.
+      ``None`` only on the success path. Full taxonomy:
+
+      Pre-summarization (this function, before any model call):
+        ``"unreadable_note"``         — OSError reading the note (perms, encoding, ENOENT)
+        ``"no_session_id"``           — frontmatter is missing the ``session_id:`` field
+        ``"no_conversation_content"`` — neither JSONL nor raw-note section yielded messages
+
+      Haiku pipeline (set inside ``generate_summary`` / ``generate_snapshot_summary``):
+        ``"haiku_timeout"``           — ``claude -p`` exceeded the per-call timeout
+        ``"haiku_subprocess_error"``  — ``claude -p`` returned non-zero or unexpected I/O
+        ``"empty_output"``            — model returned empty / whitespace-only text
+        ``"unknown_failure"``         — defensive default when no specific reason was captured
+
+      Worker wrapper (set by ``upgrade_batch`` when a future raises):
+        ``"worker_exception"``        — per-note worker raised an uncaught exception
+
+      Reserved for the Phase 2 validator (#167) — declared here for stability,
+      not yet emitted by this function:
+        ``"missing_section"``         — summary lacks a required H2 section
+        ``"importance_missing"``      — IMPORTANCE: N line absent or unparseable
+        ``"schema_loose"``            — summary structurally valid but fails strict schema
+
+      Callers MUST treat any non-``None`` value as a failure classifier. Adding a
+      new value requires updating both this docstring and the validator (#167).
 
     Adding any new return prefix to the ``status`` field requires an audit
     of routing call sites.

--- a/tests/test_pre_summarization_fallback_reasons.py
+++ b/tests/test_pre_summarization_fallback_reasons.py
@@ -1,11 +1,8 @@
 """Unit tests for the three pre-summarization fallback_reason values
 in upgrade_unsummarized_note (issue #183)."""
 
-import os
 import sys
 from pathlib import Path
-
-import pytest
 
 HOOKS = Path(__file__).resolve().parent.parent / "hooks"
 sys.path.insert(0, str(HOOKS))
@@ -78,6 +75,10 @@ def test_no_conversation_content_sets_fallback_reason(tmp_path, monkeypatch):
     # Force the JSONL lookup to return None so the function falls through to
     # raw-note extraction (which finds no `## Conversation (raw)` section).
     monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+    # Guard: verify the monkeypatch actually intercepted the lookup. A future
+    # refactor that switches to `from .other import find_transcript_jsonl`
+    # would silently bypass this patch.
+    assert obsidian_utils.find_transcript_jsonl("test-sid-001") is None
 
     status, elapsed_s, model_used, fallback_reason = upgrade_unsummarized_note(
         str(note_path), str(tmp_path), "claude-sessions", "test-proj",
@@ -85,4 +86,21 @@ def test_no_conversation_content_sets_fallback_reason(tmp_path, monkeypatch):
 
     assert status.startswith("Failed: no conversation content"), status
     assert fallback_reason == "no_conversation_content"
+    assert model_used is None
+
+
+def test_unreadable_note_encoding_error_sets_fallback_reason(tmp_path):
+    """Invalid UTF-8 in a note -> fallback_reason='unreadable_note' (encoding case)."""
+    sessions = tmp_path / "claude-sessions"
+    sessions.mkdir()
+    note_path = sessions / "2026-05-17-bad-encoding.md"
+    # Latin-1 / mixed garbage bytes that cannot be decoded as UTF-8
+    note_path.write_bytes(b"---\nproject: test-proj\n---\n\xff\xfe garbage \xc3\x28\n")
+
+    status, elapsed_s, model_used, fallback_reason = upgrade_unsummarized_note(
+        str(note_path), str(tmp_path), "claude-sessions", "test-proj",
+    )
+
+    assert status.startswith("Failed: cannot read"), status
+    assert fallback_reason == "unreadable_note"
     assert model_used is None

--- a/tests/test_pre_summarization_fallback_reasons.py
+++ b/tests/test_pre_summarization_fallback_reasons.py
@@ -1,0 +1,30 @@
+"""Unit tests for the three pre-summarization fallback_reason values
+in upgrade_unsummarized_note (issue #183)."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+HOOKS = Path(__file__).resolve().parent.parent / "hooks"
+sys.path.insert(0, str(HOOKS))
+
+import obsidian_utils  # noqa: E402
+from obsidian_utils import upgrade_unsummarized_note  # noqa: E402
+
+
+def test_unreadable_note_sets_fallback_reason(tmp_path):
+    """OSError on note read -> fallback_reason='unreadable_note'."""
+    sessions = tmp_path / "claude-sessions"
+    sessions.mkdir()
+    note_path = sessions / "2026-05-17-missing.md"  # intentionally not created
+
+    status, elapsed_s, model_used, fallback_reason = upgrade_unsummarized_note(
+        str(note_path), str(tmp_path), "claude-sessions", "test-proj",
+    )
+
+    assert status.startswith("Failed: cannot read"), status
+    assert fallback_reason == "unreadable_note"
+    assert model_used is None
+    assert elapsed_s >= 0.0

--- a/tests/test_pre_summarization_fallback_reasons.py
+++ b/tests/test_pre_summarization_fallback_reasons.py
@@ -28,3 +28,31 @@ def test_unreadable_note_sets_fallback_reason(tmp_path):
     assert fallback_reason == "unreadable_note"
     assert model_used is None
     assert elapsed_s >= 0.0
+
+
+def test_no_session_id_sets_fallback_reason(tmp_path):
+    """Frontmatter missing session_id -> fallback_reason='no_session_id'."""
+    sessions = tmp_path / "claude-sessions"
+    sessions.mkdir()
+    note_path = sessions / "2026-05-17-no-sid.md"
+    note_path.write_text(
+        "---\n"
+        "project: test-proj\n"
+        "status: auto-logged\n"
+        "date: 2026-05-17\n"
+        "---\n"
+        "\n"
+        "## Conversation (raw)\n"
+        "\n"
+        "**User:** hello\n"
+        "**Assistant:** hi\n",
+        encoding="utf-8",
+    )
+
+    status, elapsed_s, model_used, fallback_reason = upgrade_unsummarized_note(
+        str(note_path), str(tmp_path), "claude-sessions", "test-proj",
+    )
+
+    assert status.startswith("Failed: no session_id"), status
+    assert fallback_reason == "no_session_id"
+    assert model_used is None

--- a/tests/test_pre_summarization_fallback_reasons.py
+++ b/tests/test_pre_summarization_fallback_reasons.py
@@ -56,3 +56,33 @@ def test_no_session_id_sets_fallback_reason(tmp_path):
     assert status.startswith("Failed: no session_id"), status
     assert fallback_reason == "no_session_id"
     assert model_used is None
+
+
+def test_no_conversation_content_sets_fallback_reason(tmp_path, monkeypatch):
+    """Valid frontmatter but no extractable messages -> fallback_reason='no_conversation_content'."""
+    sessions = tmp_path / "claude-sessions"
+    sessions.mkdir()
+    note_path = sessions / "2026-05-17-empty-convo.md"
+    note_path.write_text(
+        "---\n"
+        "session_id: test-sid-001\n"
+        "project: test-proj\n"
+        "status: auto-logged\n"
+        "date: 2026-05-17\n"
+        "---\n"
+        "\n"
+        "Some prose body with no conversation section at all.\n",
+        encoding="utf-8",
+    )
+
+    # Force the JSONL lookup to return None so the function falls through to
+    # raw-note extraction (which finds no `## Conversation (raw)` section).
+    monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+
+    status, elapsed_s, model_used, fallback_reason = upgrade_unsummarized_note(
+        str(note_path), str(tmp_path), "claude-sessions", "test-proj",
+    )
+
+    assert status.startswith("Failed: no conversation content"), status
+    assert fallback_reason == "no_conversation_content"
+    assert model_used is None


### PR DESCRIPTION
## Summary

Closes #183.

Populates `fallback_reason` for the three pre-summarization failure paths in `upgrade_unsummarized_note` that previously returned `fallback_reason=None`, making them indistinguishable from successful upgrades in the summarizer telemetry sink:

- `unreadable_note` — `OSError` OR `UnicodeDecodeError` reading the note (perms, encoding, ENOENT)
- `no_session_id` — frontmatter missing `session_id:`
- `no_conversation_content` — neither JSONL nor raw-note section yielded messages

Also documents the full taxonomy (active + reserved Phase 2 validator values) in the `upgrade_unsummarized_note` docstring, so #167/#84 can wire validator emission without a second taxonomy negotiation.

## Why

Phase 2 validator (#167/#84) needs to triage failure dominance by layer (data quality vs. summarizer subprocess vs. validator). With these failures collapsed into `null`, the validator cannot decide whether the next intervention should be "improve note-extraction robustness" or "tighten summarizer prompt".

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-17-issue-183-pre-summarization-fallback-reason-taxonomy-design.md`
- Plan: `docs/superpowers/plans/2026-05-17-issue-183-pre-summarization-fallback-reason-taxonomy.md`

## Changes

- 3 explicit `_ret(..., fallback_reason=...)` kwargs at the three pre-summarization exit paths in `hooks/obsidian_utils.py::upgrade_unsummarized_note`
- `except OSError` widened to `except (OSError, UnicodeDecodeError)` so bad-encoding notes are correctly classified (matches docstring promise)
- Docstring rewritten with full taxonomy grouped by emitter (pre-summarization, summarizer subprocess, worker wrapper, reserved for Phase 2 validator)
- `generate_summary` docstring's reserved-value disclaimer made parity with `generate_snapshot_summary` (downstream-emitted, not by this function)
- CHANGELOG bullet under `[Unreleased]/### Added`

## Test plan

- [x] `tests/test_pre_summarization_fallback_reasons.py` — 4 new tests:
  - `test_unreadable_note_sets_fallback_reason` (ENOENT)
  - `test_unreadable_note_encoding_error_sets_fallback_reason` (UTF-8 garbage)
  - `test_no_session_id_sets_fallback_reason`
  - `test_no_conversation_content_sets_fallback_reason` (with monkeypatch guard)
- [x] `tests/test_upgrade_batch_telemetry.py` — green (no regressions)
- [x] `tests/test_summarizer_metrics.py` — green (no regressions)
- [x] `./scripts/commit-preflight.sh` green on every commit (1222 tests, 90.84% coverage)

## PR review feedback addressed

After the initial 5 commits, multi-agent PR review surfaced 1 real bug (UnicodeDecodeError not classified) + 8 polish items, all bundled into commit `a97920c`:

- Widened OSError handler to include UnicodeDecodeError + corresponding test
- Group label "Haiku pipeline" → "Summarizer subprocess" (forward-stability for #165)
- Sharpened `unknown_failure` description with emission site
- Cross-refs `#167` → `#167/#84` (the validator co-issue)
- Monkeypatch guard in Test C against silent patch misses
- Dropped unused imports in test file
- CHANGELOG count-free phrasing per project convention

## Refs

- Predecessor: PR #180 (closes #74) — added `fallback_reason` for summarizer subprocess
- Predecessor: PR #185 (closes #182) — routed `/standup` + corpus through telemetry sink
- Consumer: #167/#84 — Phase 2 validator (will use the new reasons + reserved set)
- Successor: #181 — `Literal[FallbackReason]` type alias (v2.7)
- Follow-up filed: #187 — refresh stale `fallback_reason` enumeration in `/recall` SKILL.md
- Umbrella: #169 — `/recall` cost & reliability tracking
