### PR TITLE
fix(scripts): reliably commit dev-cycle version bump in git-flow-finish (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`scripts/git-flow-finish.sh` now reliably commits the post-release dev-cycle
+  version bump (#75).** The bump phase used a single multi-pathspec `git add`
+  (`plugin.json package.json pyproject.toml Cargo.toml version.txt CHANGELOG.md`);
+  because `git add` is atomic, a missing pathspec (e.g. `package.json` in this
+  Python repo) aborted the whole command and staged **nothing**, so the bump landed
+  in the working tree but was never committed or pushed — leaving `develop`
+  half-bumped after every release. Files are now staged individually (skipping
+  absent ones), `.claude-plugin/marketplace.json` (which `bump-version.sh` updates
+  in lockstep) is now included, and a fail-loud guard aborts if any change remains
+  uncommitted after the bump.
+
 ## [2.6.1] - 2026-06-07
 
 ### Fixed

--- a/scripts/git-flow-finish.sh
+++ b/scripts/git-flow-finish.sh
@@ -438,9 +438,11 @@ else
   # Stage version file changes and CHANGELOG. Stage each path individually: a
   # multi-pathspec `git add` is atomic and aborts (staging NOTHING) if any single
   # path is missing — e.g. package.json/pyproject.toml/Cargo.toml in a repo that
-  # has none of them. That silent no-op left develop half-bumped every release
-  # (issue #75). marketplace.json must be included — bump-version.sh updates it in
-  # lockstep with plugin.json, and it was previously absent from this list.
+  # has none of them. The old form swallowed that abort with `2>/dev/null || true`,
+  # so the bump landed in the working tree but was never committed — leaving
+  # develop half-bumped every release (issue #75). Do NOT reintroduce `|| true`
+  # here: each `git add` must fail loudly under `set -e`. marketplace.json must be
+  # included — bump-version.sh updates it in lockstep with plugin.json.
   for vf in .claude-plugin/plugin.json .claude-plugin/marketplace.json \
             package.json pyproject.toml Cargo.toml version.txt CHANGELOG.md; do
     if [[ -f "$vf" ]]; then
@@ -458,17 +460,18 @@ EOF
 )"
     log_ok "Bumped to next patch and committed"
   else
-    log_skip "No version files changed"
+    log_skip "Nothing staged for version bump"
   fi
 
   # Fail-loud safety net (issue #75): the VERIFICATION phase only compares pushed
   # state and cannot see a dirty working tree, so a bump that did not get fully
-  # committed would otherwise pass with a green check. If anything remains
-  # uncommitted here, surface it and abort rather than leaving develop dirty.
-  if ! git diff --quiet; then
+  # committed would otherwise pass with a green check. Use `git status --porcelain`
+  # (not `git diff`) so this also catches untracked files a future bump step might
+  # leave behind. If anything remains uncommitted here, surface it and abort.
+  if [[ -n "$(git status --porcelain)" ]]; then
     log "Uncommitted changes remaining after version bump:"
     git status --short
-    die "Version bump left uncommitted changes in the working tree (issue #75). Stage + commit + push them manually, then re-run verification."
+    die "Version bump left uncommitted changes in the working tree (issue #75). Stage + commit + push them manually, then re-run this script."
   fi
 fi
 

--- a/scripts/git-flow-finish.sh
+++ b/scripts/git-flow-finish.sh
@@ -435,8 +435,18 @@ else
     fi
   fi
 
-  # Stage version file changes and CHANGELOG (avoid git add -A which could stage unintended files)
-  git add .claude-plugin/plugin.json package.json pyproject.toml Cargo.toml version.txt CHANGELOG.md 2>/dev/null || true
+  # Stage version file changes and CHANGELOG. Stage each path individually: a
+  # multi-pathspec `git add` is atomic and aborts (staging NOTHING) if any single
+  # path is missing — e.g. package.json/pyproject.toml/Cargo.toml in a repo that
+  # has none of them. That silent no-op left develop half-bumped every release
+  # (issue #75). marketplace.json must be included — bump-version.sh updates it in
+  # lockstep with plugin.json, and it was previously absent from this list.
+  for vf in .claude-plugin/plugin.json .claude-plugin/marketplace.json \
+            package.json pyproject.toml Cargo.toml version.txt CHANGELOG.md; do
+    if [[ -f "$vf" ]]; then
+      git add "$vf"
+    fi
+  done
   if ! git diff --cached --quiet; then
     git commit -m "$(cat <<EOF
 chore(develop): bump version for next development cycle
@@ -449,6 +459,16 @@ EOF
     log_ok "Bumped to next patch and committed"
   else
     log_skip "No version files changed"
+  fi
+
+  # Fail-loud safety net (issue #75): the VERIFICATION phase only compares pushed
+  # state and cannot see a dirty working tree, so a bump that did not get fully
+  # committed would otherwise pass with a green check. If anything remains
+  # uncommitted here, surface it and abort rather than leaving develop dirty.
+  if ! git diff --quiet; then
+    log "Uncommitted changes remaining after version bump:"
+    git status --short
+    die "Version bump left uncommitted changes in the working tree (issue #75). Stage + commit + push them manually, then re-run verification."
   fi
 fi
 


### PR DESCRIPTION
## Summary

Fixes the long-standing bug where `scripts/git-flow-finish.sh` left `develop` half-bumped after every release — the next-dev-cycle version bump landed in the working tree but was never committed or pushed.

Closes #75

## Root cause

The `BUMP DEVELOP VERSION` phase staged version files with a single multi-pathspec `git add`:

```bash
git add .claude-plugin/plugin.json package.json pyproject.toml Cargo.toml version.txt CHANGELOG.md 2>/dev/null || true
```

`git add` is **atomic**: if any one pathspec matches no file (e.g. `package.json`/`pyproject.toml`/`Cargo.toml`/`version.txt` in this Python repo), the entire command fails and stages **nothing**. The `2>/dev/null || true` swallowed the error, so the subsequent `git diff --cached --quiet` reported no staged changes → `log_skip "No version files changed"` → no commit. The `VERIFICATION` phase only compares *pushed* state, so the dirty working tree passed with a green check.

Reproduced on v2.2.0, v2.3.0, v2.4.0, and again on v2.6.1 (this session).

## Fix

- **Stage each version file individually** (skipping absent paths) so a missing file no longer aborts staging of the others.
- **Add `.claude-plugin/marketplace.json`** to the list — `bump-version.sh` updates it in lockstep with `plugin.json`, but it was previously absent entirely.
- **Fail-loud guard** — after the bump, abort with a clear message if anything remains uncommitted, instead of silently passing verification.

## Verification

Root cause and fix confirmed empirically in a throwaway git repo:
- Old multi-pathspec `git add` with missing paths → stages nothing (bug reproduced).
- New per-file loop → stages both `plugin.json` and `marketplace.json`; working tree clean afterward (fail-loud net does not false-fire).
- `bash -n` syntax check passes.

## Scaffold backport

This script is installed by `repo-hardener:harden-repo`. A follow-up will propagate the same fix to that skill's template so new repos start corrected (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
