### PR TITLE
perf(summarizer): Sonnet fallback chain (#165) + multi-note batching (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **`summary_pipeline` config key** (`"auto"` default | `"subagent"`) — set to `"subagent"` in `~/.claude/obsidian-brain-config.json` to skip the Haiku `claude -p` summarizer pipeline entirely on machines with slow CLI cold-start, routing all notes straight to the sub-agent fallback. (#84)
+- **In-process Haiku→Sonnet→Opus escalation chain (#165)** — `upgrade_unsummarized_note` now retries with a more capable model when the primary model returns empty output (`empty_output` reason only; timeouts and subprocess errors do not escalate). Fallback model chain is now Sonnet first, then Opus (replaces prior direct-to-Opus behavior). `model_used` in metrics is populated with the model that produced the accepted summary.
+- **`summary_batch_size` config key (#166)** (default `3`) — `upgrade_batch` now groups session notes into batches of up to `summary_batch_size` and summarizes each group in a single `claude -p` spawn, amortizing CLI startup overhead (~70% reduction vs. per-note fan-out). Set to `1` in `~/.claude/obsidian-brain-config.json` to restore legacy per-note behavior. Per-note parse failures and whole-spawn failures fall through automatically to the per-note solo path, and then to the Phase 2 sub-agent.
 - **`/recall` telemetry** — `upgrade_batch()` now returns per-note `elapsed_s`,
   `model_used`, and `fallback_reason`, and appends one record per call to
   `~/.claude/obsidian-brain-summarizer-metrics.jsonl` (100 KB rotation, owner-only).
@@ -19,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **Summarizer timeout budget** — `generate_summary` / `generate_snapshot_summary` first-attempt `claude -p` timeout raised from 30s to 120s (retry from 60s to 240s) to accommodate slow-start CC builds where cold-start alone can take ~46s. Fixes the 100% Haiku-pipeline failure rate on affected installs. (#84)
+- **`upgrade_batch()` gains `summary_batch_size` param** — new optional keyword argument (default reads from config, falls back to 3). When `>= 2`, uses the batched path via `generate_summaries_batch`; when `1`, preserves the legacy per-note `ThreadPoolExecutor` fan-out exactly. Existing callers without the param get batching by default.
 - **`upgrade_batch()` return shape** — was `list[tuple[path, status]]`, now
   `list[dict]` with 5 keys (`path`, `status`, `elapsed_s`, `model_used`,
   `fallback_reason`). Backward-incompatible for direct callers; in-tree

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -914,6 +914,7 @@ _DEFAULTS: dict = {
     "min_duration_minutes": 2,
     "summary_model": "haiku",
     "summary_pipeline": "auto",  # "auto" = Haiku claude -p + sub-agent fallback; "subagent" = skip Haiku pipeline. Consumed by /recall SKILL.md Step 2 (summarization is deferred to /recall), #84
+    "summary_batch_size": 3,  # notes per claude -p spawn in upgrade_batch (#166); 1 = legacy per-note fan-out
     "auto_log_enabled": True,
     "snapshot_on_compact": True,
     "snapshot_on_clear": True,
@@ -4194,6 +4195,176 @@ def prepare_summary_input(note_path: str) -> str:
         return f"RAW_OK:{note_path}"
 
 
+def _prepare_note_for_summary(
+    note_path: str,
+    vault_path: str,
+    sessions_folder: str,
+    project: str,
+) -> dict:
+    """Prepare a session/snapshot note for AI summarization (the pre-model stage).
+
+    Reads the raw note, extracts session_id, parses the JSONL transcript (with
+    raw-note fallback), builds summarizer metadata, determines note_type, and
+    (for sessions) computes the snapshot cohesion preamble into metadata.
+
+    Returns a dict. On failure: {"ok": False, "status": <one-line "Failed: ..." string>,
+    "fallback_reason": <classifier>}. On success: {"ok": True, "raw_lines": [...],
+    "session_id": str, "user_msgs": [...], "assistant_msgs": [...], "metadata": {...},
+    "note_type": str, "source": str, "warnings": [...]}.
+
+    Extracted from upgrade_unsummarized_note (#166) so the multi-note batch path
+    can reuse identical preparation. Pure: no model calls, no writes.
+    """
+    # Read the raw note
+    try:
+        with open(note_path, 'r', encoding='utf-8') as f:
+            raw_lines = f.readlines()
+    except (OSError, UnicodeDecodeError) as exc:
+        return {
+            "ok": False,
+            "status": f"Failed: cannot read {os.path.basename(note_path)}: {exc}",
+            "fallback_reason": "unreadable_note",
+        }
+
+    # Extract session_id from frontmatter
+    session_id = None
+    for line in raw_lines[:20]:
+        stripped = line.strip()
+        if stripped.startswith('session_id:'):
+            session_id = stripped.split(':', 1)[1].strip().strip('"').strip("'")
+            break
+    if not session_id:
+        return {
+            "ok": False,
+            "status": f"Failed: no session_id in frontmatter of {os.path.basename(note_path)}",
+            "fallback_reason": "no_session_id",
+        }
+
+    # Find and parse the JSONL transcript
+    jsonl_path = find_transcript_jsonl(session_id)
+    parsed: dict = {}
+    warnings: list[str] = []
+    user_msgs: list[str] = []
+    assistant_msgs: list[str] = []
+    source = "raw note"
+
+    if jsonl_path:
+        parsed = parse_full_transcript(jsonl_path)
+        user_msgs = parsed.get("user_msgs", [])
+        assistant_msgs = parsed.get("assistant_msgs", [])
+        warnings = parsed.get("warnings", [])
+
+        # Decide which source to use
+        raw_note_would_truncate = parsed.get("raw_note_would_truncate", False)
+        truncated = parsed.get("truncated", False)
+
+        # Data always comes from JSONL when found — label accurately
+        if truncated:
+            source = "JSONL transcript (head+tail, middle truncated)"
+        elif raw_note_would_truncate:
+            source = "JSONL transcript (raw note would have truncated)"
+        else:
+            source = "JSONL transcript (full, raw note also sufficient)"
+    else:
+        # Fall back to raw note content for summarization
+        source = "raw note (JSONL not found)"
+        # Extract user/assistant messages from raw note conversation section.
+        # Supports both session notes (## Conversation (raw)) and snapshot notes
+        # (## Last messages (raw)).
+        in_conversation = False
+        for line in raw_lines:
+            stripped = line.strip()
+            if stripped in ('## Conversation (raw)', '## Last messages (raw)'):
+                in_conversation = True
+                continue
+            if in_conversation:
+                if stripped.startswith('## '):
+                    break
+                if stripped.startswith('**User:**'):
+                    user_msgs.append(stripped[9:].strip())
+                elif stripped.startswith('**Assistant:**'):
+                    assistant_msgs.append(stripped[14:].strip())
+
+    # Fall back to raw note if JSONL yielded empty messages (corrupted/empty JSONL)
+    if jsonl_path and not user_msgs and not assistant_msgs:
+        source = "raw note (JSONL found but empty)"
+        in_conversation = False
+        for line in raw_lines:
+            stripped = line.strip()
+            if stripped in ('## Conversation (raw)', '## Last messages (raw)'):
+                in_conversation = True
+                continue
+            if in_conversation:
+                if stripped.startswith('## '):
+                    break
+                if stripped.startswith('**User:**'):
+                    user_msgs.append(stripped[9:].strip())
+                elif stripped.startswith('**Assistant:**'):
+                    assistant_msgs.append(stripped[14:].strip())
+
+    if not user_msgs and not assistant_msgs:
+        return {
+            "ok": False,
+            "status": f"Failed: no conversation content in {os.path.basename(note_path)}",
+            "fallback_reason": "no_conversation_content",
+        }
+
+    # Build metadata for generate_summary
+    metadata: dict = {"project": project, "vault_path": vault_path, "sessions_folder": sessions_folder}
+    for line in raw_lines[:20]:
+        stripped = line.strip()
+        if stripped.startswith('git_branch:'):
+            metadata["git_branch"] = stripped.split(':', 1)[1].strip().strip('"')
+        elif stripped.startswith('duration_minutes:'):
+            try:
+                metadata["duration_minutes"] = float(stripped.split(':', 1)[1].strip())
+            except ValueError:
+                pass
+
+    # Add files_touched and errors from parsed transcript if available
+    if jsonl_path and parsed:
+        metadata["files_touched"] = parsed.get("files_touched", [])
+        metadata["errors"] = parsed.get("errors", [])
+
+    # Route by note type — snapshots use a shorter, focused prompt.
+    note_type = ""
+    for line in raw_lines[:20]:
+        if line.strip().startswith("type:"):
+            note_type = line.split(":", 1)[1].strip().strip('"').strip("'")
+            break
+
+    # Select generator and prepare per-type input. The snapshot cohesion
+    # preamble (session path only) is computed ONCE here, before the
+    # escalation loop, so it is reused across model retries.
+    if note_type != "claude-snapshot":
+        date_str = ""
+        for line in raw_lines[:20]:
+            if line.strip().startswith("date:"):
+                date_str = line.split(":", 1)[1].strip().strip('"').strip("'")
+                break
+        sessions_dir_path = Path(vault_path) / sessions_folder
+        preamble = _augment_session_input_with_snapshots(
+            "", sessions_dir_path, session_id, date_str, project,
+        )
+        if preamble:
+            # Stash the snapshot preamble into metadata so generate_summary can
+            # prepend it to its sampled transcript. New optional key; existing
+            # callers unaffected (absent key → no-op).
+            metadata["snapshot_preamble"] = preamble
+
+    return {
+        "ok": True,
+        "raw_lines": raw_lines,
+        "session_id": session_id,
+        "user_msgs": user_msgs,
+        "assistant_msgs": assistant_msgs,
+        "metadata": metadata,
+        "note_type": note_type,
+        "source": source,
+        "warnings": warnings,
+    }
+
+
 def upgrade_unsummarized_note(
     note_path: str,
     vault_path: str,
@@ -4266,142 +4437,17 @@ def upgrade_unsummarized_note(
     ) -> tuple[str, float, str | None, str | None]:
         return status, round(time.monotonic() - _t0, 2), model_used, fallback_reason
 
-    # Read the raw note
-    try:
-        with open(note_path, 'r', encoding='utf-8') as f:
-            raw_lines = f.readlines()
-    except (OSError, UnicodeDecodeError) as exc:
-        return _ret(
-            f"Failed: cannot read {os.path.basename(note_path)}: {exc}",
-            fallback_reason="unreadable_note",
-        )
+    prep = _prepare_note_for_summary(note_path, vault_path, sessions_folder, project)
+    if not prep["ok"]:
+        return _ret(prep["status"], fallback_reason=prep["fallback_reason"])
+    user_msgs = prep["user_msgs"]
+    assistant_msgs = prep["assistant_msgs"]
+    metadata = prep["metadata"]
+    note_type = prep["note_type"]
+    source = prep["source"]
+    warnings = prep["warnings"]
 
-    # Extract session_id from frontmatter
-    session_id = None
-    for line in raw_lines[:20]:
-        stripped = line.strip()
-        if stripped.startswith('session_id:'):
-            session_id = stripped.split(':', 1)[1].strip().strip('"').strip("'")
-            break
-    if not session_id:
-        return _ret(
-            f"Failed: no session_id in frontmatter of {os.path.basename(note_path)}",
-            fallback_reason="no_session_id",
-        )
-
-    # Find and parse the JSONL transcript
-    jsonl_path = find_transcript_jsonl(session_id)
-    parsed: dict = {}
-    warnings: list[str] = []
-    user_msgs: list[str] = []
-    assistant_msgs: list[str] = []
-    source = "raw note"
-
-    if jsonl_path:
-        parsed = parse_full_transcript(jsonl_path)
-        user_msgs = parsed.get("user_msgs", [])
-        assistant_msgs = parsed.get("assistant_msgs", [])
-        warnings = parsed.get("warnings", [])
-
-        # Decide which source to use
-        raw_note_would_truncate = parsed.get("raw_note_would_truncate", False)
-        truncated = parsed.get("truncated", False)
-
-        # Data always comes from JSONL when found — label accurately
-        if truncated:
-            source = "JSONL transcript (head+tail, middle truncated)"
-        elif raw_note_would_truncate:
-            source = "JSONL transcript (raw note would have truncated)"
-        else:
-            source = "JSONL transcript (full, raw note also sufficient)"
-    else:
-        # Fall back to raw note content for summarization
-        source = "raw note (JSONL not found)"
-        # Extract user/assistant messages from raw note conversation section.
-        # Supports both session notes (## Conversation (raw)) and snapshot notes
-        # (## Last messages (raw)).
-        in_conversation = False
-        for line in raw_lines:
-            stripped = line.strip()
-            if stripped in ('## Conversation (raw)', '## Last messages (raw)'):
-                in_conversation = True
-                continue
-            if in_conversation:
-                if stripped.startswith('## '):
-                    break
-                if stripped.startswith('**User:**'):
-                    user_msgs.append(stripped[9:].strip())
-                elif stripped.startswith('**Assistant:**'):
-                    assistant_msgs.append(stripped[14:].strip())
-
-    # Fall back to raw note if JSONL yielded empty messages (corrupted/empty JSONL)
-    if jsonl_path and not user_msgs and not assistant_msgs:
-        source = "raw note (JSONL found but empty)"
-        in_conversation = False
-        for line in raw_lines:
-            stripped = line.strip()
-            if stripped in ('## Conversation (raw)', '## Last messages (raw)'):
-                in_conversation = True
-                continue
-            if in_conversation:
-                if stripped.startswith('## '):
-                    break
-                if stripped.startswith('**User:**'):
-                    user_msgs.append(stripped[9:].strip())
-                elif stripped.startswith('**Assistant:**'):
-                    assistant_msgs.append(stripped[14:].strip())
-
-    if not user_msgs and not assistant_msgs:
-        return _ret(
-            f"Failed: no conversation content in {os.path.basename(note_path)}",
-            fallback_reason="no_conversation_content",
-        )
-
-    # Build metadata for generate_summary
-    metadata: dict = {"project": project, "vault_path": vault_path, "sessions_folder": sessions_folder}
-    for line in raw_lines[:20]:
-        stripped = line.strip()
-        if stripped.startswith('git_branch:'):
-            metadata["git_branch"] = stripped.split(':', 1)[1].strip().strip('"')
-        elif stripped.startswith('duration_minutes:'):
-            try:
-                metadata["duration_minutes"] = float(stripped.split(':', 1)[1].strip())
-            except ValueError:
-                pass
-
-    # Add files_touched and errors from parsed transcript if available
-    if jsonl_path and parsed:
-        metadata["files_touched"] = parsed.get("files_touched", [])
-        metadata["errors"] = parsed.get("errors", [])
-
-    # Route by note type — snapshots use a shorter, focused prompt.
-    note_type = ""
-    for line in raw_lines[:20]:
-        if line.strip().startswith("type:"):
-            note_type = line.split(":", 1)[1].strip().strip('"').strip("'")
-            break
-
-    # Select generator and prepare per-type input. The snapshot cohesion
-    # preamble (session path only) is computed ONCE here, before the
-    # escalation loop, so it is reused across model retries.
-    if note_type == "claude-snapshot":
-        gen_fn = generate_snapshot_summary
-    else:
-        gen_fn = generate_summary
-        date_str = ""
-        for line in raw_lines[:20]:
-            if line.strip().startswith("date:"):
-                date_str = line.split(":", 1)[1].strip().strip('"').strip("'")
-                break
-        sessions_dir_path = Path(vault_path) / sessions_folder
-        preamble = _augment_session_input_with_snapshots(
-            "", sessions_dir_path, session_id, date_str, project,
-        )
-        if preamble:
-            # Stash the snapshot preamble into metadata so generate_summary can
-            # prepend it to its sampled transcript. New optional key; existing
-            # callers unaffected (absent key → no-op).
-            metadata["snapshot_preamble"] = preamble
+    gen_fn = generate_snapshot_summary if note_type == "claude-snapshot" else generate_summary
 
     # Model-escalation chain (#165): try the primary model, then escalate to
     # Sonnet, then Opus, but ONLY when the failure is a quality reason
@@ -4443,6 +4489,209 @@ def upgrade_unsummarized_note(
     return _ret(status, model_used=model_used, fallback_reason=None)
 
 
+def generate_summaries_batch(
+    prepared_notes: list[dict],
+    model: str = "haiku",
+    timeout: int = 120,
+    project: str = "unknown",
+    vault_path: str = "",
+    sessions_folder: str = "",
+) -> list[tuple[str | None, str | None]]:
+    """Summarize N SESSION notes in ONE ``claude -p --model <model>`` spawn.
+
+    ``prepared_notes`` is a list of ok=True session-note prep dicts (caller
+    guarantees: not snapshots, not prep failures).  Returns a list of
+    ``(summary_text|None, fallback_reason|None)`` ALIGNED to ``prepared_notes``
+    order.
+
+    Failure reasons returned for all notes on whole-spawn failure:
+      ``"haiku_timeout"``           — TimeoutExpired (retried once)
+      ``"haiku_subprocess_error"``  — rc != 0, FileNotFoundError, or other error (no retry)
+      ``"empty_output"``            — subprocess rc==0 but stdout empty (no retry)
+
+    Per-note parse failures on success path:
+      ``"missing_section"``         — block absent or lacks ``## Summary``
+
+    (#166)
+    """
+    n = len(prepared_notes)
+    if n == 0:
+        return []
+
+    # ---- Build multi-note prompt -----------------------------------------------
+    # Collect open items once for all notes (same project).
+    existing_items: list = []
+    try:
+        _hooks_dir = os.path.dirname(os.path.abspath(__file__))
+        if _hooks_dir not in sys.path:
+            sys.path.insert(0, _hooks_dir)
+        from open_item_dedup import collect_open_items as _collect_open_items
+        existing_items = _collect_open_items(vault_path, sessions_folder, project, max_sessions=10)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[obsidian-brain] open item collection failed (non-fatal): {exc}", file=sys.stderr)
+
+    def _sample_msgs(user_msgs: list[str], assistant_msgs: list[str]) -> tuple[str, str]:
+        if len(user_msgs) > 20:
+            sampled_user: list[str] = (
+                user_msgs[:10] + ["[... middle messages omitted ...]"] + user_msgs[-10:]
+            )
+        else:
+            sampled_user = user_msgs
+        if len(assistant_msgs) > 20:
+            sampled_asst: list[str] = (
+                assistant_msgs[:10] + ["[... middle messages omitted ...]"] + assistant_msgs[-10:]
+            )
+        else:
+            sampled_asst = assistant_msgs
+        return "\n---\n".join(sampled_user)[:12000], "\n---\n".join(sampled_asst)[:12000]
+
+    prompt_parts: list[str] = [
+        f"You are a technical summarizer. You will be given {n} session transcript(s) below.\n"
+        f"Each transcript is delimited by a line '===== NOTE k =====' where k is the note number.\n"
+        "For EACH note, output its summary starting with a line '===== SUMMARY k =====' on its own line,\n"
+        "followed by EXACTLY these markdown sections:\n"
+        "## Summary / ## Key Decisions / ## Changes Made / ## Errors Encountered / ## Open Questions / Next Steps / ## Importance\n"
+        f"Output blocks for ALL {n} notes, in order. NO commentary outside the delimited blocks.\n"
+        "Do NOT respond conversationally. Do NOT ask questions. Just output the summaries.\n\n"
+        "For ## Importance: Rate 1-10. 1-3: trivial. 4-6: standard. 7-8: key decisions. 9-10: major.\n"
+    ]
+
+    for k, prep in enumerate(prepared_notes, start=1):
+        user_sample, asst_sample = _sample_msgs(prep["user_msgs"], prep["assistant_msgs"])
+        meta = prep["metadata"]
+        preamble = meta.get("snapshot_preamble", "")
+        files_str = ", ".join(meta.get("files_touched", [])[:15]) or "none detected"
+        meta_line = (
+            f"NOTE {k} METADATA: project={meta.get('project', 'unknown')} "
+            f"branch={meta.get('git_branch', 'unknown')} "
+            f"files_touched={files_str}"
+        )
+        prompt_parts.append(f"===== NOTE {k} =====\n")
+        prompt_parts.append(f"{meta_line}\n")
+        if preamble:
+            prompt_parts.append(
+                f"{preamble}\n"
+                "Some earlier context may come from pre-compact snapshots — "
+                "synthesize the whole arc into a cohesive narrative.\n"
+            )
+        prompt_parts.append(
+            f"SESSION TRANSCRIPT:\n{user_sample}\n\n---\n\n{asst_sample}\n\n"
+        )
+        prompt_parts.append(
+            "OUTPUT EXACTLY these markdown sections with no preamble, no commentary:\n\n"
+            "## Summary\n1-3 sentence overview of what was accomplished.\n\n"
+            "## Key Decisions\n- Bullet list. Write \"None noted.\" if none.\n\n"
+            "## Changes Made\n- Bullet list. Write \"None noted.\" if none.\n\n"
+            "## Errors Encountered\n- Bullet list. Write \"None.\" if none.\n\n"
+            "## Open Questions / Next Steps\n- [ ] Checkbox list. Write \"None.\" if none.\n\n"
+            "## Importance\nRate 1-10. Output ONLY the number.\n\n"
+        )
+
+    if existing_items:
+        prompt_parts.append("## Existing Open Items for This Project (DO NOT DUPLICATE)\n")
+        prompt_parts.append(
+            "The following items are already tracked in older session notes. Do NOT include any item\n"
+            "that is semantically equivalent to these — same PR, same branch, same task, same file.\n"
+            "Only add genuinely NEW open items from this session's conversation.\n\n"
+        )
+        for _, _, item_text in existing_items:
+            prompt_parts.append(f"- {item_text}\n")
+
+    prompt = "".join(prompt_parts)
+
+    # ---- Subprocess with retry on timeout -------------------------------------
+    attempts = (timeout, timeout * 2)
+    last_reason: str | None = None
+    stdout_text: str | None = None
+
+    for i, attempt_timeout in enumerate(attempts):
+        try:
+            result = subprocess.run(
+                ["claude", "-p", "--model", model],
+                input=prompt,
+                capture_output=True,
+                text=True,
+                timeout=attempt_timeout,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                stdout_text = result.stdout.strip()
+                break
+            if result.returncode != 0:
+                last_reason = "haiku_subprocess_error"
+                print(
+                    f"[obsidian-brain] claude -p batch failed (rc={result.returncode}): "
+                    f"{result.stderr[:200]}",
+                    file=sys.stderr,
+                )
+                break
+            # rc==0 but empty stdout
+            last_reason = "empty_output"
+            print("[obsidian-brain] claude -p batch returned empty stdout", file=sys.stderr)
+            break
+        except FileNotFoundError:
+            last_reason = "haiku_subprocess_error"
+            print("[obsidian-brain] claude CLI not found, batch summarization unavailable", file=sys.stderr)
+            break
+        except subprocess.TimeoutExpired:
+            last_reason = "haiku_timeout"
+            if i < len(attempts) - 1:
+                print(
+                    f"[obsidian-brain] claude -p batch timed out at {attempt_timeout}s, retrying...",
+                    file=sys.stderr,
+                )
+                continue
+            print(
+                f"[obsidian-brain] claude -p batch timed out at {attempt_timeout}s, giving up",
+                file=sys.stderr,
+            )
+            break
+        except Exception as exc:  # noqa: BLE001
+            last_reason = "haiku_subprocess_error"
+            print(f"[obsidian-brain] claude -p batch error ({type(exc).__name__}): {exc}", file=sys.stderr)
+            break
+
+    # Whole-spawn failure — return same reason for all notes.
+    if stdout_text is None:
+        reason = last_reason or "haiku_subprocess_error"
+        return [(None, reason)] * n
+
+    # ---- Parse delimited output ------------------------------------------------
+    try:
+        _summary_header_re = re.compile(
+            r"^=====\s*SUMMARY\s+(\d+)\s*=====\s*$", re.MULTILINE
+        )
+        parts_split = _summary_header_re.split(stdout_text)
+        # parts_split alternates: [preamble, k1, block1, k2, block2, ...]
+        parsed_blocks: dict[int, str] = {}
+        it = iter(parts_split)
+        next(it, None)  # skip preamble before first header
+        for k_str, block in zip(it, it):
+            try:
+                parsed_blocks[int(k_str)] = block
+            except ValueError:
+                pass
+
+        _has_summary_re = re.compile(r"^## Summary", re.MULTILINE)
+
+        results: list[tuple[str | None, str | None]] = []
+        for i_note, prep in enumerate(prepared_notes):
+            k = i_note + 1
+            if k in parsed_blocks:
+                block_text = parsed_blocks[k].strip()
+                if _has_summary_re.search(block_text):
+                    if existing_items:
+                        block_text = _dedup_summary_open_items(block_text, existing_items)
+                    results.append((block_text, None))
+                else:
+                    results.append((None, "missing_section"))
+            else:
+                results.append((None, "missing_section"))
+        return results
+    except Exception as exc:  # noqa: BLE001
+        print(f"[obsidian-brain] batch parse error ({type(exc).__name__}): {exc}", file=sys.stderr)
+        return [(None, "missing_section")] * n
+
+
 def upgrade_batch(
     paths: list[str],
     vault_path: str,
@@ -4451,8 +4700,9 @@ def upgrade_batch(
     max_workers: int = 10,
     summary_model: str = "haiku",
     summary_timeout: int | None = None,
+    summary_batch_size: int | None = None,
 ) -> list[dict]:
-    """Fan out upgrade_unsummarized_note() concurrently.
+    """Fan out upgrade_unsummarized_note() concurrently, with optional batching.
 
     Returns a list of per-note dicts IN THE SAME ORDER AS ``paths`` (not
     completion order). Each dict has the keys:
@@ -4462,6 +4712,19 @@ def upgrade_batch(
       * ``elapsed_s`` — wall-time inside the worker, rounded to 2 dp
       * ``model_used`` — see ``upgrade_unsummarized_note`` docstring
       * ``fallback_reason`` — see ``upgrade_unsummarized_note`` docstring
+
+    ``summary_batch_size`` controls note grouping for the ``claude -p`` spawn:
+      * ``None`` (default) — read from ``load_config()`` (config key
+        ``summary_batch_size``, default 3).
+      * ``1`` — legacy per-note fan-out via ThreadPoolExecutor (unchanged
+        behavior; use to pin legacy-contract tests).
+      * ``>=2`` — batched path: session notes are grouped into batches of up
+        to ``summary_batch_size`` and summarized in a single ``claude -p``
+        spawn per group, amortizing CLI startup cost (~70% startup-overhead
+        reduction vs. per-note). Snapshots always go through the solo path.
+        Per-note parse failures (``missing_section``) and whole-spawn failures
+        fall through to ``upgrade_unsummarized_note`` (the solo path), so the
+        Phase 2 sub-agent in SKILL.md still catches anything both paths fail.
 
     Side effect: appends one record per call to
     ``~/.claude/obsidian-brain-summarizer-metrics.jsonl`` via
@@ -4485,40 +4748,236 @@ def upgrade_batch(
     from concurrent.futures import ThreadPoolExecutor
     from datetime import datetime, timezone
 
-    workers = min(max_workers, len(paths))
+    # Resolve batch size.
+    if summary_batch_size is None:
+        try:
+            summary_batch_size = int(load_config().get("summary_batch_size", 3))
+        except Exception:  # noqa: BLE001
+            summary_batch_size = 3
+    else:
+        summary_batch_size = int(summary_batch_size)
+    summary_batch_size = max(1, summary_batch_size)
+
     _wall_t0 = time.monotonic()
 
-    with ThreadPoolExecutor(max_workers=workers) as ex:
-        futs = [
-            ex.submit(
-                upgrade_unsummarized_note,
-                p,
-                vault_path,
-                sessions_folder,
-                project,
-                summary_model,
-                summary_timeout,
+    # ---- Legacy per-note fan-out path (batch_size <= 1) ----------------------
+    if summary_batch_size <= 1:
+        workers = min(max_workers, len(paths))
+        with ThreadPoolExecutor(max_workers=workers) as ex:
+            futs = [
+                ex.submit(
+                    upgrade_unsummarized_note,
+                    p,
+                    vault_path,
+                    sessions_folder,
+                    project,
+                    summary_model,
+                    summary_timeout,
+                )
+                for p in paths
+            ]
+            results: list[dict] = []
+            for p, fut in zip(paths, futs):
+                try:
+                    status, elapsed_s, model_used, fallback_reason = fut.result()
+                except Exception as exc:  # noqa: BLE001 — per-note isolation
+                    exc_str = str(exc)[:500]
+                    status = f"Failed: {type(exc).__name__}: {exc_str}"
+                    elapsed_s, model_used, fallback_reason = 0.0, None, "worker_exception"
+                results.append({
+                    "path": p,
+                    "status": status,
+                    "elapsed_s": elapsed_s,
+                    "model_used": model_used,
+                    "fallback_reason": fallback_reason,
+                })
+
+        wall_s = round(time.monotonic() - _wall_t0, 2)
+        try:
+            _hooks_dir = os.path.dirname(os.path.abspath(__file__))
+            if _hooks_dir not in sys.path:
+                sys.path.insert(0, _hooks_dir)
+            import summarizer_metrics
+            summarizer_metrics.append_metrics_record({
+                "ts": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "project": project,
+                "n_notes": len(results),
+                "wall_s": wall_s,
+                "notes": results,
+            })
+        except Exception as exc:  # noqa: BLE001 — telemetry must never break recall
+            print(
+                f"[obsidian-brain] metrics sink unavailable ({type(exc).__name__}): {exc}",
+                file=sys.stderr,
             )
-            for p in paths
-        ]
-        results: list[dict] = []
-        for p, fut in zip(paths, futs):
+        return results
+
+    # ---- Batched path (batch_size >= 2) ---------------------------------------
+
+    # Step 1: Prepare all notes concurrently.
+    workers = min(max_workers, len(paths))
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        prep_futs = {p: ex.submit(_prepare_note_for_summary, p, vault_path, sessions_folder, project)
+                     for p in paths}
+    preps: dict[str, dict] = {}
+    for p, fut in prep_futs.items():
+        try:
+            preps[p] = fut.result()
+        except Exception as exc:  # noqa: BLE001
+            preps[p] = {
+                "ok": False,
+                "status": f"Failed: worker error preparing {os.path.basename(p)}: {str(exc)[:200]}",
+                "fallback_reason": "worker_exception",
+            }
+
+    results_by_path: dict[str, dict] = {}
+
+    # Step 2: Route prep failures immediately.
+    failed_prep_paths = [p for p in paths if not preps[p]["ok"]]
+    for p in failed_prep_paths:
+        prep = preps[p]
+        results_by_path[p] = {
+            "path": p,
+            "status": prep["status"],
+            "elapsed_s": 0.0,
+            "model_used": None,
+            "fallback_reason": prep.get("fallback_reason"),
+        }
+
+    # Step 3: Route snapshots to solo path.
+    snapshot_paths = [p for p in paths if preps[p].get("ok") and preps[p].get("note_type") == "claude-snapshot"]
+    session_paths = [p for p in paths if preps[p].get("ok") and preps[p].get("note_type") != "claude-snapshot"]
+
+    if snapshot_paths:
+        snap_workers = min(max_workers, len(snapshot_paths))
+        with ThreadPoolExecutor(max_workers=snap_workers) as ex:
+            snap_futs = {
+                p: ex.submit(upgrade_unsummarized_note, p, vault_path, sessions_folder, project, summary_model, summary_timeout)
+                for p in snapshot_paths
+            }
+        for p, fut in snap_futs.items():
             try:
                 status, elapsed_s, model_used, fallback_reason = fut.result()
-            except Exception as exc:  # noqa: BLE001 — per-note isolation
+            except Exception as exc:  # noqa: BLE001
                 exc_str = str(exc)[:500]
                 status = f"Failed: {type(exc).__name__}: {exc_str}"
                 elapsed_s, model_used, fallback_reason = 0.0, None, "worker_exception"
-            results.append({
+            results_by_path[p] = {
                 "path": p,
                 "status": status,
                 "elapsed_s": elapsed_s,
                 "model_used": model_used,
                 "fallback_reason": fallback_reason,
-            })
+            }
+
+    # Step 4: Group session notes into size/char-aware batches.
+    _CHAR_CAP = 60000
+
+    groups: list[list[str]] = []
+    current_group: list[str] = []
+    current_chars = 0
+
+    for p in session_paths:
+        prep = preps[p]
+        u_est = min(len("\n---\n".join(prep["user_msgs"])), 12000)
+        a_est = min(len("\n---\n".join(prep["assistant_msgs"])), 12000)
+        note_chars = u_est + a_est
+        if current_group and (len(current_group) >= summary_batch_size or current_chars + note_chars > _CHAR_CAP):
+            groups.append(current_group)
+            current_group = [p]
+            current_chars = note_chars
+        else:
+            current_group.append(p)
+            current_chars += note_chars
+    if current_group:
+        groups.append(current_group)
+
+    # Step 5: Process each group.
+    for group_paths in groups:
+        group_preps = [preps[p] for p in group_paths]
+        g_t0 = time.monotonic()
+
+        # Try primary model, escalate on whole-group empty_output.
+        models_to_try = [summary_model] + [m for m in _SUMMARY_FALLBACK_CHAIN if m != summary_model]
+        group_results: list[tuple[str | None, str | None]] | None = None
+        used_model = summary_model
+
+        for _model in models_to_try:
+            batch_out = generate_summaries_batch(
+                group_preps,
+                model=_model,
+                timeout=(summary_timeout or 120),
+                project=project,
+                vault_path=vault_path,
+                sessions_folder=sessions_folder,
+            )
+            # Escalate at group level only on whole-spawn empty_output.
+            if all(text is None and reason == "empty_output" for text, reason in batch_out):
+                if _model != models_to_try[-1]:
+                    continue  # try next model
+            used_model = _model
+            group_results = batch_out
+            break
+
+        if group_results is None:
+            group_results = [(None, "empty_output")] * len(group_paths)
+
+        g_wall = time.monotonic() - g_t0
+        per_note_elapsed = round(g_wall / len(group_paths), 2)
+
+        # Solo fallback paths for notes that need it.
+        solo_fallback_paths: list[str] = []
+
+        for p, (summary_text, parse_reason) in zip(group_paths, group_results):
+            if summary_text is not None:
+                # Attempt write-back.
+                prep = preps[p]
+                write_status = upgrade_note_with_summary(
+                    p, summary_text, vault_path, sessions_folder, project,
+                    source=prep["source"], warnings=prep["warnings"],
+                )
+                if write_status.startswith("Upgraded "):
+                    results_by_path[p] = {
+                        "path": p,
+                        "status": write_status,
+                        "elapsed_s": per_note_elapsed,
+                        "model_used": used_model,
+                        "fallback_reason": None,
+                    }
+                else:
+                    # Write-back failed — route to solo fallback.
+                    solo_fallback_paths.append(p)
+            else:
+                # No usable summary — route to solo fallback.
+                solo_fallback_paths.append(p)
+
+        # Run solo fallback for all notes that need it in this group.
+        if solo_fallback_paths:
+            solo_workers = min(max_workers, len(solo_fallback_paths))
+            with ThreadPoolExecutor(max_workers=solo_workers) as ex:
+                solo_futs = {
+                    p: ex.submit(upgrade_unsummarized_note, p, vault_path, sessions_folder, project, summary_model, summary_timeout)
+                    for p in solo_fallback_paths
+                }
+            for p, fut in solo_futs.items():
+                try:
+                    status, elapsed_s, model_used, fallback_reason = fut.result()
+                except Exception as exc:  # noqa: BLE001
+                    exc_str = str(exc)[:500]
+                    status = f"Failed: {type(exc).__name__}: {exc_str}"
+                    elapsed_s, model_used, fallback_reason = 0.0, None, "worker_exception"
+                results_by_path[p] = {
+                    "path": p,
+                    "status": status,
+                    "elapsed_s": elapsed_s,
+                    "model_used": model_used,
+                    "fallback_reason": fallback_reason,
+                }
+
+    # Step 6: Assemble in input order.
+    results = [results_by_path[p] for p in paths]
 
     wall_s = round(time.monotonic() - _wall_t0, 2)
-
     try:
         _hooks_dir = os.path.dirname(os.path.abspath(__file__))
         if _hooks_dir not in sys.path:
@@ -4536,5 +4995,4 @@ def upgrade_batch(
             f"[obsidian-brain] metrics sink unavailable ({type(exc).__name__}): {exc}",
             file=sys.stderr,
         )
-
     return results

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1936,6 +1936,18 @@ _SUMMARY_FALLBACK_CHAIN = ("sonnet", "opus")
 # different model won't fix an environment problem.
 _MODEL_ESCALATION_REASONS = frozenset({"empty_output"})
 
+# Capability rank for escalation: only escalate to a MORE capable model than the
+# primary. Prevents a backwards chain when summary_model is explicitly "opus"/"sonnet".
+_MODEL_RANK = {"haiku": 0, "sonnet": 1, "opus": 2}
+
+
+def _escalation_models(primary: str) -> list[str]:
+    """Ordered model list: the primary, then any fallback-chain model strictly
+    more capable than the primary (#165). e.g. haiku -> [haiku, sonnet, opus];
+    sonnet -> [sonnet, opus]; opus -> [opus]."""
+    base = _MODEL_RANK.get(primary, 0)
+    return [primary] + [m for m in _SUMMARY_FALLBACK_CHAIN if _MODEL_RANK.get(m, 0) > base]
+
 
 def generate_snapshot_summary(
     user_msgs: list[str],
@@ -4453,9 +4465,7 @@ def upgrade_unsummarized_note(
     # Sonnet, then Opus, but ONLY when the failure is a quality reason
     # (empty_output). Timeouts / subprocess errors break immediately — a more
     # capable model won't fix a slow CLI cold-start or a missing binary.
-    models_to_try = [summary_model] + [
-        m for m in _SUMMARY_FALLBACK_CHAIN if m != summary_model
-    ]
+    models_to_try = _escalation_models(summary_model)
     summary_text = None
     fallback_reason = None
     model_used = None
@@ -4667,9 +4677,11 @@ def generate_summaries_batch(
         next(it, None)  # skip preamble before first header
         for k_str, block in zip(it, it):
             try:
-                parsed_blocks[int(k_str)] = block
+                k_int = int(k_str)
             except ValueError:
-                pass
+                continue
+            if k_int not in parsed_blocks:  # first-occurrence-wins (#165 Fix 1)
+                parsed_blocks[k_int] = block
 
         _has_summary_re = re.compile(r"^## Summary", re.MULTILINE)
 
@@ -4680,7 +4692,14 @@ def generate_summaries_batch(
                 block_text = parsed_blocks[k].strip()
                 if _has_summary_re.search(block_text):
                     if existing_items:
-                        block_text = _dedup_summary_open_items(block_text, existing_items)
+                        try:
+                            block_text = _dedup_summary_open_items(block_text, existing_items)
+                        except Exception as exc:  # noqa: BLE001 — dedup is best-effort, never fail the note
+                            print(
+                                f"[obsidian-brain] batch open-item dedup failed (non-fatal) "
+                                f"({type(exc).__name__}): {exc}",
+                                file=sys.stderr,
+                            )
                     results.append((block_text, None))
                 else:
                     results.append((None, "missing_section"))
@@ -4752,7 +4771,12 @@ def upgrade_batch(
     if summary_batch_size is None:
         try:
             summary_batch_size = int(load_config().get("summary_batch_size", 3))
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"[obsidian-brain] invalid summary_batch_size in config "
+                f"({type(exc).__name__}): {exc}; using 3",
+                file=sys.stderr,
+            )
             summary_batch_size = 3
     else:
         summary_batch_size = int(summary_batch_size)
@@ -4898,7 +4922,7 @@ def upgrade_batch(
         g_t0 = time.monotonic()
 
         # Try primary model, escalate on whole-group empty_output.
-        models_to_try = [summary_model] + [m for m in _SUMMARY_FALLBACK_CHAIN if m != summary_model]
+        models_to_try = _escalation_models(summary_model)
         group_results: list[tuple[str | None, str | None]] | None = None
         used_model = summary_model
 
@@ -4920,6 +4944,10 @@ def upgrade_batch(
             break
 
         if group_results is None:
+            print(
+                "[obsidian-brain] BUG: group_results unset after escalation loop (empty models_to_try?)",
+                file=sys.stderr,
+            )
             group_results = [(None, "empty_output")] * len(group_paths)
 
         g_wall = time.monotonic() - g_t0
@@ -4929,26 +4957,34 @@ def upgrade_batch(
         solo_fallback_paths: list[str] = []
 
         for p, (summary_text, parse_reason) in zip(group_paths, group_results):
-            if summary_text is not None:
-                # Attempt write-back.
-                prep = preps[p]
-                write_status = upgrade_note_with_summary(
-                    p, summary_text, vault_path, sessions_folder, project,
-                    source=prep["source"], warnings=prep["warnings"],
-                )
-                if write_status.startswith("Upgraded "):
-                    results_by_path[p] = {
-                        "path": p,
-                        "status": write_status,
-                        "elapsed_s": per_note_elapsed,
-                        "model_used": used_model,
-                        "fallback_reason": None,
-                    }
+            try:
+                if summary_text is not None:
+                    # Attempt write-back.
+                    prep = preps[p]
+                    write_status = upgrade_note_with_summary(
+                        p, summary_text, vault_path, sessions_folder, project,
+                        source=prep["source"], warnings=prep["warnings"],
+                    )
+                    if write_status.startswith("Upgraded "):
+                        results_by_path[p] = {
+                            "path": p,
+                            "status": write_status,
+                            "elapsed_s": per_note_elapsed,
+                            "model_used": used_model,
+                            "fallback_reason": None,
+                        }
+                    else:
+                        # Write-back failed — route to solo fallback.
+                        solo_fallback_paths.append(p)
                 else:
-                    # Write-back failed — route to solo fallback.
+                    # No usable summary — route to solo fallback.
                     solo_fallback_paths.append(p)
-            else:
-                # No usable summary — route to solo fallback.
+            except Exception as exc:  # noqa: BLE001 — never let one note crash the batch
+                print(
+                    f"[obsidian-brain] write-back raised unexpectedly for "
+                    f"{os.path.basename(p)} ({type(exc).__name__}): {exc}",
+                    file=sys.stderr,
+                )
                 solo_fallback_paths.append(p)
 
         # Run solo fallback for all notes that need it in this group.

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1922,6 +1922,20 @@ OUTPUT EXACTLY these two sections with no preamble, no commentary:
 """
 
 
+# Model-escalation chain for the summarizer (#165). After the primary model
+# (summary_model, default "haiku") fails with a *quality* reason, retry with a
+# more capable model. Sonnet is the first fallback (~3x cost) before Opus (~5x),
+# replacing the old behavior where the recall Phase-2 sub-agent fell straight to
+# Opus. CLI aliases passed to `claude -p --model`.
+_SUMMARY_FALLBACK_CHAIN = ("sonnet", "opus")
+# Only these generate_summary failure reasons warrant escalating to a more
+# capable model. Timeouts (haiku_timeout) are NOT escalated — a larger model is
+# slower and would worsen the slow-CLI problem (#84). Subprocess errors
+# (haiku_subprocess_error: CLI missing / non-zero rc) are NOT escalated — a
+# different model won't fix an environment problem.
+_MODEL_ESCALATION_REASONS = frozenset({"empty_output"})
+
+
 def generate_snapshot_summary(
     user_msgs: list[str],
     assistant_msgs: list[str],
@@ -4201,9 +4215,11 @@ def upgrade_unsummarized_note(
       notably ``skills/recall/SKILL.md`` Step 2 Phase 1 — MUST check the
       ``"Upgraded "`` prefix as the positive path.
     - **elapsed_s** (*float*) — wall-clock seconds rounded to 2 decimal places.
-    - **model_used** (*str | None*) — the resolved ``summary_model`` value on
-      success (default ``"haiku"``), or ``None`` on failure paths that never
-      reached summarization. Sonnet/Opus tags are reserved for Phase 3 #165.
+    - **model_used** (*str | None*) — the CLI alias of the model that produced
+      the accepted summary (``"haiku"`` on the common path; ``"sonnet"`` or
+      ``"opus"`` when the escalation chain fired on an ``"empty_output"`` from
+      the primary model, per #165), or ``None`` on failure paths that never
+      reached summarization.
     - **fallback_reason** (*str | None*) — non-``None`` when summarization
       itself failed or a worker / pre-summarization check caught a problem.
       ``None`` indicates that summarization succeeded; it does NOT by itself
@@ -4365,16 +4381,13 @@ def upgrade_unsummarized_note(
             note_type = line.split(":", 1)[1].strip().strip('"').strip("'")
             break
 
-    gen_kwargs: dict = {"model": summary_model}
-    if summary_timeout is not None:
-        gen_kwargs["timeout"] = summary_timeout
-
+    # Select generator and prepare per-type input. The snapshot cohesion
+    # preamble (session path only) is computed ONCE here, before the
+    # escalation loop, so it is reused across model retries.
     if note_type == "claude-snapshot":
-        summary_text, fallback_reason = generate_snapshot_summary(
-            user_msgs, assistant_msgs, metadata, **gen_kwargs,
-        )
+        gen_fn = generate_snapshot_summary
     else:
-        # Session — augment with snapshot bodies for cohesion.
+        gen_fn = generate_summary
         date_str = ""
         for line in raw_lines[:20]:
             if line.strip().startswith("date:"):
@@ -4389,9 +4402,30 @@ def upgrade_unsummarized_note(
             # prepend it to its sampled transcript. New optional key; existing
             # callers unaffected (absent key → no-op).
             metadata["snapshot_preamble"] = preamble
-        summary_text, fallback_reason = generate_summary(
+
+    # Model-escalation chain (#165): try the primary model, then escalate to
+    # Sonnet, then Opus, but ONLY when the failure is a quality reason
+    # (empty_output). Timeouts / subprocess errors break immediately — a more
+    # capable model won't fix a slow CLI cold-start or a missing binary.
+    models_to_try = [summary_model] + [
+        m for m in _SUMMARY_FALLBACK_CHAIN if m != summary_model
+    ]
+    summary_text = None
+    fallback_reason = None
+    model_used = None
+    for _model in models_to_try:
+        gen_kwargs: dict = {"model": _model}
+        if summary_timeout is not None:
+            gen_kwargs["timeout"] = summary_timeout
+        summary_text, fallback_reason = gen_fn(
             user_msgs, assistant_msgs, metadata, **gen_kwargs,
         )
+        if summary_text:
+            model_used = _model
+            break
+        if fallback_reason not in _MODEL_ESCALATION_REASONS:
+            # timeout / subprocess error — escalating model won't help
+            break
 
     if not summary_text:
         return _ret(
@@ -4404,9 +4438,9 @@ def upgrade_unsummarized_note(
         note_path, summary_text, vault_path, sessions_folder, project,
         source=source, warnings=warnings,
     )
-    # summary_model is the CLI alias passed to claude -p --model;
-    # at Phase 1 this is always "haiku" but Phase 3 (#165) will widen the chain.
-    return _ret(status, model_used=summary_model, fallback_reason=None)
+    # model_used is the CLI alias of the model that produced the accepted
+    # summary — "haiku" on the common path, "sonnet"/"opus" when escalated (#165).
+    return _ret(status, model_used=model_used, fallback_reason=None)
 
 
 def upgrade_batch(

--- a/skills/recall/SKILL.md
+++ b/skills/recall/SKILL.md
@@ -133,7 +133,7 @@ except Exception as exc:
 ' "$VAULT_PATH" "$SESSIONS_FOLDER" "$PROJECT"
 ```
 
-Parse the returned JSON. If the top-level object contains an `"error"` key, `upgrade_batch` itself failed — treat all notes as failed and fall back to the Phase 2 sub-agent path for each. Otherwise, parse the array normally. Each result dict has: `path`, `status`, `elapsed_s`, `model_used` (`haiku-4.5` on success, `None` on failure; `sonnet-4.6` / `opus-*` reserved for Phase 3 #165), `fallback_reason` (`haiku_timeout` | `empty_output` | `haiku_subprocess_error` | `None`). For each entry:
+Parse the returned JSON. If the top-level object contains an `"error"` key, `upgrade_batch` itself failed — treat all notes as failed and fall back to the Phase 2 sub-agent path for each. Otherwise, parse the array normally. Each result dict has: `path`, `status`, `elapsed_s`, `model_used` (`haiku-4.5` on success, `None` on failure; `sonnet-4.6` / `opus-*` reserved for Phase 3 #165), `fallback_reason` (`haiku_timeout` | `empty_output` | `haiku_subprocess_error` | `None`). Note: `upgrade_batch` now groups session notes into batches (default 3 per spawn, config key `summary_batch_size`; set to 1 to disable) and summarizes each group in a single `claude -p` spawn to amortize CLI startup cost (#166). Per-note parse failures (`missing_section`) and whole-spawn failures fall through to the per-note solo path automatically before any result reaches Phase 2. For each entry:
 - `status` starts with `Upgraded ` → mark as succeeded
 - anything else (including `Failed: ...`, empty, or unexpected prefix) → add to the Phase 2 fallback list
 

--- a/tests/test_collect_vault_corpus.py
+++ b/tests/test_collect_vault_corpus.py
@@ -575,6 +575,9 @@ class TestUpgradeAndCollectCorpus:
         def fake_uun(path, *a, **kw):
             return (f"Upgraded {os.path.basename(path)}", 0.4, "haiku", None)
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_uun)
+        # Pin to legacy per-note fan-out so upgrade_unsummarized_note is called directly
+        # (these notes lack conversation content; batch prep would fail before reaching it).
+        monkeypatch.setattr(obsidian_utils, "load_config", lambda: {"summary_batch_size": 1})
 
         sess = tmp_vault / "claude-sessions"
         for i in range(3):
@@ -658,7 +661,7 @@ class TestUpgradeAndCollectCorpus:
 
 
 class TestUpgradeErrorLogging:
-    def test_failed_upgrade_surfaces_as_failed_status_and_stderr(self, tmp_vault, tmp_path, capsys):
+    def test_failed_upgrade_surfaces_as_failed_status_and_stderr(self, tmp_vault, tmp_path, capsys, monkeypatch):
         """upgrade_and_collect_corpus surfaces worker exception as Failed: status AND logs to stderr."""
         sess = tmp_vault / "claude-sessions"
         _write_note(sess / f"{_today_str()}-fail-0001.md",
@@ -666,6 +669,9 @@ class TestUpgradeErrorLogging:
              "status": "auto-logged", "session_id": "fail-sid"},
             "# Fail\n\n## Summary\nAI summary unavailable")
         output = tmp_path / "corpus.json"
+        # Pin to legacy per-note fan-out so the RuntimeError from upgrade_unsummarized_note
+        # is visible as a worker_exception in the result dict, not lost in prep routing.
+        monkeypatch.setattr(obsidian_utils, "load_config", lambda: {"summary_batch_size": 1})
         with patch("obsidian_utils.upgrade_unsummarized_note", side_effect=RuntimeError("haiku timeout")):
             status = obsidian_utils.upgrade_and_collect_corpus(
                 str(tmp_vault), "claude-sessions", "claude-insights", 30, str(output))

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -1995,6 +1995,7 @@ class TestUpgradeBatch:
 
         result = obsidian_utils.upgrade_batch(
             ["/vault/sessions/one.md"], "/vault", "sessions", "proj",
+            summary_batch_size=1,
         )
         assert len(result) == 1
         assert result[0]["path"] == "/vault/sessions/one.md"
@@ -2020,7 +2021,8 @@ class TestUpgradeBatch:
         monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_impl)
 
         paths = [f"/vault/sessions/{name}" for name in ("a.md", "b.md", "c.md", "d.md", "e.md")]
-        result = obsidian_utils.upgrade_batch(paths, "/vault", "sessions", "proj")
+        result = obsidian_utils.upgrade_batch(paths, "/vault", "sessions", "proj",
+                                              summary_batch_size=1)
 
         assert len(result) == 5
         assert [r["path"] for r in result] == paths, "input order must be preserved"
@@ -2048,6 +2050,7 @@ class TestUpgradeBatch:
         paths = [f"/vault/sessions/note{i}.md" for i in range(N)]
         results = obsidian_utils.upgrade_batch(
             paths, "/vault", "sessions", "proj", max_workers=N,
+            summary_batch_size=1,
         )
         assert len(results) == N
         assert all(r["status"].startswith("Upgraded ") for r in results)
@@ -2063,7 +2066,8 @@ class TestUpgradeBatch:
 
         paths = [f"/vault/sessions/{n}" for n in
                  ("one.md", "two.md", "three.md", "four.md", "five.md")]
-        result = obsidian_utils.upgrade_batch(paths, "/vault", "sessions", "proj")
+        result = obsidian_utils.upgrade_batch(paths, "/vault", "sessions", "proj",
+                                              summary_batch_size=1)
 
         assert len(result) == 5
         assert [r["path"] for r in result] == paths
@@ -2094,6 +2098,7 @@ class TestUpgradeBatch:
         paths = [f"/vault/sessions/a{i}.md" for i in range(N)]
         results = obsidian_utils.upgrade_batch(
             paths, "/vault", "sessions", "proj", max_workers=10,
+            summary_batch_size=1,
         )
         assert len(results) == N
         assert all(r["status"].startswith("Upgraded ") for r in results)
@@ -2115,6 +2120,7 @@ class TestUpgradeBatch:
             "proj",
             summary_model="claude-3-5-haiku",
             summary_timeout=30,
+            summary_batch_size=1,
         )
         assert len(results) == 1
         assert results[0]["path"] == "/vault/sessions/a.md"
@@ -2131,6 +2137,7 @@ class TestUpgradeBatch:
                 obsidian_utils.upgrade_batch(
                     ["/vault/sessions/a.md"], "/vault", "sessions", "proj",
                     max_workers=bad,
+                    summary_batch_size=1,
                 )
 
     def test_upgrade_batch_skill_md_json_round_trip(self, monkeypatch):
@@ -2151,7 +2158,8 @@ class TestUpgradeBatch:
             "/vault/sessions/b.md",
             "/vault/sessions/c.md",
         ]
-        results = obsidian_utils.upgrade_batch(paths, "/vault", "sessions", "proj")
+        results = obsidian_utils.upgrade_batch(paths, "/vault", "sessions", "proj",
+                                               summary_batch_size=1)
 
         # Serialize using dict-key access (new shape)
         serialized = json.dumps([{"path": r["path"], "status": r["status"]} for r in results])
@@ -2217,6 +2225,7 @@ class TestUpgradeBatch:
 
         results = obsidian_utils.upgrade_batch(
             [str(note_path)], str(vault), "sessions", "test-project",
+            summary_batch_size=1,
         )
 
         assert len(results) == 1
@@ -2294,6 +2303,328 @@ class TestUpgradeBatch:
             f"expected no 'timeout' kwarg when summary_timeout=None, "
             f"but got kwargs={captured_gen_kwargs!r}"
         )
+
+
+# ===========================================================================
+# Section N-1: TestUpgradeBatchBatching — GH #166 batched upgrade_batch path
+# ===========================================================================
+
+
+class TestUpgradeBatchBatching:
+    """Tests for the batched (summary_batch_size >= 2) path in upgrade_batch().
+
+    Exercises generate_summaries_batch integration, fallthrough to the solo
+    path, snapshot routing, and output ordering. Monkeypatches the subprocess
+    so no ``claude -p`` calls are made.
+    """
+
+    # ---- helpers ----------------------------------------------------------------
+
+    def _write_session_note(self, sessions_dir: Path, name: str, session_id: str | None = None) -> Path:
+        """Write a minimal real session note to ``sessions_dir``."""
+        sid = session_id or f"test-batch-session-{name.replace('.md', '')}-0000-0000-000000000000"
+        note = sessions_dir / name
+        note.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-04-20\n"
+            f"session_id: {sid}\n"
+            "project: test-project\n"
+            "status: auto-logged\n"
+            "tags:\n"
+            "  - claude/session\n"
+            "  - claude/project/test-project\n"
+            "---\n\n"
+            "# Session: test-project\n\n"
+            "## Conversation (raw)\n"
+            "**User:** describe what you did\n"
+            "**Assistant:** I implemented the feature.\n",
+            encoding="utf-8",
+        )
+        return note
+
+    def _write_snapshot_note(self, sessions_dir: Path, name: str) -> Path:
+        """Write a minimal snapshot note to ``sessions_dir``."""
+        sid = f"test-snap-session-{name.replace('.md', '')}-0000-0000-000000000000"
+        note = sessions_dir / name
+        note.write_text(
+            "---\n"
+            "type: claude-snapshot\n"
+            "date: 2026-04-20\n"
+            f"session_id: {sid}\n"
+            "project: test-project\n"
+            "status: auto-logged\n"
+            "tags:\n"
+            "  - claude/snapshot\n"
+            "---\n\n"
+            "## Last messages (raw)\n"
+            "**User:** context\n"
+            "**Assistant:** snapshot content\n",
+            encoding="utf-8",
+        )
+        return note
+
+    def _fake_good_summary(self) -> str:
+        return (
+            "## Summary\nDid a thing.\n\n"
+            "## Key Decisions\n- None noted.\n\n"
+            "## Changes Made\n- None noted.\n\n"
+            "## Errors Encountered\n- None.\n\n"
+            "## Open Questions / Next Steps\n- [ ] None.\n\n"
+            "## Importance\n5\n"
+        )
+
+    # ---- tests ------------------------------------------------------------------
+
+    def test_batch_of_5_one_malformed_routes_to_fallback(self, monkeypatch, tmp_path):
+        """Mandated fixture: 4 valid summaries + 1 missing_section → malformed goes to solo fallback."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        note_names = [f"note{i}.md" for i in range(5)]
+        paths = [str(self._write_session_note(sessions_dir, name)) for name in note_names]
+
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+
+        batch_calls: list[list[dict]] = []
+        # Return good summaries for notes 0-3, missing_section for note 4.
+        def fake_generate_summaries_batch(prepared_notes, **kwargs):
+            batch_calls.append(prepared_notes)
+            results = []
+            for i, _ in enumerate(prepared_notes):
+                if i == len(prepared_notes) - 1:
+                    results.append((None, "missing_section"))
+                else:
+                    results.append((self._fake_good_summary(), None))
+            return results
+
+        monkeypatch.setattr(obsidian_utils, "generate_summaries_batch", fake_generate_summaries_batch)
+
+        # upgrade_note_with_summary returns success for all batch-written notes
+        def fake_upgrade_note_with_summary(path, summary, *args, **kwargs):
+            return f"Upgraded {os.path.basename(path)} (source: batch)"
+
+        monkeypatch.setattr(obsidian_utils, "upgrade_note_with_summary", fake_upgrade_note_with_summary)
+
+        # Solo fallback records which paths it was called with
+        solo_fallback_called: list[str] = []
+        def fake_upgrade_unsummarized_note(path, *args, **kwargs):
+            solo_fallback_called.append(path)
+            return f"Upgraded {os.path.basename(path)} (source: solo-fallback)", 0.1, "haiku", None
+
+        monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_upgrade_unsummarized_note)
+
+        results = obsidian_utils.upgrade_batch(
+            paths, str(tmp_path), "sessions", "test-project",
+            summary_batch_size=5,
+        )
+
+        # 5 results in input order
+        assert len(results) == 5
+        assert [r["path"] for r in results] == paths
+
+        # All 5 have the expected keys
+        for r in results:
+            assert set(r.keys()) == {"path", "status", "elapsed_s", "model_used", "fallback_reason"}
+
+        # First 4 upgraded via batch path
+        for i in range(4):
+            assert results[i]["status"].startswith("Upgraded "), (
+                f"note {i} should be Upgraded, got: {results[i]['status']!r}"
+            )
+            assert results[i]["model_used"] == "haiku"
+
+        # Note 4 (malformed) routed to solo fallback
+        assert paths[4] in solo_fallback_called, (
+            f"malformed note {paths[4]!r} should have gone to solo fallback; "
+            f"solo_fallback_called={solo_fallback_called!r}"
+        )
+        assert results[4]["status"].startswith("Upgraded "), (
+            f"solo fallback note should still succeed, got: {results[4]['status']!r}"
+        )
+
+    def test_batch_size_1_uses_solo_path(self, monkeypatch, tmp_path):
+        """batch_size=1: legacy fan-out fires for every note; generate_summaries_batch never called."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        paths = [str(self._write_session_note(sessions_dir, f"note{i}.md")) for i in range(3)]
+
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+
+        def batch_must_not_be_called(*args, **kwargs):
+            raise AssertionError("generate_summaries_batch must NOT be called with batch_size=1")
+
+        monkeypatch.setattr(obsidian_utils, "generate_summaries_batch", batch_must_not_be_called)
+
+        solo_calls: list[str] = []
+        def fake_solo(path, *args, **kwargs):
+            solo_calls.append(path)
+            return f"Upgraded {os.path.basename(path)} (source: solo)", 0.1, "haiku", None
+
+        monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_solo)
+
+        results = obsidian_utils.upgrade_batch(
+            paths, str(tmp_path), "sessions", "test-project",
+            summary_batch_size=1,
+        )
+
+        assert len(results) == 3
+        # Each path was processed by solo
+        assert sorted(solo_calls) == sorted(paths)
+
+    def test_whole_spawn_timeout_falls_back_to_solo(self, monkeypatch, tmp_path):
+        """Whole-spawn timeout: every note routed to solo fallback."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        n = 3
+        paths = [str(self._write_session_note(sessions_dir, f"t{i}.md")) for i in range(n)]
+
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+
+        def fake_batch_timeout(prepared_notes, **kwargs):
+            return [(None, "haiku_timeout")] * len(prepared_notes)
+
+        monkeypatch.setattr(obsidian_utils, "generate_summaries_batch", fake_batch_timeout)
+
+        solo_calls: list[str] = []
+        def fake_solo(path, *args, **kwargs):
+            solo_calls.append(path)
+            return f"Upgraded {os.path.basename(path)} (source: solo-fallback)", 0.2, "haiku", None
+
+        monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_solo)
+
+        results = obsidian_utils.upgrade_batch(
+            paths, str(tmp_path), "sessions", "test-project",
+            summary_batch_size=5,
+        )
+
+        assert len(results) == n
+        assert [r["path"] for r in results] == paths
+        assert sorted(solo_calls) == sorted(paths), (
+            f"all notes should go to solo fallback on timeout; got: {solo_calls!r}"
+        )
+        for r in results:
+            assert r["status"].startswith("Upgraded "), (
+                f"solo fallback should produce Upgraded, got: {r['status']!r}"
+            )
+
+    def test_results_in_input_order_mixed_session_and_snapshot(self, monkeypatch, tmp_path):
+        """Mixed session + snapshot notes: snapshot goes to solo, order preserved."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        session_a = self._write_session_note(sessions_dir, "session-a.md")
+        snapshot_b = self._write_snapshot_note(sessions_dir, "snapshot-b.md")
+        session_c = self._write_session_note(sessions_dir, "session-c.md")
+        paths = [str(session_a), str(snapshot_b), str(session_c)]
+
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+
+        batch_paths_seen: list[str] = []
+        def fake_batch(prepared_notes, **kwargs):
+            for p in prepared_notes:
+                # We record via metadata to know which note was batched.
+                batch_paths_seen.append(p.get("metadata", {}).get("project", "?"))
+            return [(self._fake_good_summary(), None)] * len(prepared_notes)
+
+        monkeypatch.setattr(obsidian_utils, "generate_summaries_batch", fake_batch)
+
+        def fake_upgrade_note_with_summary(path, summary, *args, **kwargs):
+            return f"Upgraded {os.path.basename(path)} (source: batch)"
+
+        monkeypatch.setattr(obsidian_utils, "upgrade_note_with_summary", fake_upgrade_note_with_summary)
+
+        solo_calls: list[str] = []
+        def fake_solo(path, *args, **kwargs):
+            solo_calls.append(path)
+            return f"Upgraded {os.path.basename(path)} (source: solo)", 0.1, "haiku", None
+
+        monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_solo)
+
+        results = obsidian_utils.upgrade_batch(
+            paths, str(tmp_path), "sessions", "test-project",
+            summary_batch_size=5,
+        )
+
+        # Correct count and order preserved
+        assert len(results) == 3
+        assert [r["path"] for r in results] == paths
+
+        # Snapshot went to solo
+        assert str(snapshot_b) in solo_calls, (
+            f"snapshot note should route to solo path; solo_calls={solo_calls!r}"
+        )
+        # Session notes NOT in solo (they went batch)
+        assert str(session_a) not in solo_calls
+        assert str(session_c) not in solo_calls
+
+        # All have Upgraded status
+        for r in results:
+            assert r["status"].startswith("Upgraded "), (
+                f"all notes should be Upgraded, got: {r['status']!r}"
+            )
+
+    def test_generate_summaries_batch_parses_delimited_output(self, monkeypatch, tmp_path):
+        """Unit-test the parser: well-formed block 1, missing ## Summary block 2."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+
+        # Two minimal prep dicts (simulate ok=True preps with messages).
+        prep1 = {
+            "ok": True,
+            "user_msgs": ["hello"],
+            "assistant_msgs": ["hi"],
+            "metadata": {"project": "test", "vault_path": "", "sessions_folder": ""},
+            "note_type": "claude-session",
+            "source": "raw note",
+            "warnings": [],
+        }
+        prep2 = dict(prep1)  # same shape
+
+        good_block = (
+            "## Summary\nDid a thing.\n\n"
+            "## Key Decisions\n- None.\n\n"
+            "## Changes Made\n- None.\n\n"
+            "## Errors Encountered\n- None.\n\n"
+            "## Open Questions / Next Steps\n- [ ] None.\n\n"
+            "## Importance\n5\n"
+        )
+        bad_block = "Just some text without the required sections.\n"
+
+        stdout_text = (
+            f"===== SUMMARY 1 =====\n{good_block}"
+            f"===== SUMMARY 2 =====\n{bad_block}"
+        )
+
+        def fake_subprocess_run(cmd, input=None, capture_output=False, text=False, timeout=None):
+            class _Res:
+                returncode = 0
+                stdout = stdout_text
+                stderr = ""
+            return _Res()
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", fake_subprocess_run)
+
+        results = obsidian_utils.generate_summaries_batch(
+            [prep1, prep2],
+            model="haiku",
+            timeout=30,
+            project="test",
+            vault_path="",
+            sessions_folder="",
+        )
+
+        assert len(results) == 2
+        text1, reason1 = results[0]
+        text2, reason2 = results[1]
+
+        assert reason1 is None, f"block 1 should be accepted; reason={reason1!r}"
+        assert text1 is not None
+        assert "## Summary" in text1
+
+        assert text2 is None, f"block 2 should be rejected (missing ## Summary)"
+        assert reason2 == "missing_section"
 
 
 # ===========================================================================

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -2626,6 +2626,213 @@ class TestUpgradeBatchBatching:
         assert text2 is None, f"block 2 should be rejected (missing ## Summary)"
         assert reason2 == "missing_section"
 
+    def test_duplicate_summary_delimiter_first_wins(self, monkeypatch, tmp_path):
+        """Fix 1: first-occurrence-wins — a repeated ===== SUMMARY k ===== delimiter
+        in model output must NOT overwrite the valid first block with the junk repeat."""
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+
+        prep1 = {
+            "ok": True,
+            "user_msgs": ["hello"],
+            "assistant_msgs": ["hi"],
+            "metadata": {"project": "test", "vault_path": "", "sessions_folder": ""},
+            "note_type": "claude-session",
+            "source": "raw note",
+            "warnings": [],
+        }
+        prep2 = dict(prep1)
+
+        valid_block_1 = (
+            "## Summary\nDid a thing.\n\n"
+            "## Key Decisions\n- None noted.\n\n"
+            "## Changes Made\n- None noted.\n\n"
+            "## Errors Encountered\n- None.\n\n"
+            "## Open Questions / Next Steps\n- [ ] None.\n\n"
+            "## Importance\n5\n"
+        )
+        junk_fragment_1 = "Oops this is extra repeated output without Summary section.\n"
+        valid_block_2 = (
+            "## Summary\nSecond note done.\n\n"
+            "## Key Decisions\n- None noted.\n\n"
+            "## Changes Made\n- None noted.\n\n"
+            "## Errors Encountered\n- None.\n\n"
+            "## Open Questions / Next Steps\n- [ ] None.\n\n"
+            "## Importance\n4\n"
+        )
+
+        # Model repeats the SUMMARY 1 delimiter — the junk block lacks ## Summary.
+        stdout_text = (
+            f"===== SUMMARY 1 =====\n{valid_block_1}"
+            f"===== SUMMARY 1 =====\n{junk_fragment_1}"
+            f"===== SUMMARY 2 =====\n{valid_block_2}"
+        )
+
+        def fake_subprocess_run(cmd, input=None, capture_output=False, text=False, timeout=None):
+            class _Res:
+                returncode = 0
+                stdout = stdout_text
+                stderr = ""
+            return _Res()
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", fake_subprocess_run)
+
+        results = obsidian_utils.generate_summaries_batch(
+            [prep1, prep2],
+            model="haiku",
+            timeout=30,
+            project="test",
+            vault_path="",
+            sessions_folder="",
+        )
+
+        assert len(results) == 2
+        text1, reason1 = results[0]
+        text2, reason2 = results[1]
+
+        # Block 1: first occurrence (valid) must win; the junk repeat must be ignored.
+        assert reason1 is None, (
+            f"block 1 should be accepted (first-occurrence-wins); reason={reason1!r}"
+        )
+        assert text1 is not None, "block 1 text should not be None"
+        assert "## Summary" in text1, "block 1 should contain the valid ## Summary section"
+        assert "Oops" not in (text1 or ""), (
+            "junk fragment must not appear in block 1 result"
+        )
+
+        # Block 2 should also be valid.
+        assert reason2 is None, f"block 2 should be accepted; reason={reason2!r}"
+        assert text2 is not None
+
+    def test_writeback_exception_routes_to_solo_fallback(self, monkeypatch, tmp_path):
+        """Fix 3: if upgrade_note_with_summary raises for one note, that note is
+        routed to solo fallback and NO exception propagates out of upgrade_batch."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        note_names = [f"note{i}.md" for i in range(3)]
+        paths = [str(self._write_session_note(sessions_dir, name)) for name in note_names]
+        bad_path = paths[1]  # index 1 will raise on write-back
+
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+
+        def fake_generate_summaries_batch(prepared_notes, **kwargs):
+            return [(self._fake_good_summary(), None)] * len(prepared_notes)
+
+        monkeypatch.setattr(obsidian_utils, "generate_summaries_batch", fake_generate_summaries_batch)
+
+        def fake_upgrade_note_with_summary(path, summary, *args, **kwargs):
+            if path == bad_path:
+                raise RuntimeError("simulated write-back failure")
+            return f"Upgraded {os.path.basename(path)} (source: batch)"
+
+        monkeypatch.setattr(obsidian_utils, "upgrade_note_with_summary", fake_upgrade_note_with_summary)
+
+        solo_fallback_called: list[str] = []
+        def fake_upgrade_unsummarized_note(path, *args, **kwargs):
+            solo_fallback_called.append(path)
+            return f"Upgraded {os.path.basename(path)} (source: solo-fallback)", 0.1, "haiku", None
+
+        monkeypatch.setattr(obsidian_utils, "upgrade_unsummarized_note", fake_upgrade_unsummarized_note)
+
+        # Must not raise even though write-back raises for bad_path.
+        results = obsidian_utils.upgrade_batch(
+            paths, str(tmp_path), "sessions", "test-project",
+            summary_batch_size=5,
+        )
+
+        # All 3 results present in input order, no KeyError.
+        assert len(results) == 3
+        assert [r["path"] for r in results] == paths
+
+        # bad_path was routed to solo fallback.
+        assert bad_path in solo_fallback_called, (
+            f"raising path should have gone to solo fallback; solo_fallback_called={solo_fallback_called!r}"
+        )
+
+        # All results have Upgraded status (solo succeeded for the bad path).
+        for r in results:
+            assert r["status"].startswith("Upgraded "), (
+                f"all notes should be Upgraded, got: {r['status']!r}"
+            )
+
+    def test_dedup_failure_does_not_fail_note(self, monkeypatch, tmp_path):
+        """Fix 2: if _dedup_summary_open_items raises, the note is still accepted
+        with the undeduped block_text — result is (text, None), NOT (None, 'missing_section')."""
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+
+        prep1 = {
+            "ok": True,
+            "user_msgs": ["hello"],
+            "assistant_msgs": ["hi"],
+            "metadata": {"project": "test", "vault_path": "", "sessions_folder": ""},
+            "note_type": "claude-session",
+            "source": "raw note",
+            "warnings": [],
+        }
+
+        valid_block = (
+            "## Summary\nDedup failure test.\n\n"
+            "## Key Decisions\n- None noted.\n\n"
+            "## Changes Made\n- None noted.\n\n"
+            "## Errors Encountered\n- None.\n\n"
+            "## Open Questions / Next Steps\n- [ ] None.\n\n"
+            "## Importance\n3\n"
+        )
+        stdout_text = f"===== SUMMARY 1 =====\n{valid_block}"
+
+        def fake_subprocess_run(cmd, input=None, capture_output=False, text=False, timeout=None):
+            class _Res:
+                returncode = 0
+                stdout = stdout_text
+                stderr = ""
+            return _Res()
+
+        monkeypatch.setattr(obsidian_utils.subprocess, "run", fake_subprocess_run)
+
+        # Make _dedup_summary_open_items raise.
+        monkeypatch.setattr(
+            obsidian_utils,
+            "_dedup_summary_open_items",
+            lambda block_text, existing_items: (_ for _ in ()).throw(RuntimeError("dedup boom")),
+        )
+
+        # Patch the import inside generate_summaries_batch so existing_items is non-empty.
+        # Save and restore the real module (if already loaded) to avoid contaminating
+        # other tests that use open_item_dedup (test-ordering safety).
+        import types
+        import sys as _sys
+
+        fake_oid_module = types.ModuleType("open_item_dedup")
+        fake_oid_module.collect_open_items = lambda *a, **kw: [("s", "t", "existing item 1")]
+
+        _orig_oid = _sys.modules.get("open_item_dedup")
+        _sys.modules["open_item_dedup"] = fake_oid_module
+
+        try:
+            results = obsidian_utils.generate_summaries_batch(
+                [prep1],
+                model="haiku",
+                timeout=30,
+                project="test",
+                vault_path="",
+                sessions_folder="",
+            )
+        finally:
+            # Restore the original module (or remove if it wasn't present before).
+            if _orig_oid is not None:
+                _sys.modules["open_item_dedup"] = _orig_oid
+            else:
+                _sys.modules.pop("open_item_dedup", None)
+
+        assert len(results) == 1
+        text1, reason1 = results[0]
+
+        # Must be accepted (not failed) even though dedup raised.
+        assert reason1 is None, (
+            f"dedup failure should not fail the note; reason={reason1!r}"
+        )
+        assert text1 is not None, "text should not be None when dedup fails"
+        assert "## Summary" in text1
+
 
 # ===========================================================================
 # Section N: canonical_project_name — worktree-aware project name derivation
@@ -3235,3 +3442,40 @@ class TestModelEscalationChain:
         assert status.startswith("Upgraded "), f"expected success, got: {status}"
         assert model_used == "haiku"
         assert fallback_reason is None
+
+
+# ===========================================================================
+# TestEscalationModels — unit tests for _escalation_models helper (Fix 4)
+# ===========================================================================
+
+
+class TestEscalationModels:
+    """Unit tests for the _escalation_models() capability-ranked helper (#165 Fix 4).
+
+    Ensures the escalation list only goes UP in capability, never backwards, so
+    that passing summary_model="sonnet" does not produce ["sonnet", "haiku", "opus"].
+    """
+
+    def test_haiku_escalates_through_full_chain(self):
+        """haiku -> [haiku, sonnet, opus]: all models tried in capability order."""
+        import obsidian_utils
+        result = obsidian_utils._escalation_models("haiku")
+        assert result == ["haiku", "sonnet", "opus"], (
+            f"haiku should escalate through full chain; got: {result!r}"
+        )
+
+    def test_sonnet_escalates_only_to_opus(self):
+        """sonnet -> [sonnet, opus]: haiku (less capable) is excluded."""
+        import obsidian_utils
+        result = obsidian_utils._escalation_models("sonnet")
+        assert result == ["sonnet", "opus"], (
+            f"sonnet should only escalate to opus; got: {result!r}"
+        )
+
+    def test_opus_no_escalation(self):
+        """opus -> [opus]: already at max capability, nothing to escalate to."""
+        import obsidian_utils
+        result = obsidian_utils._escalation_models("opus")
+        assert result == ["opus"], (
+            f"opus should have no escalation targets; got: {result!r}"
+        )

--- a/tests/test_obsidian_utils.py
+++ b/tests/test_obsidian_utils.py
@@ -2716,3 +2716,191 @@ class TestUpgradeUnsummarizedNoteReturnsTuple:
         assert elapsed_s >= 0
         assert model_used == "haiku"
         assert fallback_reason is None
+
+
+# ===========================================================================
+# Section: model-escalation chain (#165) — in-process Haiku→Sonnet→Opus
+# ===========================================================================
+
+
+class TestModelEscalationChain:
+    """upgrade_unsummarized_note escalates through Haiku→Sonnet→Opus in-process.
+
+    Fixture strategy: monkeypatch generate_summary (module-attribute form) to a
+    scripted fake that inspects the ``model`` kwarg and returns a canned
+    (text, reason) pair per model. Also monkeypatch find_transcript_jsonl to
+    None (raw-note fallback) and upgrade_note_with_summary to avoid real I/O
+    on the vault write. This matches the pattern used by
+    TestUpgradeUnsummarizedNoteReturnsTuple, which is the lightest complete
+    driver for the escalation loop.
+    """
+
+    # ------------------------------------------------------------------
+    # Shared note factory
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _write_session_note(tmp_path: Path) -> Path:
+        """Write a minimal valid session note to tmp_path and return its path."""
+        note = tmp_path / "2026-06-01-escalation-test-abcd.md"
+        note.write_text(
+            "---\n"
+            "type: claude-session\n"
+            "date: 2026-06-01\n"
+            "session_id: escalation-test-session-id-0000-0000-000000000000\n"
+            "project: test-project\n"
+            "status: auto-logged\n"
+            "---\n\n"
+            "## Conversation (raw)\n"
+            "**User:** hello\n"
+            "**Assistant:** hi there\n",
+            encoding="utf-8",
+        )
+        return note
+
+    # ------------------------------------------------------------------
+    # Helpers for common monkeypatching
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _patch_common(monkeypatch, tmp_path: Path):
+        """Patch pieces that are the same across all escalation tests."""
+        import obsidian_utils
+
+        monkeypatch.setattr(obsidian_utils, "find_transcript_jsonl", lambda sid: None)
+        monkeypatch.setattr(
+            obsidian_utils,
+            "upgrade_note_with_summary",
+            lambda note_path, summary_text, *a, **kw: f"Upgraded {os.path.basename(note_path)} (source: raw note)",
+        )
+
+    # ------------------------------------------------------------------
+    # Tests
+    # ------------------------------------------------------------------
+
+    def test_escalates_to_sonnet_on_empty_output(self, monkeypatch, tmp_path):
+        """When haiku returns (None, 'empty_output'), escalate to sonnet."""
+        import obsidian_utils
+
+        self._patch_common(monkeypatch, tmp_path)
+        note = self._write_session_note(tmp_path)
+
+        def fake_generate_summary(*args, **kwargs):
+            model = kwargs.get("model", "haiku")
+            if model == "haiku":
+                return None, "empty_output"
+            if model == "sonnet":
+                return (
+                    "## Summary\nDid a thing.\n\n"
+                    "## Key Decisions\n- None noted.\n\n"
+                    "## Changes Made\n- None noted.\n\n"
+                    "## Errors Encountered\n- None.\n\n"
+                    "## Open Questions / Next Steps\n- [ ] None.\n\n"
+                    "IMPORTANCE: 5\n"
+                ), None
+            return None, "empty_output"
+
+        monkeypatch.setattr(obsidian_utils, "generate_summary", fake_generate_summary)
+
+        status, elapsed_s, model_used, fallback_reason = obsidian_utils.upgrade_unsummarized_note(
+            str(note), str(tmp_path), "claude-sessions", "test-project",
+        )
+
+        assert status.startswith("Upgraded "), f"expected success, got: {status}"
+        assert model_used == "sonnet"
+        assert fallback_reason is None
+
+    def test_escalates_haiku_to_opus_when_sonnet_also_empty(self, monkeypatch, tmp_path):
+        """When haiku and sonnet both return (None, 'empty_output'), opus is tried."""
+        import obsidian_utils
+
+        self._patch_common(monkeypatch, tmp_path)
+        note = self._write_session_note(tmp_path)
+
+        def fake_generate_summary(*args, **kwargs):
+            model = kwargs.get("model", "haiku")
+            if model == "opus":
+                return (
+                    "## Summary\nOpus summary.\n\n"
+                    "## Key Decisions\n- None noted.\n\n"
+                    "## Changes Made\n- None noted.\n\n"
+                    "## Errors Encountered\n- None.\n\n"
+                    "## Open Questions / Next Steps\n- [ ] None.\n\n"
+                    "IMPORTANCE: 7\n"
+                ), None
+            # haiku and sonnet both fail with empty_output
+            return None, "empty_output"
+
+        monkeypatch.setattr(obsidian_utils, "generate_summary", fake_generate_summary)
+
+        status, elapsed_s, model_used, fallback_reason = obsidian_utils.upgrade_unsummarized_note(
+            str(note), str(tmp_path), "claude-sessions", "test-project",
+        )
+
+        assert status.startswith("Upgraded "), f"expected success, got: {status}"
+        assert model_used == "opus"
+        assert fallback_reason is None
+
+    def test_no_escalation_on_timeout(self, monkeypatch, tmp_path):
+        """When haiku returns (None, 'haiku_timeout'), do NOT escalate — timeout
+        means the CLI is slow; a bigger model would only make it slower (#84).
+        """
+        import obsidian_utils
+
+        self._patch_common(monkeypatch, tmp_path)
+        note = self._write_session_note(tmp_path)
+
+        models_attempted: list[str] = []
+
+        def fake_generate_summary(*args, **kwargs):
+            model = kwargs.get("model", "haiku")
+            models_attempted.append(model)
+            return None, "haiku_timeout"
+
+        monkeypatch.setattr(obsidian_utils, "generate_summary", fake_generate_summary)
+
+        status, elapsed_s, model_used, fallback_reason = obsidian_utils.upgrade_unsummarized_note(
+            str(note), str(tmp_path), "claude-sessions", "test-project",
+        )
+
+        # Should have tried haiku once and stopped immediately
+        assert models_attempted == ["haiku"], (
+            f"expected only haiku to be attempted, got: {models_attempted}"
+        )
+        assert not status.startswith("Upgraded "), f"expected failure, got: {status}"
+        assert model_used is None
+        assert fallback_reason == "haiku_timeout"
+
+    def test_happy_path_uses_primary_model_only(self, monkeypatch, tmp_path):
+        """When haiku succeeds on the first call, no escalation occurs."""
+        import obsidian_utils
+
+        self._patch_common(monkeypatch, tmp_path)
+        note = self._write_session_note(tmp_path)
+
+        models_attempted: list[str] = []
+
+        def fake_generate_summary(*args, **kwargs):
+            model = kwargs.get("model", "haiku")
+            models_attempted.append(model)
+            return (
+                "## Summary\nHaiku success.\n\n"
+                "## Key Decisions\n- None noted.\n\n"
+                "## Changes Made\n- None noted.\n\n"
+                "## Errors Encountered\n- None.\n\n"
+                "## Open Questions / Next Steps\n- [ ] None.\n\n"
+                "IMPORTANCE: 4\n"
+            ), None
+
+        monkeypatch.setattr(obsidian_utils, "generate_summary", fake_generate_summary)
+
+        status, elapsed_s, model_used, fallback_reason = obsidian_utils.upgrade_unsummarized_note(
+            str(note), str(tmp_path), "claude-sessions", "test-project",
+        )
+
+        assert models_attempted == ["haiku"], (
+            f"expected only haiku to be attempted, got: {models_attempted}"
+        )
+        assert status.startswith("Upgraded "), f"expected success, got: {status}"
+        assert model_used == "haiku"
+        assert fallback_reason is None


### PR DESCRIPTION
## Summary

Two companion summarizer cost optimizations from the #169 tracker, sharing the `upgrade_batch()` code path (one PR per the tracker's recommended ship order). Ahead of the 2026-06-15 Agent-SDK metered-credit launch, the obsidian-brain session summarizer is the dominant programmatic-cost lever.

### #165 — In-process Haiku→Sonnet→Opus escalation
The summarizer's only fallback was the recall Phase-2 sub-agent, which runs on the **main model (Opus)** — making Opus the de-facto fallback (~78% of programmatic spend). Now, when the primary model returns `empty_output`, summarization escalates **in process**: Haiku → Sonnet (~3×) → Opus (~5×, final safety net).
- Escalates **only on `empty_output`**. Timeouts (`haiku_timeout`) and subprocess errors are **not** escalated — a larger model is slower (worsening the slow-CLI problem #84) and can't fix a missing binary.
- `model_used` now reflects the model that produced the accepted summary, populating the `sonnet`/`opus` tags the #74 metrics sink measures (enables the "Opus-tagged share <5%" acceptance check).

### #166 — Batch multiple session notes per `claude -p` spawn
Amortizes per-spawn CLI overhead (process start, config/skill load, tool-registry hydration, system-prompt cache-write tokens) by summarizing 3–5 notes per spawn.
- New `generate_summaries_batch()`: multi-note prompt with `===== NOTE k =====` / `===== SUMMARY k =====` delimiters, per-note parse + `## Summary` validation, shared open-item dedup.
- `upgrade_batch` gains `summary_batch_size` (config default **3**; **`=1` preserves the exact legacy per-note fan-out**). Size-aware grouping (≤N notes AND ≤60k sampled chars/group). Snapshots stay on the solo path (distinct prompt).
- **Partial-failure safety net:** any per-note parse failure or whole-spawn failure routes that note to the solo `upgrade_unsummarized_note` path (carrying the #165 escalation), then to the Phase-2 sub-agent — no note is lost.

## Tests
- #165: escalation to Sonnet on empty_output, Haiku→Opus when Sonnet also empty, no-escalation-on-timeout, happy-path-primary-only.
- #166: **mandated 5-notes-1-malformed → 4 succeed + 1 routes to fallback**, size=1 legacy path, whole-spawn-timeout fallback, mixed session/snapshot ordering, delimiter parsing.
- Behavior-preserving refactor (`_prepare_note_for_summary` extraction) verified against the full suite.
- Full suite: **1238 passed**, coverage 90.88%.

Closes #165.
Closes #166.
Refs #169.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
