### PR TITLE
Release v2.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "obsidian-brain",
       "source": "./",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "description": "Persistent brain for Claude Code sessions using Obsidian."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "obsidian-brain",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Persistent brain for Claude Code sessions using Obsidian. Auto-logs sessions, captures curated insights, enables project-scoped context resume, and provides fast cross-project search via tags and metadata."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`scripts/git-flow-finish.sh` now reliably commits the post-release dev-cycle
+  version bump (#75).** The bump phase used a single multi-pathspec `git add`
+  (`plugin.json package.json pyproject.toml Cargo.toml version.txt CHANGELOG.md`);
+  because `git add` is atomic, a missing pathspec (e.g. `package.json` in this
+  Python repo) aborted the whole command and staged **nothing**, so the bump landed
+  in the working tree but was never committed or pushed — leaving `develop`
+  half-bumped after every release. Files are now staged individually (skipping
+  absent ones), `.claude-plugin/marketplace.json` (which `bump-version.sh` updates
+  in lockstep) is now included, and a fail-loud guard aborts if any change remains
+  uncommitted after the bump.
+
 ## [2.6.1] - 2026-06-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.2] - 2026-06-08
+
 ### Fixed
 - **`scripts/git-flow-finish.sh` now reliably commits the post-release dev-cycle
   version bump (#75).** The bump phase used a single multi-pathspec `git add`

--- a/scripts/git-flow-finish.sh
+++ b/scripts/git-flow-finish.sh
@@ -435,8 +435,20 @@ else
     fi
   fi
 
-  # Stage version file changes and CHANGELOG (avoid git add -A which could stage unintended files)
-  git add .claude-plugin/plugin.json package.json pyproject.toml Cargo.toml version.txt CHANGELOG.md 2>/dev/null || true
+  # Stage version file changes and CHANGELOG. Stage each path individually: a
+  # multi-pathspec `git add` is atomic and aborts (staging NOTHING) if any single
+  # path is missing — e.g. package.json/pyproject.toml/Cargo.toml in a repo that
+  # has none of them. The old form swallowed that abort with `2>/dev/null || true`,
+  # so the bump landed in the working tree but was never committed — leaving
+  # develop half-bumped every release (issue #75). Do NOT reintroduce `|| true`
+  # here: each `git add` must fail loudly under `set -e`. marketplace.json must be
+  # included — bump-version.sh updates it in lockstep with plugin.json.
+  for vf in .claude-plugin/plugin.json .claude-plugin/marketplace.json \
+            package.json pyproject.toml Cargo.toml version.txt CHANGELOG.md; do
+    if [[ -f "$vf" ]]; then
+      git add "$vf"
+    fi
+  done
   if ! git diff --cached --quiet; then
     git commit -m "$(cat <<EOF
 chore(develop): bump version for next development cycle
@@ -448,7 +460,18 @@ EOF
 )"
     log_ok "Bumped to next patch and committed"
   else
-    log_skip "No version files changed"
+    log_skip "Nothing staged for version bump"
+  fi
+
+  # Fail-loud safety net (issue #75): the VERIFICATION phase only compares pushed
+  # state and cannot see a dirty working tree, so a bump that did not get fully
+  # committed would otherwise pass with a green check. Use `git status --porcelain`
+  # (not `git diff`) so this also catches untracked files a future bump step might
+  # leave behind. If anything remains uncommitted here, surface it and abort.
+  if [[ -n "$(git status --porcelain)" ]]; then
+    log "Uncommitted changes remaining after version bump:"
+    git status --short
+    die "Version bump left uncommitted changes in the working tree (issue #75). Stage + commit + push them manually, then re-run this script."
   fi
 fi
 


### PR DESCRIPTION
## Release v2.6.2

Patch release. Branched from `develop`, targets `main` per Git Flow.

### Fixed
- **`scripts/git-flow-finish.sh` now reliably commits the post-release dev-cycle version bump (#75).** The bump phase used a single multi-pathspec `git add`; because `git add` is atomic, a missing pathspec (e.g. `package.json` in this Python repo) aborted the whole command and staged nothing, so the bump landed in the working tree but was never committed — leaving `develop` half-bumped after every release. Files are now staged individually (skipping absent ones), `.claude-plugin/marketplace.json` is included, and a fail-loud guard aborts if any change remains uncommitted after the bump. (#203)

### Release mechanics
- Version `2.6.2` was already present in `plugin.json` / `marketplace.json` (pre-bumped on `develop` via ec8746a) — no additional bump needed.
- CHANGELOG `[Unreleased]` entry promoted to `## [2.6.2] - 2026-06-08`.
- Preflight passed (secrets, version-sync, tests).

### Note
This release dogfoods the #75 fix: when finished via `git-flow-finish.sh`, the next dev-cycle bump (to 2.6.3) should commit cleanly with no manual recovery.

### Merge checklist (Git Flow)
- [ ] Review CHANGELOG accuracy
- [ ] Merge to `main` + tag `v2.6.2`
- [ ] Publish GitHub Release
- [ ] Back-merge `main` into `develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
