### PR TITLE
fix: stop test suite polluting production index DB (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `OBSIDIAN_BRAIN_DB`; `_connect()` is the single guarded DB chokepoint that
   refuses to open the real production DB under a pytest context; an autouse
   fixture isolates each test's DB; and `no-default-db.py` now forbids raw
-  `sqlite3.connect` bypasses across `hooks/`, `skills/`, and `scripts/`. (#192)
+  `sqlite3.connect` bypasses across `hooks/`, `skills/`, and `scripts/` (Python
+  files, `SKILL.md` python blocks, and shell heredocs, with accurate source line
+  numbers). (#192)
 
 ## [2.6.0] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Test/dev-test suite no longer pollutes the production index DB
+  (`~/.claude/obsidian-brain-vault.db`). `_default_db_path()` now honors
+  `OBSIDIAN_BRAIN_DB`; `_connect()` is the single guarded DB chokepoint that
+  refuses to open the real production DB under a pytest context; an autouse
+  fixture isolates each test's DB; and `no-default-db.py` now forbids raw
+  `sqlite3.connect` bypasses across `hooks/`, `skills/`, and `scripts/`. (#192)
+
 ## [2.6.0] - 2026-06-02
 
 ### Added

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -2737,7 +2737,7 @@ def _note_has_inbound_links(basename_stem: str, db_path: str | None = None) -> b
                 db_path = os.path.join(os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db")
         if not os.path.exists(db_path):
             return True  # conservative: assume referenced
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)  # noqa: vault-db-connect — read-only URI mode; cannot use _connect (WAL pragma incompatible with mode=ro)
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)  # noqa: vault-db-connect — opens via uri=True (file:...?mode=ro) which _connect() does not accept (plain-path connect + realpath guard can't parse a URI); read-only, so it cannot pollute
         try:
             # Escape LIKE wildcards in the stem so that `_` (common in project
             # slugs) is treated as a literal character, not a single-char wildcard.

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -2737,7 +2737,7 @@ def _note_has_inbound_links(basename_stem: str, db_path: str | None = None) -> b
                 db_path = os.path.join(os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db")
         if not os.path.exists(db_path):
             return True  # conservative: assume referenced
-        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)  # noqa: vault-db-connect — read-only URI mode; cannot use _connect (WAL pragma incompatible with mode=ro)
         try:
             # Escape LIKE wildcards in the stem so that `_` (common in project
             # slugs) is treated as a literal character, not a single-char wildcard.

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -2749,7 +2749,8 @@ def _note_has_inbound_links(basename_stem: str, db_path: str | None = None) -> b
             return row is not None
         finally:
             conn.close()
-    except Exception:
+    except Exception as exc:
+        print(f"[obsidian-utils] inbound-link check failed for {basename_stem!r}: {exc}", file=sys.stderr)
         return True  # conservative: assume referenced on any error
 
 

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -131,16 +131,18 @@ def _default_db_path() -> str:
 
 
 # Hardcoded real production DB path, resolved once at import. The guard in
-# _connect() compares against THIS (not _default_db_path(), which the env
-# override/monkeypatch may redirect) so isolation cannot defeat the guard (#192).
+# _connect() compares against THIS (not _default_db_path(), which the
+# OBSIDIAN_BRAIN_DB env override redirects), so test isolation cannot defeat
+# the guard (#192).
 _REAL_PROD_DB = os.path.realpath(
     os.path.join(os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db")
 )
 
 
 def _in_test_ctx() -> bool:
-    """True when running under pytest (set automatically, inherited by
-    subprocesses spawned during a test). Production never sets this."""
+    """True when running under pytest. PYTEST_CURRENT_TEST is set automatically
+    by pytest and inherited by subprocesses that copy the parent environment
+    (os.environ.copy()). Production never sets this."""
     return "PYTEST_CURRENT_TEST" in os.environ
 
 

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -145,7 +145,17 @@ def _in_test_ctx() -> bool:
 
 
 def _connect(db_path: str) -> sqlite3.Connection:
-    """Open a WAL-mode connection with 5s timeout."""
+    """Open a WAL-mode connection with 5s timeout.
+
+    Guard (#192): under a pytest context, refuse to open the REAL production
+    index DB. Any test that reaches this path is leaking; fail loudly instead of
+    silently polluting ~/.claude/obsidian-brain-vault.db.
+    """
+    if _in_test_ctx() and os.path.realpath(db_path) == _REAL_PROD_DB:
+        raise RuntimeError(
+            f"refusing to open production index DB under test context: {db_path}. "
+            "Pass an isolated db_path or set OBSIDIAN_BRAIN_DB."
+        )
     conn = sqlite3.connect(db_path, timeout=5.0)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.row_factory = sqlite3.Row

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -780,7 +780,7 @@ def log_access(db_path: str, note_path: str, context_type: str, project: str | N
             [(p, now, context_type, project) for p in paths],
         )
         conn.commit()
-    except Exception as exc:
+    except sqlite3.Error as exc:
         print(f"[vault-index] log_access failed for {note_path!r}: {exc}", file=sys.stderr)
     finally:
         conn.close()
@@ -867,7 +867,7 @@ def batch_activations(
                 summation += dt ** (-decay)
             if summation > 0.0:
                 result[path] = math.log(summation)
-    except Exception as exc:
+    except sqlite3.Error as exc:
         print(f"[vault-index] batch_activations failed ({len(note_paths)} paths): {exc}",
               file=sys.stderr)
         return result

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -688,7 +688,8 @@ def _parent_session_for_snapshot(note_path: str, db_path: str) -> str | None:
          resolve to <sessions_folder>/<stem>.md. If the file exists, cache
          and return it. If not, cache None and return None.
 
-    Swallows all exceptions — logging is observability, not a blocker.
+    Swallows sqlite3.Error; propagates RuntimeError from the #192 pollution
+    guard — logging is observability, not a blocker.
 
     Cache entries are NOT invalidated when a snapshot is re-indexed; a
     corrected ``source_session_note`` won't take effect until the next process
@@ -698,7 +699,12 @@ def _parent_session_for_snapshot(note_path: str, db_path: str) -> str | None:
     if note_path in _PARENT_CACHE:
         return _PARENT_CACHE[note_path]
     resolved: str | None = None
-    conn = _connect(db_path)  # guard may raise RuntimeError — let it propagate
+    try:
+        conn = _connect(db_path)  # guard RuntimeError propagates; sqlite3.Error degrades as before
+    except sqlite3.Error as exc:
+        print(f"[vault-index] parent-resolve DB error for {note_path!r}: {exc}",
+              file=sys.stderr)
+        return None
     try:
         try:
             row = conn.execute(
@@ -761,7 +767,11 @@ def log_access(db_path: str, note_path: str, context_type: str, project: str | N
     if parent:
         paths.append(parent)
 
-    conn = _connect(db_path)  # guard may raise RuntimeError — let it propagate
+    try:
+        conn = _connect(db_path)  # guard RuntimeError propagates; sqlite3.Error degrades as before
+    except sqlite3.Error as exc:
+        print(f"[vault-index] log_access failed for {note_path!r}: {exc}", file=sys.stderr)
+        return
     try:
         now = time.time()
         conn.executemany(
@@ -830,7 +840,12 @@ def batch_activations(
 
     result: dict[str, float] = {p: 0.0 for p in note_paths}
 
-    conn = _connect(db_path)  # guard may raise — propagate, do not swallow
+    try:
+        conn = _connect(db_path)  # guard RuntimeError propagates; sqlite3.Error degrades as before
+    except sqlite3.Error as exc:
+        print(f"[vault-index] batch_activations failed ({len(note_paths)} paths): {exc}",
+              file=sys.stderr)
+        return result
     try:
         now = time.time()
         placeholders = ",".join("?" for _ in note_paths)

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -119,8 +119,29 @@ def _is_under(child: Path, parent: Path) -> bool:
 
 
 def _default_db_path() -> str:
-    """Return default DB path: ~/.claude/obsidian-brain-vault.db."""
-    return os.path.join(os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db")
+    """Return default DB path: ~/.claude/obsidian-brain-vault.db.
+
+    Overridable via the OBSIDIAN_BRAIN_DB env var so tests, dev-test scripts,
+    and subprocesses can isolate the index DB without threading db_path through
+    every call site (#192).
+    """
+    return os.environ.get("OBSIDIAN_BRAIN_DB") or os.path.join(
+        os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db"
+    )
+
+
+# Hardcoded real production DB path, resolved once at import. The guard in
+# _connect() compares against THIS (not _default_db_path(), which the env
+# override/monkeypatch may redirect) so isolation cannot defeat the guard (#192).
+_REAL_PROD_DB = os.path.realpath(
+    os.path.join(os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db")
+)
+
+
+def _in_test_ctx() -> bool:
+    """True when running under pytest (set automatically, inherited by
+    subprocesses spawned during a test). Production never sets this."""
+    return "PYTEST_CURRENT_TEST" in os.environ
 
 
 def _connect(db_path: str) -> sqlite3.Connection:

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -151,13 +151,24 @@ def _connect(db_path: str) -> sqlite3.Connection:
 
     Guard (#192): under a pytest context, refuse to open the REAL production
     index DB. Any test that reaches this path is leaking; fail loudly instead of
-    silently polluting ~/.claude/obsidian-brain-vault.db.
+    silently polluting ~/.claude/obsidian-brain-vault.db. Both path-equality
+    (realpath, catching symlinks) and inode-equality (samefile, catching hard
+    links) are checked.
     """
-    if _in_test_ctx() and os.path.realpath(db_path) == _REAL_PROD_DB:
-        raise RuntimeError(
-            f"refusing to open production index DB under test context: {db_path}. "
-            "Pass an isolated db_path or set OBSIDIAN_BRAIN_DB."
-        )
+    if _in_test_ctx():
+        try:
+            same_inode = (
+                os.path.exists(db_path)
+                and os.path.exists(_REAL_PROD_DB)
+                and os.path.samefile(db_path, _REAL_PROD_DB)
+            )
+        except OSError:
+            same_inode = False
+        if os.path.realpath(db_path) == _REAL_PROD_DB or same_inode:
+            raise RuntimeError(
+                f"refusing to open production index DB under test context: {db_path}. "
+                "Pass an isolated db_path or set OBSIDIAN_BRAIN_DB."
+            )
     conn = sqlite3.connect(db_path, timeout=5.0)
     conn.execute("PRAGMA journal_mode=WAL")
     conn.row_factory = sqlite3.Row

--- a/hooks/vault_index.py
+++ b/hooks/vault_index.py
@@ -698,8 +698,8 @@ def _parent_session_for_snapshot(note_path: str, db_path: str) -> str | None:
     if note_path in _PARENT_CACHE:
         return _PARENT_CACHE[note_path]
     resolved: str | None = None
+    conn = _connect(db_path)  # guard may raise RuntimeError — let it propagate
     try:
-        conn = sqlite3.connect(db_path, timeout=5.0)
         try:
             row = conn.execute(
                 "SELECT type FROM notes WHERE path = ?", (note_path,),
@@ -761,20 +761,19 @@ def log_access(db_path: str, note_path: str, context_type: str, project: str | N
     if parent:
         paths.append(parent)
 
+    conn = _connect(db_path)  # guard may raise RuntimeError — let it propagate
     try:
-        conn = sqlite3.connect(db_path, timeout=5.0)
-        try:
-            now = time.time()
-            conn.executemany(
-                "INSERT INTO access_log (note_path, timestamp, context_type, project) "
-                "VALUES (?, ?, ?, ?)",
-                [(p, now, context_type, project) for p in paths],
-            )
-            conn.commit()
-        finally:
-            conn.close()
+        now = time.time()
+        conn.executemany(
+            "INSERT INTO access_log (note_path, timestamp, context_type, project) "
+            "VALUES (?, ?, ?, ?)",
+            [(p, now, context_type, project) for p in paths],
+        )
+        conn.commit()
     except Exception as exc:
         print(f"[vault-index] log_access failed for {note_path!r}: {exc}", file=sys.stderr)
+    finally:
+        conn.close()
 
 
 def _batch_log_access(
@@ -831,35 +830,34 @@ def batch_activations(
 
     result: dict[str, float] = {p: 0.0 for p in note_paths}
 
+    conn = _connect(db_path)  # guard may raise — propagate, do not swallow
     try:
-        conn = sqlite3.connect(db_path, timeout=5.0)
-        try:
-            now = time.time()
-            placeholders = ",".join("?" for _ in note_paths)
-            rows = conn.execute(
-                f"SELECT note_path, timestamp FROM access_log "
-                f"WHERE note_path IN ({placeholders})",
-                note_paths,
-            ).fetchall()
+        now = time.time()
+        placeholders = ",".join("?" for _ in note_paths)
+        rows = conn.execute(
+            f"SELECT note_path, timestamp FROM access_log "
+            f"WHERE note_path IN ({placeholders})",
+            note_paths,
+        ).fetchall()
 
-            # Group timestamps by note_path
-            accesses: dict[str, list[float]] = defaultdict(list)
-            for row in rows:
-                accesses[row[0]].append(row[1])
+        # Group timestamps by note_path
+        accesses: dict[str, list[float]] = defaultdict(list)
+        for row in rows:
+            accesses[row[0]].append(row[1])
 
-            for path, timestamps in accesses.items():
-                summation = 0.0
-                for ts in timestamps:
-                    dt = max(now - ts, 0.001)  # clamp to 1ms minimum
-                    summation += dt ** (-decay)
-                if summation > 0.0:
-                    result[path] = math.log(summation)
-        finally:
-            conn.close()
+        for path, timestamps in accesses.items():
+            summation = 0.0
+            for ts in timestamps:
+                dt = max(now - ts, 0.001)  # clamp to 1ms minimum
+                summation += dt ** (-decay)
+            if summation > 0.0:
+                result[path] = math.log(summation)
     except Exception as exc:
         print(f"[vault-index] batch_activations failed ({len(note_paths)} paths): {exc}",
               file=sys.stderr)
         return result
+    finally:
+        conn.close()
 
     return result
 

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -199,7 +199,7 @@ def compute_stats(db_path: str, project: str) -> str:
 
     conn = None
     try:
-        conn = sqlite3.connect(db_path, timeout=5.0)  # noqa: vault-db-connect — stats reader; db_path is always caller-supplied (never default-resolved here)
+        conn = sqlite3.connect(db_path, timeout=5.0)  # noqa: vault-db-connect — de-facto read-only: every SQL statement on this connection is SELECT-only (no INSERT/UPDATE/commit in the compute_stats chain), so it cannot pollute regardless of db_path
         conn.row_factory = sqlite3.Row
     except (sqlite3.Error, OSError) as exc:
         if conn is not None:

--- a/hooks/vault_stats.py
+++ b/hooks/vault_stats.py
@@ -199,7 +199,7 @@ def compute_stats(db_path: str, project: str) -> str:
 
     conn = None
     try:
-        conn = sqlite3.connect(db_path, timeout=5.0)
+        conn = sqlite3.connect(db_path, timeout=5.0)  # noqa: vault-db-connect — stats reader; db_path is always caller-supplied (never default-resolved here)
         conn.row_factory = sqlite3.Row
     except (sqlite3.Error, OSError) as exc:
         if conn is not None:

--- a/scripts/ci-checks/no-default-db.py
+++ b/scripts/ci-checks/no-default-db.py
@@ -30,6 +30,7 @@ Known limitations:
 from __future__ import annotations
 
 import ast
+import re
 import sys
 from pathlib import Path
 
@@ -40,6 +41,102 @@ GUARDED_FUNCS = frozenset({
 })
 NOQA_MARKER = "# noqa: no-default-db"
 TESTS_DIR = Path(__file__).resolve().parent.parent.parent / "tests"
+
+# --- #192: forbid raw sqlite3.connect bypasses of vault_index._connect ---
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# Dirs scanned for raw-connect bypasses (relative to repo root).
+RAW_CONNECT_SCAN_DIRS = ("hooks", "skills", "scripts")
+
+# rel_path -> set of function names permitted to call sqlite3.connect directly.
+RAW_CONNECT_ALLOWLIST = {
+    "hooks/vault_index.py": {"_connect"},
+}
+
+_PY_FENCE = re.compile(r"```python\n(.*?)```", re.DOTALL)
+
+
+def _extract_python_blocks(md_source: str) -> str:
+    """Concatenate the bodies of ```python fenced blocks in a markdown string."""
+    return "\n".join(_PY_FENCE.findall(md_source))
+
+
+def _is_sqlite_connect(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "connect"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "sqlite3"
+    )
+
+
+def audit_raw_connect(rel_path: str, source: str) -> list[tuple[int, str]]:
+    """Return (lineno, message) for raw sqlite3.connect calls outside the
+    allowlisted function for rel_path, unless suppressed by
+    '# noqa: vault-db-connect' on the call's line. SyntaxError -> no findings
+    (best-effort for partial SKILL.md snippets)."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    allowed = RAW_CONNECT_ALLOWLIST.get(rel_path, set())
+    lines = source.splitlines()
+    findings: list[tuple[int, str]] = []
+
+    class _V(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.stack: list[str] = []
+
+        def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+            self.stack.append(node.name)
+            self.generic_visit(node)
+            self.stack.pop()
+
+        visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+        def visit_Call(self, node: ast.Call) -> None:
+            if _is_sqlite_connect(node):
+                enclosing = self.stack[-1] if self.stack else "<module>"
+                line = lines[node.lineno - 1] if 0 <= node.lineno - 1 < len(lines) else ""
+                if enclosing not in allowed and "noqa: vault-db-connect" not in line:
+                    findings.append(
+                        (
+                            node.lineno,
+                            f"raw sqlite3.connect in {enclosing}() — route through "
+                            f"vault_index._connect() or add '# noqa: vault-db-connect'",
+                        )
+                    )
+            self.generic_visit(node)
+
+    _V().visit(tree)
+    return findings
+
+
+def scan_raw_connect() -> list[str]:
+    """Scan RAW_CONNECT_SCAN_DIRS for bypass violations. Returns formatted lines."""
+    out: list[str] = []
+    for d in RAW_CONNECT_SCAN_DIRS:
+        base = REPO_ROOT / d
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*.py")):
+            if "__pycache__" in path.parts:
+                continue
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            src = path.read_text(encoding="utf-8", errors="replace")
+            for lineno, msg in audit_raw_connect(rel, src):
+                out.append(f"{rel}:{lineno}: {msg}")
+        for path in sorted(base.rglob("SKILL.md")):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            md = path.read_text(encoding="utf-8", errors="replace")
+            blocks = _extract_python_blocks(md)
+            if not blocks:
+                continue
+            for lineno, msg in audit_raw_connect(rel, blocks):
+                out.append(f"{rel} (embedded python): {msg}")
+    return out
 
 
 def _call_name(node: ast.Call) -> str | None:
@@ -140,8 +237,19 @@ def main(argv: list[str]) -> int:
             "polluting the user's live ~/.claude/obsidian-brain-vault.db.",
             file=sys.stderr,
         )
-        return 1
-    return 0
+
+    raw_connect_violations = scan_raw_connect()
+    for v in raw_connect_violations:
+        print(f"RAW-CONNECT BYPASS: {v}")
+    if raw_connect_violations:
+        print(
+            f"\n{len(raw_connect_violations)} raw sqlite3.connect bypass(es) in "
+            "hooks/skills/scripts. Route through vault_index._connect() or add "
+            "'# noqa: vault-db-connect' with a brief reason.",
+            file=sys.stderr,
+        )
+
+    return 1 if (total_violations or raw_connect_violations) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/ci-checks/no-default-db.py
+++ b/scripts/ci-checks/no-default-db.py
@@ -168,7 +168,7 @@ def scan_raw_connect() -> list[str]:
             rel = path.relative_to(REPO_ROOT).as_posix()
             md = path.read_text(encoding="utf-8", errors="replace")
             blocks = _extract_python_blocks(md)
-            if not blocks:
+            if not blocks.strip():
                 continue
             for lineno, msg in audit_raw_connect(rel, blocks):
                 out.append(f"{rel}:{lineno}: {msg} (embedded python)")

--- a/scripts/ci-checks/no-default-db.py
+++ b/scripts/ci-checks/no-default-db.py
@@ -53,28 +53,47 @@ RAW_CONNECT_ALLOWLIST = {
     "hooks/vault_index.py": {"_connect"},
 }
 
-def _extract_python_blocks(md_source: str) -> str:
-    """Return a line-aligned projection of md_source containing only the bodies
-    of ```python fenced blocks; every other line (prose and the fence markers)
-    is blanked. Line numbers are PRESERVED — the returned string has the same
-    line count as the source — so audit findings report the true source line
-    rather than an offset into concatenated blocks (#192 follow-up)."""
+# Fence info-string language tokens treated as Python / shell when scanning
+# embedded code blocks in SKILL.md files.
+_PYTHON_LANGS = frozenset({"py", "python", "python3"})
+_SHELL_LANGS = frozenset({"sh", "bash", "shell", "console"})
+
+
+def _extract_fenced_blocks(md_source: str) -> list[tuple[int, str, str]]:
+    """Return (start_lineno, lang, block_source) for each fenced code block.
+
+    start_lineno is the 1-based source line of the block's FIRST body line, so a
+    finding's in-block line can be mapped back to the true file line. `lang` is
+    the lowercased first token of the fence info string (e.g. ```python title=x
+    -> "python"). Each block is returned SEPARATELY so a SyntaxError in one
+    partial snippet cannot suppress detection in the others — the previous
+    whole-file merge let one malformed block hide raw connects in every later
+    block (#192 follow-up)."""
+    blocks: list[tuple[int, str, str]] = []
     lines = md_source.splitlines()
-    out = [""] * len(lines)
     in_block = False
-    for i, line in enumerate(lines):
+    cur: list[str] = []
+    start = 0
+    lang = ""
+    for i, line in enumerate(lines, start=1):
         stripped = line.strip()
         if not in_block:
-            if stripped == "```python":
+            if stripped.startswith("```"):
+                info = stripped[3:].strip()
+                lang = info.split(maxsplit=1)[0].lower() if info else ""
                 in_block = True
-            # the opening-fence line itself stays blank
+                cur = []
+                start = i + 1  # first body line is the next line
         else:
             if stripped == "```":
                 in_block = False
-                # the closing-fence line itself stays blank
+                if cur:
+                    blocks.append((start, lang, "\n".join(cur)))
             else:
-                out[i] = line
-    return "\n".join(out)
+                cur.append(line)
+    if in_block and cur:  # unterminated block runs to EOF
+        blocks.append((start, lang, "\n".join(cur)))
+    return blocks
 
 
 def _is_sqlite_connect(node: ast.AST) -> bool:
@@ -114,8 +133,10 @@ def audit_raw_connect(rel_path: str, source: str) -> list[tuple[int, str]]:
         def visit_Call(self, node: ast.Call) -> None:
             if _is_sqlite_connect(node):
                 enclosing = self.stack[-1] if self.stack else "<module>"
-                line = lines[node.lineno - 1] if 0 <= node.lineno - 1 < len(lines) else ""
-                if enclosing not in allowed and "noqa: vault-db-connect" not in line:
+                end = getattr(node, "end_lineno", node.lineno) or node.lineno
+                span = lines[node.lineno - 1 : end]  # every physical line of the call
+                suppressed = any("noqa: vault-db-connect" in ln for ln in span)
+                if enclosing not in allowed and not suppressed:
                     findings.append(
                         (
                             node.lineno,
@@ -167,11 +188,13 @@ def scan_raw_connect() -> list[str]:
         for path in sorted(base.rglob("SKILL.md")):
             rel = path.relative_to(REPO_ROOT).as_posix()
             md = path.read_text(encoding="utf-8", errors="replace")
-            blocks = _extract_python_blocks(md)
-            if not blocks.strip():
-                continue
-            for lineno, msg in audit_raw_connect(rel, blocks):
-                out.append(f"{rel}:{lineno}: {msg} (embedded python)")
+            for start, lang, block in _extract_fenced_blocks(md):
+                if lang in _PYTHON_LANGS:
+                    for lineno, msg in audit_raw_connect(rel, block):
+                        out.append(f"{rel}:{start - 1 + lineno}: {msg} (embedded python)")
+                elif lang in _SHELL_LANGS:
+                    for lineno, msg in audit_shell_raw_connect(rel, block):
+                        out.append(f"{rel}:{start - 1 + lineno}: {msg} (embedded shell)")
         for path in sorted(base.rglob("*.sh")):
             rel = path.relative_to(REPO_ROOT).as_posix()
             src = path.read_text(encoding="utf-8", errors="replace")

--- a/scripts/ci-checks/no-default-db.py
+++ b/scripts/ci-checks/no-default-db.py
@@ -30,7 +30,6 @@ Known limitations:
 from __future__ import annotations
 
 import ast
-import re
 import sys
 from pathlib import Path
 
@@ -54,12 +53,28 @@ RAW_CONNECT_ALLOWLIST = {
     "hooks/vault_index.py": {"_connect"},
 }
 
-_PY_FENCE = re.compile(r"```python\n(.*?)```", re.DOTALL)
-
-
 def _extract_python_blocks(md_source: str) -> str:
-    """Concatenate the bodies of ```python fenced blocks in a markdown string."""
-    return "\n".join(_PY_FENCE.findall(md_source))
+    """Return a line-aligned projection of md_source containing only the bodies
+    of ```python fenced blocks; every other line (prose and the fence markers)
+    is blanked. Line numbers are PRESERVED — the returned string has the same
+    line count as the source — so audit findings report the true source line
+    rather than an offset into concatenated blocks (#192 follow-up)."""
+    lines = md_source.splitlines()
+    out = [""] * len(lines)
+    in_block = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if not in_block:
+            if stripped == "```python":
+                in_block = True
+            # the opening-fence line itself stays blank
+        else:
+            if stripped == "```":
+                in_block = False
+                # the closing-fence line itself stays blank
+            else:
+                out[i] = line
+    return "\n".join(out)
 
 
 def _is_sqlite_connect(node: ast.AST) -> bool:
@@ -114,6 +129,27 @@ def audit_raw_connect(rel_path: str, source: str) -> list[tuple[int, str]]:
     return findings
 
 
+def audit_shell_raw_connect(rel_path: str, source: str) -> list[tuple[int, str]]:
+    """Line-based scan of a shell script for raw sqlite3.connect( calls
+    (typically inside a python heredoc or `python3 -c`). Heredoc python often
+    interpolates shell vars and would not parse as standalone Python, so this is
+    intentionally a text scan, not AST. Shell scripts never define
+    vault_index._connect, so any occurrence is a bypass unless the line carries
+    '# noqa: vault-db-connect' (#192 follow-up: .sh files were previously
+    unscanned)."""
+    findings: list[tuple[int, str]] = []
+    for i, line in enumerate(source.splitlines(), start=1):
+        if "sqlite3.connect(" in line and "noqa: vault-db-connect" not in line:
+            findings.append(
+                (
+                    i,
+                    "raw sqlite3.connect in shell script — route through "
+                    "vault_index._connect() or add '# noqa: vault-db-connect'",
+                )
+            )
+    return findings
+
+
 def scan_raw_connect() -> list[str]:
     """Scan RAW_CONNECT_SCAN_DIRS for bypass violations. Returns formatted lines."""
     out: list[str] = []
@@ -135,7 +171,12 @@ def scan_raw_connect() -> list[str]:
             if not blocks:
                 continue
             for lineno, msg in audit_raw_connect(rel, blocks):
-                out.append(f"{rel} (embedded python): {msg}")
+                out.append(f"{rel}:{lineno}: {msg} (embedded python)")
+        for path in sorted(base.rglob("*.sh")):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            src = path.read_text(encoding="utf-8", errors="replace")
+            for lineno, msg in audit_shell_raw_connect(rel, src):
+                out.append(f"{rel}:{lineno}: {msg}")
     return out
 
 

--- a/scripts/dev-test/test-issue-128-manual.py
+++ b/scripts/dev-test/test-issue-128-manual.py
@@ -290,7 +290,7 @@ try:
     conn.commit()
 finally:
     conn.close()
-saved_access = sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0]
+saved_access = sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0]  # noqa: vault-db-connect — dev smoke-test, direct verification read
 
 try:
     reindex(db)
@@ -308,7 +308,7 @@ except Exception as e:
         fail_(f"unexpected exception type: {type(e).__name__}: {e}")
 
 # Verify access_log is intact (the abort prevented the destructive fall-through)
-n_after = sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0]
+n_after = sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0]  # noqa: vault-db-connect — dev smoke-test, direct verification read
 if n_after == saved_access:
     pass_("access_log preserved after abort")
 else:
@@ -316,7 +316,7 @@ else:
 
 # Now run with explicit consent — should succeed and wipe.
 stats = reindex(db, allow_fallthrough=True)
-n_final = sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0]
+n_final = sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0]  # noqa: vault-db-connect — dev smoke-test, direct verification read
 if stats.get("mode") == "full" and n_final == 0:
     pass_("--allow-fallthrough opted-in and wiped access_log as expected")
 else:
@@ -333,15 +333,15 @@ insert_note_row(db, str(canonical), canonical.stat().st_mtime)
 insert_note_row(db, "/private/tmp/foreign.md", time.time())  # would-be foreign prune target
 insert_access(db, "/private/tmp/foreign.md")  # would-be orphan
 before = {
-    "notes": sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM notes").fetchone()[0],
-    "access_log": sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0],
+    "notes": sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM notes").fetchone()[0],  # noqa: vault-db-connect — dev smoke-test, direct verification read
+    "access_log": sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0],  # noqa: vault-db-connect — dev smoke-test, direct verification read
 }
 audit_before = set((HOME_FIX / ".claude" / "obsidian-brain").glob("reindex-prune-*.log"))
 backup_before = set(FIXTURE.glob("p17.db.bak-*"))
 stats = reindex(db, dry_run=True)
 after = {
-    "notes": sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM notes").fetchone()[0],
-    "access_log": sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0],
+    "notes": sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM notes").fetchone()[0],  # noqa: vault-db-connect — dev smoke-test, direct verification read
+    "access_log": sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM access_log").fetchone()[0],  # noqa: vault-db-connect — dev smoke-test, direct verification read
 }
 audit_after = set((HOME_FIX / ".claude" / "obsidian-brain").glob("reindex-prune-*.log"))
 backup_after = set(FIXTURE.glob("p17.db.bak-*"))
@@ -369,7 +369,7 @@ canonical = write_note(
 )
 try:
     stats = reindex(db)
-    if db.exists() and sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM notes").fetchone()[0] >= 1:
+    if db.exists() and sqlite3.connect(str(db)).execute("SELECT COUNT(*) FROM notes").fetchone()[0] >= 1:  # noqa: vault-db-connect — dev smoke-test, direct verification read
         pass_(f"missing-DB fall-through created index ({stats.get('mode')}, inserted={stats.get('inserted')})")
     else:
         fail_(f"missing-DB fall-through ran but DB still empty: {stats}")
@@ -393,7 +393,7 @@ recovered = [
     "2026-04-27-obsidian-brain-2b78.md",
     "2026-04-29-knowledge-base-ui-59bb.md",
 ]
-conn = sqlite3.connect(str(real_db_path))
+conn = sqlite3.connect(str(real_db_path))  # noqa: vault-db-connect — dev smoke-test, direct verification read against real vault DB
 try:
     found = 0
     for fn in recovered:
@@ -409,7 +409,7 @@ else:
 
 # 2.2 — access_log canonical
 print("  2.2  access_log all canonical")
-conn = sqlite3.connect(str(real_db_path))
+conn = sqlite3.connect(str(real_db_path))  # noqa: vault-db-connect — dev smoke-test, direct verification read against real vault DB
 try:
     n_total = conn.execute("SELECT COUNT(*) FROM access_log").fetchone()[0]
     n_canonical = conn.execute(
@@ -427,7 +427,7 @@ else:
 # 2.3 — dry-run on real vault is non-destructive
 print("  2.3  dry-run on real vault is non-destructive")
 real_before = {}
-conn = sqlite3.connect(str(real_db_path))
+conn = sqlite3.connect(str(real_db_path))  # noqa: vault-db-connect — dev smoke-test, direct verification read against real vault DB
 try:
     for tbl in ("notes", "access_log", "themes", "theme_members"):
         real_before[tbl] = conn.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]
@@ -444,7 +444,7 @@ try:
 finally:
     pass
 real_after = {}
-conn = sqlite3.connect(str(real_db_path))
+conn = sqlite3.connect(str(real_db_path))  # noqa: vault-db-connect — dev smoke-test, direct verification read against real vault DB
 try:
     for tbl in ("notes", "access_log", "themes", "theme_members"):
         real_after[tbl] = conn.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]

--- a/scripts/dev-test/test-issue-192-pollution-guard.py
+++ b/scripts/dev-test/test-issue-192-pollution-guard.py
@@ -42,13 +42,13 @@ FAIL = 0
 def pass_(msg: str) -> None:
     global PASS
     PASS += 1
-    print(f"✅ {msg}")
+    print(f"  ✅ {msg}")
 
 
 def fail_(msg: str) -> None:
     global FAIL
     FAIL += 1
-    print(f"❌ {msg}")
+    print(f"  ❌ {msg}")
 
 
 def _make_vault(root: Path, n: int) -> Path:

--- a/scripts/dev-test/test-issue-192-pollution-guard.py
+++ b/scripts/dev-test/test-issue-192-pollution-guard.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""End-to-end dogfood for #192 — production index DB pollution guard.
+
+Builds a synthetic vault + a SENTINEL "production" DB (never the real
+~/.claude one), then asserts a 4-cell prevention matrix plus a regression half
+proving normal functionality is intact. Exit non-zero on any failure.
+
+Usage:
+    python3 scripts/dev-test/test-issue-192-pollution-guard.py [--dev-repo PATH]
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _resolve_hooks(dev_repo: str | None) -> str:
+    if dev_repo:
+        cand = os.path.join(dev_repo, "hooks")
+        if os.path.isdir(cand):
+            return cand
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo_hooks = os.path.abspath(os.path.join(here, "..", "..", "hooks"))
+    if os.path.isdir(repo_hooks):
+        return repo_hooks
+    cache = sorted(glob.glob(os.path.expanduser(
+        "~/.claude/plugins/cache/*/obsidian-brain/*/hooks")))
+    if cache:
+        return cache[-1]
+    raise SystemExit("could not resolve hooks/ dir; pass --dev-repo")
+
+
+PASS = 0
+FAIL = 0
+
+
+def pass_(msg: str) -> None:
+    global PASS
+    PASS += 1
+    print(f"✅ {msg}")
+
+
+def fail_(msg: str) -> None:
+    global FAIL
+    FAIL += 1
+    print(f"❌ {msg}")
+
+
+def _make_vault(root: Path, n: int) -> Path:
+    vault = root / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    for i in range(n):
+        (sessions / f"2026-06-03-demo-{i:04d}.md").write_text(
+            f"---\ntype: claude-session\nproject: demo\n---\n\n# Demo {i}\n"
+            f"alpha bravo charlie note {i}\n",
+            encoding="utf-8",
+        )
+    return vault
+
+
+def _rowcount(db: str) -> int:
+    if not os.path.exists(db):
+        return 0
+    conn = sqlite3.connect(db)  # noqa: vault-db-connect — independent verification read on a sentinel/tmp DB, not the prod index
+    try:
+        return conn.execute("SELECT count(*) FROM notes").fetchone()[0]
+    except sqlite3.Error:
+        return 0
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dev-repo", default=None)
+    args = ap.parse_args()
+
+    sys.path.insert(0, _resolve_hooks(args.dev_repo))
+    import vault_index  # noqa: E402
+
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        n_notes = 5
+        vault = _make_vault(root, n_notes)
+        sentinel_prod = root / "sentinel-prod.db"
+        iso = root / "iso.db"
+
+        # --- Cell 1: test ctx + REAL prod path -> guard raises ---
+        os.environ["PYTEST_CURRENT_TEST"] = "dogfood::cell1"
+        try:
+            vault_index._connect(vault_index._REAL_PROD_DB)
+            fail_("cell1: _connect did NOT raise on real prod path under test ctx")
+        except RuntimeError:
+            pass_("cell1: guard blocks real prod DB under test ctx")
+        finally:
+            os.environ.pop("PYTEST_CURRENT_TEST", None)
+
+        # --- Cell 2: test ctx + isolated path -> writes succeed ---
+        os.environ["PYTEST_CURRENT_TEST"] = "dogfood::cell2"
+        try:
+            db = vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=str(iso))
+            if _rowcount(db) == n_notes:
+                pass_("cell2: isolated write under test ctx succeeded")
+            else:
+                fail_(f"cell2: expected {n_notes} rows, got {_rowcount(db)}")
+        finally:
+            os.environ.pop("PYTEST_CURRENT_TEST", None)
+
+        # --- Cell 3: test ctx + INDIRECT (no db_path) -> lands in OBSIDIAN_BRAIN_DB, sentinel untouched ---
+        indirect_db = root / "indirect.db"
+        os.environ["PYTEST_CURRENT_TEST"] = "dogfood::cell3"
+        os.environ["OBSIDIAN_BRAIN_DB"] = str(indirect_db)
+        # Point the sentinel as if it were "prod" and confirm it is never written.
+        before = _rowcount(str(sentinel_prod))
+        try:
+            db = vault_index.ensure_index(str(vault), ["claude-sessions"])  # no db_path
+            ok_path = os.path.realpath(db) == os.path.realpath(str(indirect_db))
+            ok_sentinel = _rowcount(str(sentinel_prod)) == before
+            if ok_path and ok_sentinel and _rowcount(db) == n_notes:
+                pass_("cell3: indirect call routed to isolated DB; sentinel untouched")
+            else:
+                fail_(f"cell3: path_ok={ok_path} sentinel_ok={ok_sentinel} rows={_rowcount(db)}")
+        finally:
+            os.environ.pop("PYTEST_CURRENT_TEST", None)
+            os.environ.pop("OBSIDIAN_BRAIN_DB", None)
+
+        # --- Cell 4: NON-test ctx + default(env) -> writes succeed (production success path) ---
+        os.environ.pop("PYTEST_CURRENT_TEST", None)
+        os.environ["OBSIDIAN_BRAIN_DB"] = str(sentinel_prod)
+        try:
+            db = vault_index.ensure_index(str(vault), ["claude-sessions"])  # default -> sentinel
+            if os.path.realpath(db) == os.path.realpath(str(sentinel_prod)) and _rowcount(db) == n_notes:
+                pass_("cell4: production success path writes normally (no guard in non-test ctx)")
+            else:
+                fail_(f"cell4: db={db} rows={_rowcount(db)}")
+        finally:
+            os.environ.pop("OBSIDIAN_BRAIN_DB", None)
+
+        # --- Regression half: functionality intact on isolated DB ---
+        # NOTE: search_vault actual signature is search_vault(db_path, query, ..., limit=...)
+        # — db_path is the FIRST positional arg, query is the SECOND.
+        # The plan's draft had them swapped; corrected here to match vault_index.py line 1451.
+        os.environ["OBSIDIAN_BRAIN_DB"] = str(iso)
+        try:
+            db = vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=str(iso))
+
+            hits = vault_index.search_vault(str(iso), "bravo", limit=10)
+            if hits:
+                pass_(f"regression: search_vault returned {len(hits)} hit(s)")
+            else:
+                fail_("regression: search_vault returned no hits for seeded term")
+
+            note0 = str(vault / "claude-sessions" / "2026-06-03-demo-0000.md")
+            vault_index.log_access(str(iso), note0, "recall", "demo")
+            acts = vault_index.batch_activations(str(iso), [note0])
+            if note0 in acts:
+                pass_("regression: log_access + batch_activations work via _connect")
+            else:
+                fail_("regression: batch_activations missing seeded note")
+
+            if _rowcount(str(iso)) == n_notes:
+                pass_(f"regression: index note count == {n_notes} (no inflation)")
+            else:
+                fail_(f"regression: expected {n_notes} rows, got {_rowcount(str(iso))}")
+        finally:
+            os.environ.pop("OBSIDIAN_BRAIN_DB", None)
+
+    print(f"\n=== dogfood #192: {PASS} passed, {FAIL} failed ===")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev-test/test-snapshots-manual.sh
+++ b/scripts/dev-test/test-snapshots-manual.sh
@@ -343,7 +343,7 @@ _PARENT_CACHE.clear()
 snap_path = "$FIXTURE/v/claude-sessions/2026-04-18-demo-abcd-snapshot-140000.md"
 log_access(db, snap_path, "search", "demo")
 
-conn = sqlite3.connect(db)
+conn = sqlite3.connect(db)  # noqa: vault-db-connect — manual dev test: read on the isolated $FIXTURE_DB tmp index, not the prod DB
 rows = conn.execute("SELECT note_path FROM access_log").fetchall()
 conn.close()
 paths = sorted({r[0] for r in rows})

--- a/scripts/dev-test/validate_phase2.py
+++ b/scripts/dev-test/validate_phase2.py
@@ -295,7 +295,7 @@ def test_assign_theme_idempotent(tmpdir: Path) -> None:
     vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=db_path)
 
     # Seed a theme matching the note's vector
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script, direct DB read for numerical/behavioral checks
     conn.row_factory = sqlite3.Row
     vec = json.loads(conn.execute(
         "SELECT tfidf_vector FROM notes WHERE path = ?", (str(note_path),)
@@ -316,7 +316,7 @@ def test_assign_theme_idempotent(tmpdir: Path) -> None:
         fail_("first assign_to_theme returned None")
         return
 
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script, direct DB read for numerical/behavioral checks
     conn.row_factory = sqlite3.Row
     row = conn.execute(
         "SELECT note_count, centroid FROM themes WHERE id = ?", (theme_id,)
@@ -335,7 +335,7 @@ def test_assign_theme_idempotent(tmpdir: Path) -> None:
         fail_("second assign_to_theme returned None")
         return
 
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script, direct DB read for numerical/behavioral checks
     conn.row_factory = sqlite3.Row
     row = conn.execute(
         "SELECT note_count, centroid FROM themes WHERE id = ?", (theme_id,)
@@ -384,7 +384,7 @@ def test_reindex_invariance(tmpdir: Path) -> None:
     vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=db_path)
 
     def snapshot_df() -> dict[str, int]:
-        conn = sqlite3.connect(db_path)
+        conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script, direct DB read for numerical/behavioral checks
         try:
             return dict(conn.execute("SELECT term, df FROM term_df").fetchall())
         finally:
@@ -445,7 +445,7 @@ def test_delete_unfolds_centroid(tmpdir: Path) -> None:
     vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=db_path)
 
     # Hand-build theme with A+B running-avg centroid
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script, direct DB read for numerical/behavioral checks
     conn.row_factory = sqlite3.Row
     vec_a = json.loads(conn.execute("SELECT tfidf_vector FROM notes WHERE path=?", (str(a_path),)).fetchone()["tfidf_vector"])
     vec_b = json.loads(conn.execute("SELECT tfidf_vector FROM notes WHERE path=?", (str(b_path),)).fetchone()["tfidf_vector"])
@@ -475,7 +475,7 @@ def test_delete_unfolds_centroid(tmpdir: Path) -> None:
     finally:
         conn.close()
 
-    conn = sqlite3.connect(db_path)
+    conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script, direct DB read for numerical/behavioral checks
     conn.row_factory = sqlite3.Row
     row = conn.execute("SELECT note_count, centroid FROM themes WHERE id=?", (theme_id,)).fetchone()
     if row is None:

--- a/scripts/dev-test/validate_phase2.py
+++ b/scripts/dev-test/validate_phase2.py
@@ -295,7 +295,7 @@ def test_assign_theme_idempotent(tmpdir: Path) -> None:
     vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=db_path)
 
     # Seed a theme matching the note's vector
-    conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script, direct DB read for numerical/behavioral checks
+    conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script: direct DB access (read + write) on an isolated tmp DB for fixture seeding and behavioral checks
     conn.row_factory = sqlite3.Row
     vec = json.loads(conn.execute(
         "SELECT tfidf_vector FROM notes WHERE path = ?", (str(note_path),)
@@ -445,7 +445,7 @@ def test_delete_unfolds_centroid(tmpdir: Path) -> None:
     vault_index.ensure_index(str(vault), ["claude-sessions"], db_path=db_path)
 
     # Hand-build theme with A+B running-avg centroid
-    conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script, direct DB read for numerical/behavioral checks
+    conn = sqlite3.connect(db_path)  # noqa: vault-db-connect — dev validation script: direct DB access (read + write) on an isolated tmp DB for fixture seeding and behavioral checks
     conn.row_factory = sqlite3.Row
     vec_a = json.loads(conn.execute("SELECT tfidf_vector FROM notes WHERE path=?", (str(a_path),)).fetchone()["tfidf_vector"])
     vec_b = json.loads(conn.execute("SELECT tfidf_vector FROM notes WHERE path=?", (str(b_path),)).fetchone()["tfidf_vector"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,7 +224,7 @@ def _isolate_vault_index_db_globally(tmp_path_factory, monkeypatch):
     backstop; this fixture is the belt (#192).
 
     Tests that pass an explicit db_path are unaffected (they ignore the env).
-    Subprocess tests inherit OBSIDIAN_BRAIN_DB via the environment.
+    Subprocess tests inherit OBSIDIAN_BRAIN_DB when they copy the parent environment (os.environ.copy()), which the existing subprocess tests do.
     """
     db = tmp_path_factory.mktemp("vidx") / "test-vault.db"
     monkeypatch.setenv("OBSIDIAN_BRAIN_DB", str(db))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,3 +214,17 @@ def _isolate_secure_dir_globally(tmp_path_factory, monkeypatch):
     monkeypatch.setattr(obsidian_utils, "_LOCK_DIR", str(secure / "locks"))
     monkeypatch.setattr(obsidian_utils, "_CACHE_PREFIX", str(secure / "cache-"))
     monkeypatch.setattr(obsidian_utils, "_BOOTSTRAP_PREFIX", str(secure / "sid-"))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_vault_index_db_globally(tmp_path_factory, monkeypatch):
+    """Redirect the default index DB to a per-test tmp path so an un-isolated
+    in-process call (e.g. deep_analysis_pipeline / obsidian_utils indexing with
+    no db_path) cannot reach the production DB. The _connect() guard is the
+    backstop; this fixture is the belt (#192).
+
+    Tests that pass an explicit db_path are unaffected (they ignore the env).
+    Subprocess tests inherit OBSIDIAN_BRAIN_DB via the environment.
+    """
+    db = tmp_path_factory.mktemp("vidx") / "test-vault.db"
+    monkeypatch.setenv("OBSIDIAN_BRAIN_DB", str(db))

--- a/tests/test_no_default_db_scanner.py
+++ b/tests/test_no_default_db_scanner.py
@@ -64,3 +64,44 @@ def test_allowlist_is_function_scoped_not_file_scoped():
     src = "import sqlite3\n\ndef other(p):\n    return sqlite3.connect(p)\n"
     violations = mod.audit_raw_connect("hooks/vault_index.py", src)
     assert violations, "allowlist must be function-scoped, not file-scoped"
+
+
+def test_extract_python_blocks_preserves_source_line_numbers():
+    mod = _load_scanner()
+    md = (
+        "# Title\n"                       # line 1
+        "prose line\n"                    # line 2
+        "```python\n"                     # line 3
+        "import sqlite3\n"                 # line 4
+        "conn = sqlite3.connect('x')\n"   # line 5
+        "```\n"                           # line 6
+    )
+    blocks = mod._extract_python_blocks(md)
+    violations = mod.audit_raw_connect("skills/x/SKILL.md", blocks)
+    assert violations, "expected a finding for the raw connect in the python block"
+    assert violations[0][0] == 5, f"lineno should map to source line 5, got {violations[0][0]}"
+
+
+def test_audit_shell_raw_connect_flags_heredoc():
+    mod = _load_scanner()
+    sh = (
+        "#!/usr/bin/env bash\n"
+        "python3 - <<'PY'\n"
+        "import sqlite3\n"
+        "conn = sqlite3.connect(db)\n"
+        "PY\n"
+    )
+    violations = mod.audit_shell_raw_connect("scripts/dev-test/x.sh", sh)
+    assert violations, "raw sqlite3.connect in a shell heredoc must be flagged"
+    assert violations[0][0] == 4, f"lineno should be the shell line 4, got {violations[0][0]}"
+
+
+def test_audit_shell_raw_connect_respects_noqa():
+    mod = _load_scanner()
+    sh = (
+        "python3 - <<'PY'\n"
+        "conn = sqlite3.connect(db)  # noqa: vault-db-connect\n"
+        "PY\n"
+    )
+    violations = mod.audit_shell_raw_connect("scripts/dev-test/x.sh", sh)
+    assert violations == [], "# noqa: vault-db-connect must suppress the shell finding"

--- a/tests/test_no_default_db_scanner.py
+++ b/tests/test_no_default_db_scanner.py
@@ -42,3 +42,25 @@ def test_extract_python_blocks_from_markdown():
     md = "text\n```python\nimport sqlite3\nsqlite3.connect('x')\n```\nmore\n"
     blocks = mod._extract_python_blocks(md)
     assert "sqlite3.connect" in blocks
+
+
+def test_audit_flags_raw_connect_in_extracted_markdown_block():
+    mod = _load_scanner()
+    md = (
+        "Some skill prose.\n\n```python\n"
+        "import sqlite3\n\n"
+        "def opendb(p):\n    return sqlite3.connect(p)\n"
+        "```\n\nmore prose\n"
+    )
+    blocks = mod._extract_python_blocks(md)
+    violations = mod.audit_raw_connect("skills/foo/SKILL.md", blocks)
+    assert violations, "raw sqlite3.connect inside an extracted SKILL.md python block must be flagged"
+
+
+def test_allowlist_is_function_scoped_not_file_scoped():
+    mod = _load_scanner()
+    # In an allowlisted FILE, only the allowlisted FUNCTION (_connect) may call
+    # sqlite3.connect — any other function in that file must still be flagged.
+    src = "import sqlite3\n\ndef other(p):\n    return sqlite3.connect(p)\n"
+    violations = mod.audit_raw_connect("hooks/vault_index.py", src)
+    assert violations, "allowlist must be function-scoped, not file-scoped"

--- a/tests/test_no_default_db_scanner.py
+++ b/tests/test_no_default_db_scanner.py
@@ -16,29 +16,32 @@ def _load_scanner():
     return mod
 
 
+_SCANNER = _load_scanner()
+
+
 def test_flags_raw_connect_in_non_allowed_function():
-    mod = _load_scanner()
+    mod = _SCANNER
     src = "import sqlite3\n\ndef open_db(p):\n    return sqlite3.connect(p)\n"
     violations = mod.audit_raw_connect("hooks/other.py", src)
     assert violations, "expected a raw sqlite3.connect violation"
 
 
 def test_allows_raw_connect_in_allowlisted_connect():
-    mod = _load_scanner()
+    mod = _SCANNER
     src = "import sqlite3\n\ndef _connect(p):\n    return sqlite3.connect(p, timeout=5.0)\n"
     violations = mod.audit_raw_connect("hooks/vault_index.py", src)
     assert violations == [], "vault_index._connect must be allowlisted"
 
 
 def test_noqa_suppresses_violation():
-    mod = _load_scanner()
+    mod = _SCANNER
     src = "import sqlite3\n\ndef f(p):\n    return sqlite3.connect(p)  # noqa: vault-db-connect\n"
     violations = mod.audit_raw_connect("hooks/other.py", src)
     assert violations == [], "# noqa: vault-db-connect must suppress"
 
 
 def test_extract_fenced_blocks_returns_python_block():
-    mod = _load_scanner()
+    mod = _SCANNER
     md = "text\n```python\nimport sqlite3\nsqlite3.connect('x')\n```\nmore\n"
     blocks = mod._extract_fenced_blocks(md)
     assert any(lang in {"py", "python", "python3"} and "sqlite3.connect" in src
@@ -46,7 +49,7 @@ def test_extract_fenced_blocks_returns_python_block():
 
 
 def test_audit_flags_raw_connect_in_extracted_markdown_block():
-    mod = _load_scanner()
+    mod = _SCANNER
     md = "prose\n```python\nimport sqlite3\nsqlite3.connect(p)\n```\n"
     found = []
     for start, lang, block in mod._extract_fenced_blocks(md):
@@ -56,7 +59,7 @@ def test_audit_flags_raw_connect_in_extracted_markdown_block():
 
 
 def test_allowlist_is_function_scoped_not_file_scoped():
-    mod = _load_scanner()
+    mod = _SCANNER
     # In an allowlisted FILE, only the allowlisted FUNCTION (_connect) may call
     # sqlite3.connect — any other function in that file must still be flagged.
     src = "import sqlite3\n\ndef other(p):\n    return sqlite3.connect(p)\n"
@@ -65,7 +68,7 @@ def test_allowlist_is_function_scoped_not_file_scoped():
 
 
 def test_extract_fenced_blocks_preserves_source_line_numbers():
-    mod = _load_scanner()
+    mod = _SCANNER
     md = (
         "# Title\n"                       # line 1
         "prose line\n"                    # line 2
@@ -83,7 +86,7 @@ def test_extract_fenced_blocks_preserves_source_line_numbers():
 
 
 def test_audit_shell_raw_connect_flags_heredoc():
-    mod = _load_scanner()
+    mod = _SCANNER
     sh = (
         "#!/usr/bin/env bash\n"
         "python3 - <<'PY'\n"
@@ -97,7 +100,7 @@ def test_audit_shell_raw_connect_flags_heredoc():
 
 
 def test_audit_shell_raw_connect_respects_noqa():
-    mod = _load_scanner()
+    mod = _SCANNER
     sh = (
         "python3 - <<'PY'\n"
         "conn = sqlite3.connect(db)  # noqa: vault-db-connect\n"
@@ -108,7 +111,7 @@ def test_audit_shell_raw_connect_respects_noqa():
 
 
 def test_one_malformed_block_does_not_suppress_later_blocks():
-    mod = _load_scanner()
+    mod = _SCANNER
     md = (
         "```python\n"                       # 1
         "def f(  # unterminated paren\n"    # 2  -> SyntaxError in this block
@@ -127,7 +130,7 @@ def test_one_malformed_block_does_not_suppress_later_blocks():
 
 
 def test_noqa_honored_on_closing_line_of_multiline_call():
-    mod = _load_scanner()
+    mod = _SCANNER
     src = (
         "import sqlite3\n"
         "def f(p):\n"
@@ -140,7 +143,7 @@ def test_noqa_honored_on_closing_line_of_multiline_call():
 
 
 def test_extract_scans_py_and_info_string_fences():
-    mod = _load_scanner()
+    mod = _SCANNER
     md = (
         "```py\nconn = sqlite3.connect(p)\n```\n\n"
         "```python title=example.py\nconn = sqlite3.connect(q)\n```\n"
@@ -153,7 +156,7 @@ def test_extract_scans_py_and_info_string_fences():
 
 
 def test_bash_block_heredoc_flagged():
-    mod = _load_scanner()
+    mod = _SCANNER
     md = "```bash\npython3 - <<'PY'\nconn = sqlite3.connect(db)\nPY\n```\n"
     hits = []
     for start, lang, block in mod._extract_fenced_blocks(md):

--- a/tests/test_no_default_db_scanner.py
+++ b/tests/test_no_default_db_scanner.py
@@ -37,24 +37,22 @@ def test_noqa_suppresses_violation():
     assert violations == [], "# noqa: vault-db-connect must suppress"
 
 
-def test_extract_python_blocks_from_markdown():
+def test_extract_fenced_blocks_returns_python_block():
     mod = _load_scanner()
     md = "text\n```python\nimport sqlite3\nsqlite3.connect('x')\n```\nmore\n"
-    blocks = mod._extract_python_blocks(md)
-    assert "sqlite3.connect" in blocks
+    blocks = mod._extract_fenced_blocks(md)
+    assert any(lang in {"py", "python", "python3"} and "sqlite3.connect" in src
+               for _start, lang, src in blocks)
 
 
 def test_audit_flags_raw_connect_in_extracted_markdown_block():
     mod = _load_scanner()
-    md = (
-        "Some skill prose.\n\n```python\n"
-        "import sqlite3\n\n"
-        "def opendb(p):\n    return sqlite3.connect(p)\n"
-        "```\n\nmore prose\n"
-    )
-    blocks = mod._extract_python_blocks(md)
-    violations = mod.audit_raw_connect("skills/foo/SKILL.md", blocks)
-    assert violations, "raw sqlite3.connect inside an extracted SKILL.md python block must be flagged"
+    md = "prose\n```python\nimport sqlite3\nsqlite3.connect(p)\n```\n"
+    found = []
+    for start, lang, block in mod._extract_fenced_blocks(md):
+        if lang in {"py", "python", "python3"}:
+            found += mod.audit_raw_connect("skills/foo/SKILL.md", block)
+    assert found, "raw sqlite3.connect inside a SKILL.md python block must be flagged"
 
 
 def test_allowlist_is_function_scoped_not_file_scoped():
@@ -66,7 +64,7 @@ def test_allowlist_is_function_scoped_not_file_scoped():
     assert violations, "allowlist must be function-scoped, not file-scoped"
 
 
-def test_extract_python_blocks_preserves_source_line_numbers():
+def test_extract_fenced_blocks_preserves_source_line_numbers():
     mod = _load_scanner()
     md = (
         "# Title\n"                       # line 1
@@ -76,10 +74,12 @@ def test_extract_python_blocks_preserves_source_line_numbers():
         "conn = sqlite3.connect('x')\n"   # line 5
         "```\n"                           # line 6
     )
-    blocks = mod._extract_python_blocks(md)
-    violations = mod.audit_raw_connect("skills/x/SKILL.md", blocks)
-    assert violations, "expected a finding for the raw connect in the python block"
-    assert violations[0][0] == 5, f"lineno should map to source line 5, got {violations[0][0]}"
+    hits = []
+    for start, lang, block in mod._extract_fenced_blocks(md):
+        if lang in {"py", "python", "python3"}:
+            for lineno, _msg in mod.audit_raw_connect("skills/x/SKILL.md", block):
+                hits.append(start - 1 + lineno)
+    assert hits == [5], f"connect should map to source line 5, got {hits}"
 
 
 def test_audit_shell_raw_connect_flags_heredoc():
@@ -105,3 +105,59 @@ def test_audit_shell_raw_connect_respects_noqa():
     )
     violations = mod.audit_shell_raw_connect("scripts/dev-test/x.sh", sh)
     assert violations == [], "# noqa: vault-db-connect must suppress the shell finding"
+
+
+def test_one_malformed_block_does_not_suppress_later_blocks():
+    mod = _load_scanner()
+    md = (
+        "```python\n"                       # 1
+        "def f(  # unterminated paren\n"    # 2  -> SyntaxError in this block
+        "```\n"                             # 3
+        "\n"                                # 4
+        "```python\n"                       # 5
+        "conn = sqlite3.connect(p)\n"       # 6
+        "```\n"                             # 7
+    )
+    hits = []
+    for start, lang, block in mod._extract_fenced_blocks(md):
+        if lang in {"py", "python", "python3"}:
+            for lineno, _msg in mod.audit_raw_connect("skills/x/SKILL.md", block):
+                hits.append(start - 1 + lineno)
+    assert hits == [6], f"a malformed earlier block must not hide the later connect; got {hits}"
+
+
+def test_noqa_honored_on_closing_line_of_multiline_call():
+    mod = _load_scanner()
+    src = (
+        "import sqlite3\n"
+        "def f(p):\n"
+        "    conn = sqlite3.connect(\n"
+        "        p, timeout=5.0\n"
+        "    )  # noqa: vault-db-connect\n"
+    )
+    assert mod.audit_raw_connect("hooks/other.py", src) == [], \
+        "noqa on the closing line of a multi-line connect must suppress"
+
+
+def test_extract_scans_py_and_info_string_fences():
+    mod = _load_scanner()
+    md = (
+        "```py\nconn = sqlite3.connect(p)\n```\n\n"
+        "```python title=example.py\nconn = sqlite3.connect(q)\n```\n"
+    )
+    found = 0
+    for _start, lang, block in mod._extract_fenced_blocks(md):
+        if lang in {"py", "python", "python3"}:
+            found += len(mod.audit_raw_connect("skills/x/SKILL.md", block))
+    assert found == 2, f"both ```py and ```python info-string blocks must be scanned, got {found}"
+
+
+def test_bash_block_heredoc_flagged():
+    mod = _load_scanner()
+    md = "```bash\npython3 - <<'PY'\nconn = sqlite3.connect(db)\nPY\n```\n"
+    hits = []
+    for start, lang, block in mod._extract_fenced_blocks(md):
+        if lang in {"sh", "bash", "shell", "console"}:
+            for lineno, _msg in mod.audit_shell_raw_connect("skills/x/SKILL.md", block):
+                hits.append(start - 1 + lineno)
+    assert hits, "sqlite3.connect in a SKILL.md bash heredoc must be flagged"

--- a/tests/test_no_default_db_scanner.py
+++ b/tests/test_no_default_db_scanner.py
@@ -1,0 +1,44 @@
+"""Self-test for the extended no-default-db raw-connect scanner (#192)."""
+from __future__ import annotations
+
+import importlib.util
+import os
+
+_SCANNER_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "scripts", "ci-checks", "no-default-db.py"
+)
+
+
+def _load_scanner():
+    spec = importlib.util.spec_from_file_location("no_default_db", _SCANNER_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_flags_raw_connect_in_non_allowed_function():
+    mod = _load_scanner()
+    src = "import sqlite3\n\ndef open_db(p):\n    return sqlite3.connect(p)\n"
+    violations = mod.audit_raw_connect("hooks/other.py", src)
+    assert violations, "expected a raw sqlite3.connect violation"
+
+
+def test_allows_raw_connect_in_allowlisted_connect():
+    mod = _load_scanner()
+    src = "import sqlite3\n\ndef _connect(p):\n    return sqlite3.connect(p, timeout=5.0)\n"
+    violations = mod.audit_raw_connect("hooks/vault_index.py", src)
+    assert violations == [], "vault_index._connect must be allowlisted"
+
+
+def test_noqa_suppresses_violation():
+    mod = _load_scanner()
+    src = "import sqlite3\n\ndef f(p):\n    return sqlite3.connect(p)  # noqa: vault-db-connect\n"
+    violations = mod.audit_raw_connect("hooks/other.py", src)
+    assert violations == [], "# noqa: vault-db-connect must suppress"
+
+
+def test_extract_python_blocks_from_markdown():
+    mod = _load_scanner()
+    md = "text\n```python\nimport sqlite3\nsqlite3.connect('x')\n```\nmore\n"
+    blocks = mod._extract_python_blocks(md)
+    assert "sqlite3.connect" in blocks

--- a/tests/test_vault_index_db_guard.py
+++ b/tests/test_vault_index_db_guard.py
@@ -50,3 +50,20 @@ def test_connect_allows_isolated_path(tmp_path):
         assert db.exists()
     finally:
         conn.close()
+
+
+def test_log_access_routes_through_connect():
+    with pytest.raises(RuntimeError, match="refusing to open production index DB"):
+        vault_index.log_access(
+            vault_index._REAL_PROD_DB, "/some/note.md", "recall", "proj"
+        )
+
+
+def test_batch_activations_routes_through_connect():
+    with pytest.raises(RuntimeError, match="refusing to open production index DB"):
+        vault_index.batch_activations(vault_index._REAL_PROD_DB, ["/some/note.md"])
+
+
+def test_parent_session_routes_through_connect():
+    with pytest.raises(RuntimeError, match="refusing to open production index DB"):
+        vault_index._parent_session_for_snapshot("/some/snap.md", vault_index._REAL_PROD_DB)

--- a/tests/test_vault_index_db_guard.py
+++ b/tests/test_vault_index_db_guard.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 import importlib
 import os
+import sqlite3
+
+import pytest
 
 import vault_index
 
@@ -30,11 +33,6 @@ def test_autouse_fixture_redirects_default_db(tmp_path):
     resolved = vault_index._default_db_path()
     assert resolved != vault_index._REAL_PROD_DB
     assert "OBSIDIAN_BRAIN_DB" in os.environ
-
-
-import sqlite3
-
-import pytest
 
 
 def test_connect_raises_on_real_prod_path_under_test():

--- a/tests/test_vault_index_db_guard.py
+++ b/tests/test_vault_index_db_guard.py
@@ -88,3 +88,41 @@ def test_indirect_ensure_index_lands_in_isolated_db(tmp_path, monkeypatch):
 
     # The real prod DB must be untouched (guard would have raised otherwise).
     assert os.path.realpath(str(iso_db)) != vault_index._REAL_PROD_DB
+
+
+def test_log_access_degrades_on_sqlite_error(tmp_path):
+    # A non-prod path that sqlite3 cannot open (a directory) triggers a
+    # connect-phase sqlite3.Error — log_access must degrade (return None), NOT raise.
+    bad = tmp_path / "a-directory.db"
+    bad.mkdir()
+    assert vault_index.log_access(str(bad), "/some/note.md", "recall", "demo") is None
+
+
+def test_batch_activations_degrades_on_sqlite_error(tmp_path):
+    # Same connect-phase sqlite3.Error path: batch_activations must degrade to the
+    # zero-filled result dict, NOT raise.
+    bad = tmp_path / "a-directory.db"
+    bad.mkdir()
+    note = "/some/note.md"
+    result = vault_index.batch_activations(str(bad), [note])
+    assert result == {note: 0.0}
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unsupported on this platform")
+def test_connect_blocks_symlink_to_prod_db(tmp_path):
+    # A symlink whose realpath resolves to the real prod DB must NOT evade the guard.
+    link = tmp_path / "sneaky.db"
+    try:
+        os.symlink(vault_index._REAL_PROD_DB, str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("could not create symlink")
+    with pytest.raises(RuntimeError, match="refusing to open production index DB"):
+        vault_index._connect(str(link))
+
+
+def test_default_db_path_empty_env_falls_back(monkeypatch):
+    # OBSIDIAN_BRAIN_DB="" is falsy → the `or` must fall back to the real default
+    # (regression guard against refactoring to os.environ.get(key, default)).
+    monkeypatch.setenv("OBSIDIAN_BRAIN_DB", "")
+    expected = os.path.join(os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db")
+    assert vault_index._default_db_path() == expected

--- a/tests/test_vault_index_db_guard.py
+++ b/tests/test_vault_index_db_guard.py
@@ -126,3 +126,20 @@ def test_default_db_path_empty_env_falls_back(monkeypatch):
     monkeypatch.setenv("OBSIDIAN_BRAIN_DB", "")
     expected = os.path.join(os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db")
     assert vault_index._default_db_path() == expected
+
+
+@pytest.mark.skipif(not hasattr(os, "link"), reason="hard links unsupported on this platform")
+def test_connect_blocks_hardlink_to_prod_db(tmp_path, monkeypatch):
+    # A hard link shares the target's inode but has its own path, so realpath
+    # does NOT resolve it back to the prod DB — only the samefile/inode check
+    # catches it. Use a stand-in prod DB (never the real one) to test safely.
+    fake_prod = tmp_path / "prod.db"
+    fake_prod.write_text("")  # must exist to be hard-linked
+    monkeypatch.setattr(vault_index, "_REAL_PROD_DB", os.path.realpath(str(fake_prod)))
+    link = tmp_path / "hardlink.db"
+    try:
+        os.link(str(fake_prod), str(link))
+    except (OSError, NotImplementedError):
+        pytest.skip("could not create a hard link")
+    with pytest.raises(RuntimeError, match="refusing to open production index DB"):
+        vault_index._connect(str(link))

--- a/tests/test_vault_index_db_guard.py
+++ b/tests/test_vault_index_db_guard.py
@@ -22,3 +22,11 @@ def test_default_db_path_falls_back_without_env(monkeypatch):
 def test_in_test_ctx_true_under_pytest():
     # pytest always sets PYTEST_CURRENT_TEST while a test runs.
     assert vault_index._in_test_ctx() is True
+
+
+def test_autouse_fixture_redirects_default_db(tmp_path):
+    # Under the autouse fixture, OBSIDIAN_BRAIN_DB is set to a per-test tmp path,
+    # so an un-isolated default call never resolves to the real prod DB.
+    resolved = vault_index._default_db_path()
+    assert resolved != vault_index._REAL_PROD_DB
+    assert "OBSIDIAN_BRAIN_DB" in os.environ

--- a/tests/test_vault_index_db_guard.py
+++ b/tests/test_vault_index_db_guard.py
@@ -1,7 +1,6 @@
 """Regression tests for the #192 production-index-DB pollution guard."""
 from __future__ import annotations
 
-import importlib
 import os
 import sqlite3
 

--- a/tests/test_vault_index_db_guard.py
+++ b/tests/test_vault_index_db_guard.py
@@ -1,0 +1,24 @@
+"""Regression tests for the #192 production-index-DB pollution guard."""
+from __future__ import annotations
+
+import importlib
+import os
+
+import vault_index
+
+
+def test_default_db_path_honors_env_override(monkeypatch, tmp_path):
+    target = tmp_path / "override.db"
+    monkeypatch.setenv("OBSIDIAN_BRAIN_DB", str(target))
+    assert vault_index._default_db_path() == str(target)
+
+
+def test_default_db_path_falls_back_without_env(monkeypatch):
+    monkeypatch.delenv("OBSIDIAN_BRAIN_DB", raising=False)
+    expected = os.path.join(os.path.expanduser("~"), ".claude", "obsidian-brain-vault.db")
+    assert vault_index._default_db_path() == expected
+
+
+def test_in_test_ctx_true_under_pytest():
+    # pytest always sets PYTEST_CURRENT_TEST while a test runs.
+    assert vault_index._in_test_ctx() is True

--- a/tests/test_vault_index_db_guard.py
+++ b/tests/test_vault_index_db_guard.py
@@ -30,3 +30,23 @@ def test_autouse_fixture_redirects_default_db(tmp_path):
     resolved = vault_index._default_db_path()
     assert resolved != vault_index._REAL_PROD_DB
     assert "OBSIDIAN_BRAIN_DB" in os.environ
+
+
+import sqlite3
+
+import pytest
+
+
+def test_connect_raises_on_real_prod_path_under_test():
+    with pytest.raises(RuntimeError, match="refusing to open production index DB"):
+        vault_index._connect(vault_index._REAL_PROD_DB)
+
+
+def test_connect_allows_isolated_path(tmp_path):
+    db = tmp_path / "isolated.db"
+    conn = vault_index._connect(str(db))
+    try:
+        assert isinstance(conn, sqlite3.Connection)
+        assert db.exists()
+    finally:
+        conn.close()

--- a/tests/test_vault_index_db_guard.py
+++ b/tests/test_vault_index_db_guard.py
@@ -67,3 +67,26 @@ def test_batch_activations_routes_through_connect():
 def test_parent_session_routes_through_connect():
     with pytest.raises(RuntimeError, match="refusing to open production index DB"):
         vault_index._parent_session_for_snapshot("/some/snap.md", vault_index._REAL_PROD_DB)
+
+
+def test_indirect_ensure_index_lands_in_isolated_db(tmp_path, monkeypatch):
+    # Simulate the indirect leak path: call ensure_index with NO db_path.
+    # The autouse fixture has pointed OBSIDIAN_BRAIN_DB at a tmp file; override
+    # it here to a path we control so we can assert rows landed there.
+    iso_db = tmp_path / "iso.db"
+    monkeypatch.setenv("OBSIDIAN_BRAIN_DB", str(iso_db))
+
+    vault = tmp_path / "vault"
+    sessions = vault / "claude-sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "2026-06-03-demo-aaaa.md").write_text(
+        "---\ntype: claude-session\nproject: demo\n---\n\n# Demo\nbody text\n",
+        encoding="utf-8",
+    )
+
+    returned = vault_index.ensure_index(str(vault), ["claude-sessions"])  # noqa: no-default-db — intentional: guards the indirect (no db_path) leak path
+    assert returned == str(iso_db)
+    assert iso_db.exists()
+
+    # The real prod DB must be untouched (guard would have raised otherwise).
+    assert os.path.realpath(str(iso_db)) != vault_index._REAL_PROD_DB


### PR DESCRIPTION
## Summary

Stops the test/dev-test suite from polluting the **production** index DB (`~/.claude/obsidian-brain-vault.db`). Root cause: production code paths call `ensure_index()` with no `db_path`, defaulting to the real DB even under pytest — silently inflating it with phantom rows every test run.

Fix is **defense-in-depth** (belt, suspenders, and a static guard):

1. **Env override** — `_default_db_path()` honors `OBSIDIAN_BRAIN_DB`, so tests/dev-test/subprocesses isolate the DB without threading `db_path` everywhere.
2. **Chokepoint guard** — `_connect()` raises `RuntimeError` if asked to open the *real* prod DB under a pytest context (`PYTEST_CURRENT_TEST` present). Compares against an import-time `_REAL_PROD_DB` realpath constant, so env/monkeypatch redirection can't defeat it.
3. **Chokepoint consolidation** — the three raw `sqlite3.connect` writers (`log_access`, `batch_activations`, `_parent_session_for_snapshot`) now route through `_connect()`. Connect-phase `sqlite3.Error` is still swallowed (best-effort behavior preserved); only the guard's `RuntimeError` propagates.
4. **Autouse isolation fixture** — `tests/conftest.py` points `OBSIDIAN_BRAIN_DB` at a per-test tmp DB for every test (covers in-process leaks; subprocesses inherit it).
5. **Indirect-leak regression test** — locks the actual #192 path (no-`db_path` `ensure_index` lands in the isolated DB).
6. **Static guard** — `no-default-db.py` now forbids raw `sqlite3.connect` bypasses of `_connect` across `hooks/`, `skills/` (embedded python in `SKILL.md`), and `scripts/` (allowlist: `vault_index._connect`; escape hatch: `# noqa: vault-db-connect`). Pre-existing read-only / SELECT-only opens are annotated with justified noqa.
7. **End-to-end dogfood** — `scripts/dev-test/test-issue-192-pollution-guard.py`: a 4-cell prevention matrix (incl. the production success path) + a regression half, against a sentinel tmp DB (never the real one).

**Acceptance:** the full pytest run leaves the real prod DB's `notes` row count **unchanged** (verified: 2469 → 2469).

## Test Plan

- [x] `python3 -m pytest -q` → **1314 passed** (was 1300; +14 new)
- [x] `python3 scripts/ci-checks/no-default-db.py` → **exit 0**
- [x] `python3 scripts/dev-test/test-issue-192-pollution-guard.py --dev-repo "$(pwd)"` → **7 passed, 0 failed**
- [x] Prod DB row count identical before/after full suite (2469 = 2469)
- [x] `commit-preflight.sh` green on every commit (coverage ≥ 90%)

## Notes

- Repo default branch is `main`; this PR targets `develop`, so `Closes #192` cross-references rather than auto-closing — the issue will be closed manually on merge.
- Follow-up nits (non-blocking, from final review): `.sh` heredocs aren't scanned by `no-default-db.py`; the scanner's reported line numbers for embedded `SKILL.md` python blocks are relative to the concatenated blocks.

Closes #192
