### PR TITLE
fix(summarizer): raise claude -p timeout budget + summary_pipeline escape hatch (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`summary_pipeline` config key** (`"auto"` default | `"subagent"`) — set to `"subagent"` in `~/.claude/obsidian-brain-config.json` to skip the Haiku `claude -p` summarizer pipeline entirely on machines with slow CLI cold-start, routing all notes straight to the sub-agent fallback. (#84)
 - **`/recall` telemetry** — `upgrade_batch()` now returns per-note `elapsed_s`,
   `model_used`, and `fallback_reason`, and appends one record per call to
   `~/.claude/obsidian-brain-summarizer-metrics.jsonl` (100 KB rotation, owner-only).
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fallback_reason` populated on pre-summarization failures in `upgrade_unsummarized_note`: `unreadable_note`, `no_session_id`, `no_conversation_content`. Full taxonomy (including Phase 2 validator reserved values, #167/#84) documented in the function's docstring. Closes #183.
 
 ### Changed
+- **Summarizer timeout budget** — `generate_summary` / `generate_snapshot_summary` first-attempt `claude -p` timeout raised from 30s to 120s (retry from 60s to 240s) to accommodate slow-start CC builds where cold-start alone can take ~46s. Fixes the 100% Haiku-pipeline failure rate on affected installs. (#84)
 - **`upgrade_batch()` return shape** — was `list[tuple[path, status]]`, now
   `list[dict]` with 5 keys (`path`, `status`, `elapsed_s`, `model_used`,
   `fallback_reason`). Backward-incompatible for direct callers; in-tree

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -913,7 +913,7 @@ _DEFAULTS: dict = {
     "min_messages": 3,
     "min_duration_minutes": 2,
     "summary_model": "haiku",
-    "summary_pipeline": "auto",  # "auto" = Haiku claude -p + sub-agent fallback; "subagent" = skip Haiku pipeline (escape hatch for slow-start CC builds, #84)
+    "summary_pipeline": "auto",  # "auto" = Haiku claude -p + sub-agent fallback; "subagent" = skip Haiku pipeline. Consumed by /recall SKILL.md Step 2 (summarization is deferred to /recall), #84
     "auto_log_enabled": True,
     "snapshot_on_compact": True,
     "snapshot_on_clear": True,

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -913,6 +913,7 @@ _DEFAULTS: dict = {
     "min_messages": 3,
     "min_duration_minutes": 2,
     "summary_model": "haiku",
+    "summary_pipeline": "auto",  # "auto" = Haiku claude -p + sub-agent fallback; "subagent" = skip Haiku pipeline (escape hatch for slow-start CC builds, #84)
     "auto_log_enabled": True,
     "snapshot_on_compact": True,
     "snapshot_on_clear": True,
@@ -1926,7 +1927,7 @@ def generate_snapshot_summary(
     assistant_msgs: list[str],
     metadata: dict,
     model: str = "haiku",
-    timeout: int = 30,
+    timeout: int = 120,
 ) -> tuple[str | None, str | None]:
     """Call ``claude -p --model <model>`` with the snapshot-specific prompt.
 
@@ -1992,7 +1993,7 @@ def generate_summary(
     assistant_msgs: list[str],
     metadata: dict,
     model: str = "haiku",
-    timeout: int = 30,
+    timeout: int = 120,
 ) -> tuple[str | None, str | None]:
     """Call ``claude -p --model <model>`` to summarize the session.
 

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -34,10 +34,11 @@ print("VAULT=" + c["vault_path"])
 print("SESS=" + c.get("sessions_folder", "claude-sessions"))
 print("INS=" + c.get("insights_folder", "claude-insights"))
 print("PROJECT=" + project)
+print("PIPELINE=" + c.get("summary_pipeline", "auto"))
 '
 ```
 
-Parse each output line as KEY=VALUE, splitting on the first `=`.
+Parse each output line as KEY=VALUE, splitting on the first `=`. Also capture PIPELINE (defaults to "auto").
 
 If the user passed a project name argument (e.g. `/recall my-project`), override `PROJECT` with that value.
 
@@ -92,6 +93,8 @@ Update task #1 to completed. Update task #2 subject to `Summarize N unsummarized
 Update task #2 subject to `No unsummarized notes found` and set to `completed`. Skip to Step 3.
 
 #### Path B: N>=1 (parallel Haiku pipelines with sub-agent fallback)
+
+> **Config escape hatch (#84):** If `PIPELINE=subagent`, SKIP Phase 1 (the `upgrade_batch` Haiku `claude -p` pipeline) entirely and treat ALL N notes as the Phase 2 fallback list — route every note directly to the sub-agent path in Phase 2. This is for machines where `claude -p` cold-start latency exceeds the timeout budget (the Haiku pipeline would waste ~2-4 min/note on doomed timeouts). When `PIPELINE=auto` (default), proceed with Phase 1 as written below.
 
 **Task management threshold:** If N <= 5, create a sub-task per note. If N > 5, skip per-note sub-tasks — use a single progress update on task #2 instead. This saves ~15-20s of parent round-trip overhead at large N.
 

--- a/tests/test_emerge_snapshot_filter.py
+++ b/tests/test_emerge_snapshot_filter.py
@@ -1,21 +1,23 @@
 import json
 from pathlib import Path
+from datetime import date, timedelta
 
 from hooks.obsidian_utils import collect_vault_corpus
 
 
 def _setup(tmp_path):
+    recent = (date.today() - timedelta(days=2)).isoformat()
     vault = tmp_path / "v"
     sess = vault / "claude-sessions"
     ins = vault / "claude-insights"
     sess.mkdir(parents=True); ins.mkdir()
-    (sess / "2026-04-18-demo-aa.md").write_text(
-        "---\ntype: claude-session\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+    (sess / f"{recent}-demo-aa.md").write_text(
+        f"---\ntype: claude-session\ndate: {recent}\nsession_id: s1\nproject: demo\n"
         "tags: [claude/session]\n---\n\n# S\n\n## Summary\nSession body.\n",
         encoding="utf-8",
     )
-    (sess / "2026-04-18-demo-aa-snapshot-140000.md").write_text(
-        "---\ntype: claude-snapshot\ndate: 2026-04-18\nsession_id: s1\nproject: demo\n"
+    (sess / f"{recent}-demo-aa-snapshot-140000.md").write_text(
+        f"---\ntype: claude-snapshot\ndate: {recent}\nsession_id: s1\nproject: demo\n"
         "tags: [claude/snapshot]\n---\n\n# Snap\n\n## Summary\nSnapshot body.\n",
         encoding="utf-8",
     )

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -76,6 +76,31 @@ class TestLoadConfig:
         assert obsidian_utils.get_project_name("/home/user/my-project") == "my-project"
         assert obsidian_utils.get_project_name("") == "unknown"
 
+    def test_load_config_summary_pipeline_user_override(self, tmp_path, monkeypatch):
+        """User config with summary_pipeline=subagent must surface through load_config."""
+        config_file = tmp_path / "obsidian-brain-config.json"
+        config_file.write_text(json.dumps({"summary_pipeline": "subagent"}), encoding="utf-8")
+
+        monkeypatch.setattr(obsidian_utils, "_CONFIG_PATH", config_file)
+        # Use a unique sid per call so the session-scoped config cache never
+        # bleeds between test invocations (mirrors the pattern used throughout
+        # this class — see _get_session_id_fast mock above).
+        monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: _unique_sid())
+
+        cfg = obsidian_utils.load_config()
+        assert cfg["summary_pipeline"] == "subagent"
+
+    def test_load_config_summary_pipeline_default_is_auto(self, tmp_path, monkeypatch):
+        """No user override → summary_pipeline defaults to 'auto'."""
+        config_file = tmp_path / "obsidian-brain-config.json"
+        config_file.write_text(json.dumps({"vault_path": str(tmp_path)}), encoding="utf-8")
+
+        monkeypatch.setattr(obsidian_utils, "_CONFIG_PATH", config_file)
+        monkeypatch.setattr(obsidian_utils, "_get_session_id_fast", lambda: _unique_sid())
+
+        cfg = obsidian_utils.load_config()
+        assert cfg["summary_pipeline"] == "auto"
+
 
 class TestGetWorkspaceRoots:
     """Tests for the get_workspace_roots() helper (R13 C5 — config-driven workspace roots)."""
@@ -1167,15 +1192,28 @@ class TestSummarizerTimeoutBudget:
 
     def test_generate_summary_first_attempt_timeout_is_120(self, monkeypatch):
         captured: dict = {}
-        monkeypatch.setattr("subprocess.run", self._capture_timeout_run(captured))
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", self._capture_timeout_run(captured))
         obsidian_utils.generate_summary(["u"], ["a"], {"project": "t", "files_touched": []})
         assert captured.get("timeout") == 120
 
     def test_generate_snapshot_summary_first_attempt_timeout_is_120(self, monkeypatch):
         captured: dict = {}
-        monkeypatch.setattr("subprocess.run", self._capture_timeout_run(captured))
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", self._capture_timeout_run(captured))
         obsidian_utils.generate_snapshot_summary(["u"], ["a"], {"project": "t"})
         assert captured.get("timeout") == 120
+
+    def test_generate_summary_retry_uses_double_timeout(self, monkeypatch):
+        """Both attempts must time out; second attempt must use timeout * 2 == 240."""
+        seen = []
+
+        def fake_run(cmd, **kwargs):
+            seen.append(kwargs.get("timeout"))
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=kwargs.get("timeout"))
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", fake_run)
+        result = obsidian_utils.generate_summary(["u"], ["a"], {"project": "t", "files_touched": []})
+        assert seen == [120, 240]
+        assert result == (None, "haiku_timeout")
 
 
 def test_summary_pipeline_default_is_auto():
@@ -2191,6 +2229,71 @@ class TestUpgradeBatch:
         assert "status: summarized" in updated
         assert "## Summary" in updated
         assert "Did a thing." in updated
+
+    def test_upgrade_unsummarized_note_default_timeout_reaches_generate_summary(
+        self, monkeypatch, tmp_path
+    ):
+        """When summary_timeout=None (the default), generate_summary must be called WITHOUT
+        a timeout kwarg so its own default of 120 applies. This pins the propagation
+        path upgrade_unsummarized_note(summary_timeout=None) → gen_kwargs has no
+        'timeout' key → generate_summary uses its default parameter (120).
+
+        Approach: monkeypatch generate_summary to capture kwargs; drive one real
+        note through upgrade_unsummarized_note without passing summary_timeout.
+        Assert 'timeout' is absent from captured kwargs (so the 120 default applies).
+        """
+        vault = tmp_path / "vault"
+        sessions_dir = vault / "sessions"
+        sessions_dir.mkdir(parents=True)
+
+        note_path = sessions_dir / "2026-04-20-default-timeout-test-abcd.md"
+        note_path.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-20\n"
+            "session_id: default-timeout-session-id-0000-0000-000000000000\n"
+            "project: test-project\n"
+            "status: auto-logged\n"
+            "tags:\n"
+            "  - claude/session\n"
+            "---\n\n"
+            "## Conversation (raw)\n"
+            "**User:** hello\n"
+            "**Assistant:** hi there\n",
+            encoding="utf-8",
+        )
+
+        captured_gen_kwargs: dict = {}
+
+        def fake_generate_summary(*args, **kwargs):
+            captured_gen_kwargs.update(kwargs)
+            return (
+                "## Summary\nDid a thing.\n\n"
+                "## Key Decisions\n- None noted.\n\n"
+                "## Changes Made\n- None noted.\n\n"
+                "## Errors Encountered\n- None.\n\n"
+                "## Open Questions / Next Steps\n- [ ] None.\n\n"
+                "IMPORTANCE: 5\n"
+            ), None
+
+        monkeypatch.setattr(obsidian_utils, "generate_summary", fake_generate_summary)
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda session_id: None)
+
+        # Call without summary_timeout — default None path
+        status, elapsed_s, model_used, fallback_reason = obsidian_utils.upgrade_unsummarized_note(
+            str(note_path),
+            str(vault),
+            "sessions",
+            "test-project",
+        )
+
+        assert status.startswith("Upgraded "), f"expected Upgraded, got: {status!r}"
+        # 'timeout' must NOT be in kwargs: the default (120) should come from
+        # generate_summary's own parameter default, not a forwarded value.
+        assert "timeout" not in captured_gen_kwargs, (
+            f"expected no 'timeout' kwarg when summary_timeout=None, "
+            f"but got kwargs={captured_gen_kwargs!r}"
+        )
 
 
 # ===========================================================================

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -1156,6 +1156,32 @@ class TestGenerateSummarySampling:
         assert len(prompt) < 30000  # generous upper bound; key check is it's bounded
 
 
+class TestSummarizerTimeoutBudget:
+    """#84 — claude -p first-attempt timeout raised 30s→120s for slow-start CC builds."""
+
+    def _capture_timeout_run(self, captured: dict):
+        def fake_run(cmd, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+            return type("Result", (), {"returncode": 0, "stdout": "## Summary\nDone.\n", "stderr": ""})()
+        return fake_run
+
+    def test_generate_summary_first_attempt_timeout_is_120(self, monkeypatch):
+        captured: dict = {}
+        monkeypatch.setattr("subprocess.run", self._capture_timeout_run(captured))
+        obsidian_utils.generate_summary(["u"], ["a"], {"project": "t", "files_touched": []})
+        assert captured.get("timeout") == 120
+
+    def test_generate_snapshot_summary_first_attempt_timeout_is_120(self, monkeypatch):
+        captured: dict = {}
+        monkeypatch.setattr("subprocess.run", self._capture_timeout_run(captured))
+        obsidian_utils.generate_snapshot_summary(["u"], ["a"], {"project": "t"})
+        assert captured.get("timeout") == 120
+
+
+def test_summary_pipeline_default_is_auto():
+    assert obsidian_utils._DEFAULTS.get("summary_pipeline") == "auto"
+
+
 # ===========================================================================
 # Section 7: build_context_brief — sort order and duration
 # ===========================================================================


### PR DESCRIPTION
## Summary

Fixes the **100% Haiku summarizer failure rate on slow-start Claude Code builds** (#84), part of the #169 `/recall` cost & reliability tracker.

On some CC installs, `claude -p --model haiku` cold-start (process startup + auth + API handshake) alone takes ~46s — already exceeding the old 30s first-attempt timeout. Every `/recall` then wasted ~90s/note on doomed timeouts before falling through to the sub-agent fallback.

## Changes

- **Timeout budget raised** — `generate_summary` / `generate_snapshot_summary` first-attempt `claude -p` timeout `30s → 120s` (retry escalation `60s → 240s`). Accommodates slow-start builds for most session sizes. One-line, safe.
- **`summary_pipeline` config escape hatch** — new key in `~/.claude/obsidian-brain-config.json`: `"auto"` (default, current behavior) or `"subagent"` (skip the Haiku `claude -p` pipeline entirely and route all notes to the reliable sub-agent fallback). For machines known to be slow, this avoids the wasted per-note timeout wait.
- **`skills/recall/SKILL.md`** — Step 1 surfaces `PIPELINE`; Step 2 Path B honors the `subagent` escape hatch.

### Scope note
The issue's "medium-term real fix" (Anthropic Python SDK to bypass the CLI) is **out of scope** here — this repo is stdlib-only with no pip dependencies (see `CLAUDE.md`). The timeout bump + escape hatch are the in-scope, dependency-free mitigations.

## Tests
- New `TestSummarizerTimeoutBudget` asserts 120s first-attempt timeout for both summarizers.
- New `summary_pipeline` config-default test.
- Drive-by: fixed pre-existing **date-rot** in `test_emerge_snapshot_filter.py` fixtures (hardcoded `2026-04-18` aged out of the `days=30` window) — separate commit, was blocking the preflight gate. Unrelated to #84.
- Full suite: **1225 passed**, coverage 90.84%.

Closes #84.
Refs #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
