### PR TITLE
feat(vault-doctor): opt-in audit-historic-repairs check (#95) + date-rollover test fix (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the default all-checks sweep via the new registry `OPT_IN` attribute.
 
 ### Fixed
+- `vault_doctor --apply` now prints each error Result's detail message (previously the per-note error string was dropped; only the status mark survived).
 - Date-rollover test flakiness (#205): 12 test call sites scanned hardcoded
   April-2026 fixtures with 60-day windows, so the suite started failing once
   the wall clock reached 2026-06-09 (CI was green the day before). Widened to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`vault-doctor --check audit-historic-repairs` (#95)** — one-shot, opt-in audit
+  of historic source-sessions repairs. Walks the doctor backup runs under
+  `~/.claude/obsidian-brain-doctor-backup/`, diffs each backed-up note's
+  `source_session`/`source_session_note` against the note's current state
+  (oldest backup wins — it is the true pre-doctor original), and classifies
+  every historic repair by date agreement: **A** restore (original matched the
+  note date, current doesn't — mtime-bug corruption), **B** keep (legit fix),
+  **C** same-day ambiguous, **D** both-wrong. Only category A is applied on
+  `fix`; restores are themselves backed up under
+  `<run>/audit-historic-repairs/` and re-runs are drift-stable. Excluded from
+  the default all-checks sweep via the new registry `OPT_IN` attribute.
+
+### Fixed
+- Date-rollover test flakiness (#205): 12 test call sites scanned hardcoded
+  April-2026 fixtures with 60-day windows, so the suite started failing once
+  the wall clock reached 2026-06-09 (CI was green the day before). Widened to
+  the established `days=10000` convention.
+
 ## [2.6.2] - 2026-06-08
 
 ### Fixed

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -241,6 +241,7 @@ def main() -> int:
                 print(f"  {status_mark} {r.status}  {Path(r.note_path).name}", file=sys.stderr)
                 if r.status == "error":
                     any_errors = True
+                    print(f"      {r.error}", file=sys.stderr)
 
     return 2 if any_errors else 1
 

--- a/scripts/vault_doctor_checks/__init__.py
+++ b/scripts/vault_doctor_checks/__init__.py
@@ -87,4 +87,13 @@ def all_checks() -> list:
     only run when explicitly named via get_check() / --check.
     """
     _discover()
-    return [m for m in _CHECKS.values() if not getattr(m, "OPT_IN", False)]
+    result = []
+    for m in _CHECKS.values():
+        flag = getattr(m, "OPT_IN", False)
+        if not isinstance(flag, bool):
+            raise TypeError(
+                f"{getattr(m, 'NAME', m)}: OPT_IN must be bool, got {flag!r}"
+            )
+        if not flag:
+            result.append(m)
+    return result

--- a/scripts/vault_doctor_checks/__init__.py
+++ b/scripts/vault_doctor_checks/__init__.py
@@ -81,5 +81,10 @@ def get_check(name: str):
 
 
 def all_checks() -> list:
+    """All registered checks minus opt-in ones (``OPT_IN = True``).
+
+    Opt-in checks (e.g. one-shot audit tools like audit-historic-repairs)
+    only run when explicitly named via get_check() / --check.
+    """
     _discover()
-    return list(_CHECKS.values())
+    return [m for m in _CHECKS.values() if not getattr(m, "OPT_IN", False)]

--- a/scripts/vault_doctor_checks/__init__.py
+++ b/scripts/vault_doctor_checks/__init__.py
@@ -6,6 +6,8 @@ Each check module in this package must export:
   - DEFAULT_WINDOW_DAYS: int
   - scan(vault_path, sessions_folder, insights_folder, days, project=None) -> list[Issue]
   - apply(issues, backup_root) -> list[Result]
+  - OPT_IN: bool (optional, default False) — True excludes the check from the
+    default all-checks sweep; it only runs when named via --check
 
 The registry auto-discovers modules in this package directory on first access.
 """

--- a/scripts/vault_doctor_checks/audit_historic_repairs.py
+++ b/scripts/vault_doctor_checks/audit_historic_repairs.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -59,7 +60,7 @@ OPT_IN = True  # excluded from the default all-checks sweep
 
 _CATEGORY_REASONS = {
     "A": "original backlink matches note date; current does not — mtime-drift corruption, restore original",
-    "B": "current backlink matches note date; original did not — historic repair was legitimate, keeping",
+    "B": "current backlink matches note date; original did not — likely a legitimate repair (verify manually if the session spanned midnight)",
     "C": "original and current backlinks are both same-day as the note — ambiguous, needs JSONL-window or human review",
     "D": "neither original nor current backlink matches the note date — unresolved, needs human review",
 }
@@ -158,11 +159,15 @@ def scan(
     # it is the true pre-doctor original. Intermediate backups are
     # vault-doctor iterations on vault-doctor.
     oldest: dict[str, tuple[float, Path]] = {}
+    skipped_old_runs = 0  # FIX 3: count run dirs excluded by --days cutoff
     for run_dir in sorted(root.iterdir()):
         if not run_dir.is_dir():
             continue
         run_ts = _parse_run_ts(run_dir.name)
-        if run_ts is None or run_ts < cutoff:
+        if run_ts is None:
+            continue
+        if run_ts < cutoff:
+            skipped_old_runs += 1  # FIX 3: parseable but aged-out
             continue
         for md in run_dir.rglob("*.md"):
             # Skip this check's own restore backups — re-running the audit
@@ -173,19 +178,61 @@ def scan(
             if existing is None or run_ts < existing[0]:
                 oldest[md.name] = (run_ts, md)
 
+    # FIX 3: warn if aged-out run dirs were skipped
+    if skipped_old_runs > 0:
+        print(
+            f"[audit-historic-repairs] WARNING: {skipped_old_runs} backup run(s) older than"
+            f" --days={days} were excluded; 'oldest backup' may not be the true"
+            f" pre-doctor original. Re-run with a larger --days.",
+            file=sys.stderr,
+        )
+
     issues: list[Issue] = []
+    # FIX 5: counters for end-of-scan coverage summary
+    missing_current = 0
+    non_source = 0
+    no_drift = 0
+    unreadable = 0
+    project_filtered = 0
+
     for basename in sorted(oldest):
         _, backup_path = oldest[basename]
         current_path = _find_current_note(
             vault, basename, sessions_folder, insights_folder
         )
         if current_path is None:
+            missing_current += 1  # FIX 5
             continue  # note deleted/renamed since — nothing to audit
 
         try:
             backup_text = backup_path.read_text(encoding="utf-8", errors="replace")
             current_text = current_path.read_text(encoding="utf-8", errors="replace")
-        except OSError:
+        except OSError as exc:
+            # FIX 2 / R2-1: don't silently drop unreadable notes. Emitted
+            # UNCONDITIONALLY — even with --project set — because an
+            # unreadable note cannot be attributed to a project, and the
+            # project filter must not suppress audit-infrastructure failures.
+            unreadable += 1  # FIX 5
+            issues.append(Issue(
+                check=NAME,
+                note_path=str(current_path),
+                project="unknown",
+                current_source="(unreadable)",
+                proposed_source="",
+                reason=(
+                    f"could not read note or backup for audit (note could not"
+                    f" be attributed to a project): {exc}"
+                ),
+                confidence=0.0,
+                extra={
+                    "category": "D",
+                    "signal_class": "historic-unreadable",
+                    "unresolved": True,
+                    "orig_sid": "",
+                    "orig_basename": "",
+                    "backup_path": str(backup_path),
+                },
+            ))
             continue
 
         backup_fm = _parse_frontmatter(backup_text, source=str(backup_path))
@@ -199,15 +246,26 @@ def scan(
         # Not a source-sessions note (e.g. a session note backed up by the
         # snapshot checks) — nothing to audit.
         if not orig_sid and not orig_note:
+            # FIX 4: warn when backup has no source fields but current note does
+            if curr_sid or curr_note:
+                print(
+                    f"[audit-historic-repairs] WARNING: backup {backup_path} has no"
+                    f" parsable source_session frontmatter but current note does —"
+                    f" backup may be corrupted; skipping.",
+                    file=sys.stderr,
+                )
+            non_source += 1  # FIX 5
             continue
 
         # No drift: the backlink was never rewritten (backup is from another
         # check, or a restore already ran).
         if orig_sid == curr_sid and orig_note == curr_note:
+            no_drift += 1  # FIX 5
             continue
 
         note_project = current_fm.get("project", "unknown") or "unknown"
         if project and note_project != project:
+            project_filtered += 1  # FIX 5
             continue
 
         file_date = _note_date(basename)
@@ -216,29 +274,60 @@ def scan(
         else:
             category = _classify(file_date, _note_date(orig_note), _note_date(curr_note))
 
+        # FIX 6: category A without a complete source_session pair must not
+        # be auto-applyable — mark as unresolved so apply() never attempts it.
+        unresolved = category != "A"
+        confidence = 0.9 if category == "A" else 0.0
+        reason = f"category {category}: {_CATEGORY_REASONS[category]}"
+        if category == "A" and (not orig_sid or not orig_note):
+            unresolved = True
+            confidence = 0.0
+            reason = (
+                "category A: original backlink matches note date but backup lacks"
+                " a complete source_session pair — manual restore needed"
+            )
+
         issues.append(Issue(
             check=NAME,
             note_path=str(current_path),
             project=note_project,
             current_source=f"[[{curr_note}]]" if curr_note else "(missing)",
             proposed_source=f"[[{orig_note}]]" if category == "A" else "",
-            reason=f"category {category}: {_CATEGORY_REASONS[category]}",
-            confidence=0.9 if category == "A" else 0.0,
+            reason=reason,
+            confidence=confidence,
             extra={
                 "category": category,
                 "signal_class": _CATEGORY_SIGNALS[category],
-                "unresolved": category != "A",
+                "unresolved": unresolved,
                 "orig_sid": orig_sid,
                 "orig_basename": orig_note,
                 "backup_path": str(backup_path),
             },
         ))
 
+    # FIX 5 / R2-2: end-of-scan coverage summary. Buckets partition
+    # len(oldest): every unreadable note also appended an issue (R2-1), so
+    # subtract it from the classified count to avoid double-counting.
+    if oldest:
+        classified = len(issues) - unreadable
+        print(
+            f"[audit-historic-repairs] audited {len(oldest)} backed-up note(s):"
+            f" {classified} classified, {missing_current} missing-current,"
+            f" {non_source} non-source-session, {no_drift} no-drift,"
+            f" {unreadable} unreadable, {project_filtered} project-filtered",
+            file=sys.stderr,
+        )
+
     return issues
 
 
 def apply(issues: list[Issue], backup_root: str) -> list[Result]:
-    """Restore category-A notes to their original source_session backlink."""
+    """Restore category-A notes to their original source_session backlink.
+
+    Note: the OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT override only affects which
+    backups scan() reads; apply() always writes its restore-backups under the
+    dispatcher-provided backup_root.
+    """
     results: list[Result] = []
 
     for issue in issues:

--- a/scripts/vault_doctor_checks/audit_historic_repairs.py
+++ b/scripts/vault_doctor_checks/audit_historic_repairs.py
@@ -1,0 +1,334 @@
+"""vault_doctor check: audit historic source-sessions repairs and reverse corruptions.
+
+One-shot audit tool (issue #95, companion to #93). Earlier `/vault-doctor fix`
+runs applied a buggy mtime-as-capture-time algorithm to `source_session`
+backlinks. Even after the algorithm fix (#93/#106), the vault still contains
+backlinks rewritten by the buggy versions. This check walks the doctor backup
+roots under ``~/.claude/obsidian-brain-doctor-backup/``, diffs each backed-up
+note's ``source_session`` / ``source_session_note`` against the note's current
+state, and classifies every historic repair:
+
+  A — restore:   original backlink matched the note's filename date; current
+                 one does not → mtime-drift corruption; auto-proposes restore.
+  B — keep:      original was wrong-day; current matches → legit fix; no action.
+  C — ambiguous: both same-day but different sessions → human review.
+  D — both-wrong: neither matches the filename date → unresolved warning.
+
+Only category A is auto-applyable. ``apply()`` restores the ORIGINAL
+``source_session`` + ``source_session_note`` from the oldest backup (the true
+pre-doctor state) and writes its own backups under
+``<backup_root>/audit-historic-repairs/`` so the restore is itself reversible.
+
+This check is OPT-IN: it does not run in the default all-checks sweep
+(`vault_doctor` with no ``--check``) because B/C/D classifications are
+permanent report rows, not actionable drift. Run it explicitly:
+
+    python3 scripts/vault_doctor.py --check audit-historic-repairs
+
+The backup root can be overridden via ``OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT``
+(used by tests). ``--days`` bounds the age of backup RUNS considered
+(default 180 — stale backups aren't load-bearing).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import Issue, Result
+
+# Reuse the package-shared frontmatter helpers so parsing/rewriting semantics
+# stay byte-identical with the source-sessions check that wrote these repairs.
+from .source_sessions import (
+    _EXTRA_INSIGHT_FOLDERS,
+    _FILENAME_DATE_RE,
+    _parse_frontmatter,
+    _rewrite_frontmatter,
+)
+
+NAME = "audit-historic-repairs"
+DESCRIPTION = (
+    "Classify historic source-sessions repairs from doctor backups and "
+    "reverse clear mtime-bug corruptions (opt-in; run via --check)"
+)
+DEFAULT_WINDOW_DAYS = 180  # backup runs older than this are skipped
+OPT_IN = True  # excluded from the default all-checks sweep
+
+_CATEGORY_REASONS = {
+    "A": "original backlink matches note date; current does not — mtime-drift corruption, restore original",
+    "B": "current backlink matches note date; original did not — historic repair was legitimate, keeping",
+    "C": "original and current backlinks are both same-day as the note — ambiguous, needs JSONL-window or human review",
+    "D": "neither original nor current backlink matches the note date — unresolved, needs human review",
+}
+
+_CATEGORY_SIGNALS = {
+    "A": "historic-restore",
+    "B": "historic-keep",
+    "C": "historic-ambiguous",
+    "D": "historic-both-wrong",
+}
+
+
+def _backup_root() -> Path:
+    override = os.environ.get("OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT")
+    if override:
+        return Path(override)
+    return Path.home() / ".claude" / "obsidian-brain-doctor-backup"
+
+
+def _parse_run_ts(dirname: str) -> float | None:
+    """Parse a backup-run dir name like ``2026-04-11T19-28-58+00-00`` to epoch.
+
+    Run dirs are written by the dispatcher as ``_iso_now().replace(":", "-")``,
+    so the first 19 chars are ``YYYY-MM-DDTHH-MM-SS`` in UTC. Anything that
+    doesn't parse is not a run dir and returns None.
+    """
+    try:
+        dt = datetime.strptime(dirname[:19], "%Y-%m-%dT%H-%M-%S")
+    except ValueError:
+        return None
+    return dt.replace(tzinfo=timezone.utc).timestamp()
+
+
+def _note_date(basename: str) -> str | None:
+    """Extract the YYYY-MM-DD prefix from a note basename, if present."""
+    m = _FILENAME_DATE_RE.match(basename)
+    return m.group(1) if m else None
+
+
+def _backlink_basename(fm: dict) -> str:
+    """Extract the bare basename from a ``source_session_note`` value.
+
+    Values look like ``[[2026-04-09-obsidian-brain-2381]]`` (quotes already
+    stripped by the frontmatter parser).
+    """
+    raw = fm.get("source_session_note", "")
+    return raw.strip().lstrip("[").rstrip("]").strip()
+
+
+def _candidate_folders(sessions_folder: str, insights_folder: str) -> list[str]:
+    return [insights_folder, *_EXTRA_INSIGHT_FOLDERS, sessions_folder]
+
+
+def _find_current_note(
+    vault: Path, basename: str, sessions_folder: str, insights_folder: str
+) -> Path | None:
+    for folder in _candidate_folders(sessions_folder, insights_folder):
+        candidate = vault / folder / basename
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _classify(file_date: str, orig_date: str | None, curr_date: str | None) -> str:
+    """Classify a historic repair by date agreement (see module docstring)."""
+    if orig_date is None or curr_date is None:
+        return "D"
+    orig_ok = orig_date == file_date
+    curr_ok = curr_date == file_date
+    if orig_ok and not curr_ok:
+        return "A"
+    if not orig_ok and curr_ok:
+        return "B"
+    if orig_ok and curr_ok:
+        return "C"
+    return "D"
+
+
+def scan(
+    vault_path: str,
+    sessions_folder: str,
+    insights_folder: str,
+    days: int,
+    project: str | None = None,
+) -> list[Issue]:
+    """Diff backed-up notes against current state and classify each repair."""
+    vault = Path(vault_path)
+    root = _backup_root()
+    if not root.is_dir():
+        return []
+
+    now = datetime.now(timezone.utc).timestamp()
+    cutoff = now - days * 86400
+
+    # basename -> (run_ts, backup_path); keep the OLDEST backup per note —
+    # it is the true pre-doctor original. Intermediate backups are
+    # vault-doctor iterations on vault-doctor.
+    oldest: dict[str, tuple[float, Path]] = {}
+    for run_dir in sorted(root.iterdir()):
+        if not run_dir.is_dir():
+            continue
+        run_ts = _parse_run_ts(run_dir.name)
+        if run_ts is None or run_ts < cutoff:
+            continue
+        for md in run_dir.rglob("*.md"):
+            # Skip this check's own restore backups — re-running the audit
+            # must not treat its own output as a historic repair.
+            if NAME in md.relative_to(run_dir).parts:
+                continue
+            existing = oldest.get(md.name)
+            if existing is None or run_ts < existing[0]:
+                oldest[md.name] = (run_ts, md)
+
+    issues: list[Issue] = []
+    for basename in sorted(oldest):
+        _, backup_path = oldest[basename]
+        current_path = _find_current_note(
+            vault, basename, sessions_folder, insights_folder
+        )
+        if current_path is None:
+            continue  # note deleted/renamed since — nothing to audit
+
+        try:
+            backup_text = backup_path.read_text(encoding="utf-8", errors="replace")
+            current_text = current_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        backup_fm = _parse_frontmatter(backup_text, source=str(backup_path))
+        current_fm = _parse_frontmatter(current_text, source=str(current_path))
+
+        orig_sid = backup_fm.get("source_session", "")
+        curr_sid = current_fm.get("source_session", "")
+        orig_note = _backlink_basename(backup_fm)
+        curr_note = _backlink_basename(current_fm)
+
+        # Not a source-sessions note (e.g. a session note backed up by the
+        # snapshot checks) — nothing to audit.
+        if not orig_sid and not orig_note:
+            continue
+
+        # No drift: the backlink was never rewritten (backup is from another
+        # check, or a restore already ran).
+        if orig_sid == curr_sid and orig_note == curr_note:
+            continue
+
+        note_project = current_fm.get("project", "unknown") or "unknown"
+        if project and note_project != project:
+            continue
+
+        file_date = _note_date(basename)
+        if file_date is None:
+            category = "D"
+        else:
+            category = _classify(file_date, _note_date(orig_note), _note_date(curr_note))
+
+        issues.append(Issue(
+            check=NAME,
+            note_path=str(current_path),
+            project=note_project,
+            current_source=f"[[{curr_note}]]" if curr_note else "(missing)",
+            proposed_source=f"[[{orig_note}]]" if category == "A" else "",
+            reason=f"category {category}: {_CATEGORY_REASONS[category]}",
+            confidence=0.9 if category == "A" else 0.0,
+            extra={
+                "category": category,
+                "signal_class": _CATEGORY_SIGNALS[category],
+                "unresolved": category != "A",
+                "orig_sid": orig_sid,
+                "orig_basename": orig_note,
+                "backup_path": str(backup_path),
+            },
+        ))
+
+    return issues
+
+
+def apply(issues: list[Issue], backup_root: str) -> list[Result]:
+    """Restore category-A notes to their original source_session backlink."""
+    results: list[Result] = []
+
+    for issue in issues:
+        if issue.extra.get("unresolved"):
+            results.append(Result(
+                check=NAME, note_path=issue.note_path, status="unresolved",
+            ))
+            continue
+
+        # Defense-in-depth (mirrors source_sessions.apply): only category A
+        # is auto-applyable. Anything else reaching this point is a
+        # programming error — fail loudly rather than writing the wrong fix.
+        category = issue.extra.get("category", "")
+        if category != "A":
+            raise RuntimeError(
+                f"apply() refuses category={category!r} for {issue.note_path}; "
+                f"only category A (historic-restore) is auto-applyable."
+            )
+
+        orig_sid = issue.extra.get("orig_sid", "")
+        orig_basename = issue.extra.get("orig_basename", "")
+        if not orig_sid or not orig_basename:
+            results.append(Result(
+                check=NAME, note_path=issue.note_path, status="error",
+                error="missing orig_sid or orig_basename in issue extra",
+            ))
+            continue
+
+        note_path = Path(issue.note_path)
+        try:
+            content = note_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            results.append(Result(
+                check=NAME, note_path=issue.note_path, status="error", error=str(exc),
+            ))
+            continue
+
+        # Backup the current state under a check-named subdir so re-running
+        # this tool is itself reversible.
+        source_folder = note_path.parent.name
+        backup_dir = Path(backup_root) / NAME / source_folder
+        try:
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            backup_path = backup_dir / note_path.name
+            shutil.copy2(note_path, backup_path)
+        except OSError as exc:
+            results.append(Result(
+                check=NAME, note_path=issue.note_path, status="error",
+                error=f"backup failed: {exc}",
+            ))
+            continue
+
+        try:
+            new_content = _rewrite_frontmatter(content, orig_sid, orig_basename)
+        except ValueError as exc:
+            results.append(Result(
+                check=NAME, note_path=issue.note_path, status="error", error=str(exc),
+            ))
+            continue
+
+        tmp = None
+        try:
+            fd, tmp = tempfile.mkstemp(
+                dir=str(note_path.parent), prefix=".vd-audithist-", suffix=".tmp",
+            )
+            try:
+                os.write(fd, new_content.encode("utf-8"))
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, str(note_path))
+            tmp = None  # consumed by os.replace
+        except OSError as exc:
+            results.append(Result(
+                check=NAME, note_path=issue.note_path, status="error", error=str(exc),
+            ))
+            continue
+        finally:
+            if tmp is not None:
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
+
+        results.append(Result(
+            check=NAME,
+            note_path=issue.note_path,
+            status="applied",
+            backup_path=str(backup_path),
+        ))
+
+    return results

--- a/scripts/vault_doctor_checks/audit_historic_repairs.py
+++ b/scripts/vault_doctor_checks/audit_historic_repairs.py
@@ -155,11 +155,26 @@ def scan(
     now = datetime.now(timezone.utc).timestamp()
     cutoff = now - days * 86400
 
-    # basename -> (run_ts, backup_path); keep the OLDEST backup per note —
-    # it is the true pre-doctor original. Intermediate backups are
-    # vault-doctor iterations on vault-doctor.
+    # Resolve each backup to its current note FIRST, then key `oldest` on the
+    # RESOLVED target path — not the bare basename. A bare-basename key would
+    # collapse cross-folder basename collisions (e.g. an insight and a
+    # decision both named 2026-04-10-foo.md) into one entry, silently
+    # dropping one note from the audit and potentially pairing a backup with
+    # the WRONG note (which apply() would then "restore" into an uncorrupted
+    # note). Modern backup runs nest each note under its source folder
+    # (<run>/<project>/<folder>/<basename>), so the backup's parent dir name
+    # is used as a folder hint when it matches a known note folder.
+    known_folders = set(_candidate_folders(sessions_folder, insights_folder))
+
+    # resolved target path (str) -> (run_ts, backup_path); the OLDEST run per
+    # target wins — it is the true pre-doctor original. Intermediate backups
+    # are vault-doctor iterations on vault-doctor.
     oldest: dict[str, tuple[float, Path]] = {}
-    skipped_old_runs = 0  # FIX 3: count run dirs excluded by --days cutoff
+    # Distinct backups whose current note cannot be found (deleted/renamed
+    # since). Tracked separately so the coverage summary still partitions the
+    # full audited population.
+    missing: set[str] = set()
+    skipped_old_runs = 0  # parseable run dirs excluded by the --days cutoff
     for run_dir in sorted(root.iterdir()):
         if not run_dir.is_dir():
             continue
@@ -167,18 +182,36 @@ def scan(
         if run_ts is None:
             continue
         if run_ts < cutoff:
-            skipped_old_runs += 1  # FIX 3: parseable but aged-out
+            skipped_old_runs += 1
             continue
         for md in run_dir.rglob("*.md"):
             # Skip this check's own restore backups — re-running the audit
             # must not treat its own output as a historic repair.
             if NAME in md.relative_to(run_dir).parts:
                 continue
-            existing = oldest.get(md.name)
+            folder_hint = md.parent.name if md.parent.name in known_folders else None
+            if folder_hint:
+                candidate = vault / folder_hint / md.name
+                target = candidate if candidate.is_file() else None
+            else:
+                # Legacy-layout backups (<run>/<project>/<basename>) carry no
+                # folder information; fall back to the ordered folder search.
+                # A cross-folder basename collision can still mis-resolve
+                # here — no folder info exists to disambiguate — but
+                # reachability is near-zero in practice.
+                target = _find_current_note(
+                    vault, md.name, sessions_folder, insights_folder
+                )
+            if target is None:
+                missing.add(f"{folder_hint or '?'}/{md.name}")
+                continue
+            key = str(target)
+            existing = oldest.get(key)
             if existing is None or run_ts < existing[0]:
-                oldest[md.name] = (run_ts, md)
+                oldest[key] = (run_ts, md)
 
-    # FIX 3: warn if aged-out run dirs were skipped
+    # The 'oldest backup wins' premise breaks if older runs were age-filtered
+    # out — surface that to the operator.
     if skipped_old_runs > 0:
         print(
             f"[audit-historic-repairs] WARNING: {skipped_old_runs} backup run(s) older than"
@@ -188,31 +221,27 @@ def scan(
         )
 
     issues: list[Issue] = []
-    # FIX 5: counters for end-of-scan coverage summary
-    missing_current = 0
+    # Counters for the end-of-scan coverage summary (every audited backup
+    # lands in exactly one bucket).
     non_source = 0
     no_drift = 0
     unreadable = 0
     project_filtered = 0
 
-    for basename in sorted(oldest):
-        _, backup_path = oldest[basename]
-        current_path = _find_current_note(
-            vault, basename, sessions_folder, insights_folder
-        )
-        if current_path is None:
-            missing_current += 1  # FIX 5
-            continue  # note deleted/renamed since — nothing to audit
+    for target in sorted(oldest):
+        _, backup_path = oldest[target]
+        current_path = Path(target)
+        basename = current_path.name
 
         try:
             backup_text = backup_path.read_text(encoding="utf-8", errors="replace")
             current_text = current_path.read_text(encoding="utf-8", errors="replace")
         except OSError as exc:
-            # FIX 2 / R2-1: don't silently drop unreadable notes. Emitted
-            # UNCONDITIONALLY — even with --project set — because an
-            # unreadable note cannot be attributed to a project, and the
-            # project filter must not suppress audit-infrastructure failures.
-            unreadable += 1  # FIX 5
+            # Don't silently drop unreadable notes. Emitted UNCONDITIONALLY —
+            # even with --project set — because an unreadable note cannot be
+            # attributed to a project, and the project filter must not
+            # suppress audit-infrastructure failures.
+            unreadable += 1
             issues.append(Issue(
                 check=NAME,
                 note_path=str(current_path),
@@ -246,7 +275,8 @@ def scan(
         # Not a source-sessions note (e.g. a session note backed up by the
         # snapshot checks) — nothing to audit.
         if not orig_sid and not orig_note:
-            # FIX 4: warn when backup has no source fields but current note does
+            # A backup without source fields whose CURRENT note has them is
+            # suspicious — the backup may be truncated/corrupted; warn.
             if curr_sid or curr_note:
                 print(
                     f"[audit-historic-repairs] WARNING: backup {backup_path} has no"
@@ -254,18 +284,18 @@ def scan(
                     f" backup may be corrupted; skipping.",
                     file=sys.stderr,
                 )
-            non_source += 1  # FIX 5
+            non_source += 1
             continue
 
         # No drift: the backlink was never rewritten (backup is from another
         # check, or a restore already ran).
         if orig_sid == curr_sid and orig_note == curr_note:
-            no_drift += 1  # FIX 5
+            no_drift += 1
             continue
 
         note_project = current_fm.get("project", "unknown") or "unknown"
         if project and note_project != project:
-            project_filtered += 1  # FIX 5
+            project_filtered += 1
             continue
 
         file_date = _note_date(basename)
@@ -274,8 +304,8 @@ def scan(
         else:
             category = _classify(file_date, _note_date(orig_note), _note_date(curr_note))
 
-        # FIX 6: category A without a complete source_session pair must not
-        # be auto-applyable — mark as unresolved so apply() never attempts it.
+        # Category A without a complete source_session pair must not be
+        # auto-applyable — mark as unresolved so apply() never attempts it.
         unresolved = category != "A"
         confidence = 0.9 if category == "A" else 0.0
         reason = f"category {category}: {_CATEGORY_REASONS[category]}"
@@ -305,14 +335,17 @@ def scan(
             },
         ))
 
-    # FIX 5 / R2-2: end-of-scan coverage summary. Buckets partition
-    # len(oldest): every unreadable note also appended an issue (R2-1), so
-    # subtract it from the classified count to avoid double-counting.
-    if oldest:
+    # End-of-scan coverage summary. The audited denominator is the resolved
+    # targets plus the distinct backups whose note no longer exists; the six
+    # buckets partition it exactly. Every unreadable note also appended an
+    # issue above, so subtract it from the classified count to avoid
+    # double-counting.
+    audited = len(oldest) + len(missing)
+    if audited:
         classified = len(issues) - unreadable
         print(
-            f"[audit-historic-repairs] audited {len(oldest)} backed-up note(s):"
-            f" {classified} classified, {missing_current} missing-current,"
+            f"[audit-historic-repairs] audited {audited} backed-up note(s):"
+            f" {classified} classified, {len(missing)} missing-current,"
             f" {non_source} non-source-session, {no_drift} no-drift,"
             f" {unreadable} unreadable, {project_filtered} project-filtered",
             file=sys.stderr,
@@ -372,8 +405,16 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
         try:
             backup_dir.mkdir(parents=True, exist_ok=True)
             backup_path = backup_dir / note_path.name
+            # Defense-in-depth (mirrors source_sessions.apply): the backup
+            # write must never escape backup_root via a hostile folder name.
+            resolved_root = Path(backup_root).resolve()
+            resolved_backup = backup_path.resolve()
+            if resolved_root not in resolved_backup.parents:
+                raise ValueError(
+                    f"backup path {backup_path} would escape backup_root {backup_root}"
+                )
             shutil.copy2(note_path, backup_path)
-        except OSError as exc:
+        except (OSError, ValueError) as exc:
             results.append(Result(
                 check=NAME, note_path=issue.note_path, status="error",
                 error=f"backup failed: {exc}",

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -18,6 +18,7 @@ Audit and repair the Obsidian vault. Ships with one check initially (`source-ses
 - `/vault-doctor --check source-sessions` — run one specific check
 - `/vault-doctor --check snapshot-integrity` — snapshot orphans, broken backlinks, stale/missing session snapshot lists, status/summary mismatches
 - `/vault-doctor --check snapshot-migration` — migrate pre-spec snapshots (legacy filenames, missing status/backlink fields, missing session snapshot lists). Runs 4 ordered sub-checks; idempotent.
+- `/vault-doctor --check audit-historic-repairs` — one-shot audit of historic source-sessions repairs: diffs doctor backups against current notes, classifies each repair (A restore / B keep / C ambiguous / D both-wrong) by date agreement, and restores category-A mtime-bug corruptions on `fix`. **Opt-in** — excluded from the default all-checks sweep; must be named via `--check`. `--days` bounds backup-run age (default 180).
 - `/vault-doctor --days 14` — override default window (default: 7 days)
 - `/vault-doctor --project obsidian-brain` — limit to one project
 - `/vault-doctor fix --check source-sessions --days 7` — combine flags

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -84,7 +84,7 @@ def test_cli_dry_run_reports_issues(tmp_path):
 
     script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
     result = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "10000",
          "--project", "proj1", "--json"],
         capture_output=True,
         text=True,
@@ -140,7 +140,7 @@ def test_cli_apply_with_yes(tmp_path):
 
     script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
     result = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "10000",
          "--project", "proj1", "--apply", "--yes"],
         capture_output=True,
         text=True,

--- a/tests/test_vault_doctor_audit_historic_repairs.py
+++ b/tests/test_vault_doctor_audit_historic_repairs.py
@@ -1,0 +1,279 @@
+"""Tests for the audit-historic-repairs vault_doctor check module (#95)."""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import vault_doctor_checks  # noqa: E402 (must follow sys.path setup)
+import vault_doctor_checks.audit_historic_repairs as ahr  # noqa: E402
+from vault_doctor_checks import Issue  # noqa: E402
+
+
+def _run_dirname(dt: datetime) -> str:
+    """Mirror the dispatcher's backup-run dir naming (ISO with ':' → '-')."""
+    return dt.strftime("%Y-%m-%dT%H-%M-%S") + "+00-00"
+
+
+def _days_ago(days: int) -> datetime:
+    return datetime.now(timezone.utc) - timedelta(days=days)
+
+
+def _insight_text(date: str, sid: str, backlink: str, project: str = "proj1") -> str:
+    return (
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: {date}\n"
+        f"source_session: {sid}\n"
+        f'source_session_note: "[[{backlink}]]"\n'
+        f"project: {project}\n"
+        f"---\n"
+        f"# Insight body\n"
+    )
+
+
+@pytest.fixture
+def audit_env(tmp_path, monkeypatch):
+    vault = tmp_path / "vault"
+    insights = vault / "claude-insights"
+    sessions = vault / "claude-sessions"
+    insights.mkdir(parents=True)
+    sessions.mkdir(parents=True)
+    backup_root = tmp_path / "doctor-backup"
+    backup_root.mkdir()
+    monkeypatch.setenv("OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT", str(backup_root))
+    return {
+        "vault": vault,
+        "insights": insights,
+        "sessions": sessions,
+        "backups": backup_root,
+    }
+
+
+def _seed(env, basename, run_dt, orig_sid, orig_link, curr_sid, curr_link,
+          project="proj1", write_current=True):
+    """Seed one backed-up note + its current vault state."""
+    date = basename[:10]
+    run_dir = env["backups"] / _run_dirname(run_dt) / project / "claude-insights"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / basename).write_text(
+        _insight_text(date, orig_sid, orig_link, project), encoding="utf-8")
+    if write_current:
+        (env["insights"] / basename).write_text(
+            _insight_text(date, curr_sid, curr_link, project), encoding="utf-8")
+
+
+def _scan(env, days=180, project=None):
+    return ahr.scan(str(env["vault"]), "claude-sessions", "claude-insights",
+                    days, project=project)
+
+
+# ---------------------------------------------------------------- categories
+
+def test_category_a_proposes_restore(audit_env):
+    _seed(audit_env, "2026-04-09-foo-1111.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",   # original: same-day (correct)
+          "sid-curr", "2026-04-10-proj1-bbbb")   # current: different-day (drift)
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    i = issues[0]
+    assert i.extra["category"] == "A"
+    assert i.extra["signal_class"] == "historic-restore"
+    assert i.extra["unresolved"] is False
+    assert i.confidence == 0.9
+    assert i.proposed_source == "[[2026-04-09-proj1-aaaa]]"
+    assert i.extra["orig_sid"] == "sid-orig"
+
+
+def test_category_b_keep(audit_env):
+    _seed(audit_env, "2026-04-09-foo-2222.md", _days_ago(30),
+          "sid-orig", "2026-04-08-proj1-aaaa",   # original: wrong-day
+          "sid-curr", "2026-04-09-proj1-bbbb")   # current: same-day (legit fix)
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    i = issues[0]
+    assert i.extra["category"] == "B"
+    assert i.extra["signal_class"] == "historic-keep"
+    assert i.extra["unresolved"] is True
+    assert i.confidence == 0.0
+    assert i.proposed_source == ""
+
+
+def test_category_c_ambiguous(audit_env):
+    _seed(audit_env, "2026-04-09-foo-3333.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",   # both same-day,
+          "sid-curr", "2026-04-09-proj1-bbbb")   # different sessions
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    assert issues[0].extra["category"] == "C"
+    assert issues[0].extra["unresolved"] is True
+
+
+def test_category_d_both_wrong(audit_env):
+    _seed(audit_env, "2026-04-09-foo-4444.md", _days_ago(30),
+          "sid-orig", "2026-04-07-proj1-aaaa",   # neither matches
+          "sid-curr", "2026-04-08-proj1-bbbb")   # the filename date
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    assert issues[0].extra["category"] == "D"
+    assert issues[0].extra["unresolved"] is True
+
+
+def test_unparsable_backlink_is_category_d(audit_env):
+    _seed(audit_env, "2026-04-09-foo-5555.md", _days_ago(30),
+          "sid-orig", "no-date-prefix-note",
+          "sid-curr", "2026-04-09-proj1-bbbb")
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    assert issues[0].extra["category"] == "D"
+
+
+# ------------------------------------------------------------------ skipping
+
+def test_no_drift_skipped(audit_env):
+    _seed(audit_env, "2026-04-09-foo-6666.md", _days_ago(30),
+          "sid-same", "2026-04-09-proj1-aaaa",
+          "sid-same", "2026-04-09-proj1-aaaa")
+    assert _scan(audit_env) == []
+
+
+def test_aged_run_skipped(audit_env):
+    _seed(audit_env, "2026-04-09-foo-7777.md", _days_ago(200),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-10-proj1-bbbb")
+    assert _scan(audit_env, days=180) == []
+    # ...but a wider window picks it up
+    assert len(_scan(audit_env, days=365)) == 1
+
+
+def test_missing_current_note_skipped(audit_env):
+    _seed(audit_env, "2026-04-09-foo-8888.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-10-proj1-bbbb", write_current=False)
+    assert _scan(audit_env) == []
+
+
+def test_non_source_session_backup_skipped(audit_env):
+    """Backups from other checks (e.g. session notes) have no source_session."""
+    basename = "2026-04-09-proj1-9999.md"
+    run_dir = audit_env["backups"] / _run_dirname(_days_ago(30)) / "snapshot-integrity"
+    run_dir.mkdir(parents=True)
+    text = "---\ntype: claude-session\ndate: 2026-04-09\nproject: proj1\n---\n# S\n"
+    (run_dir / basename).write_text(text, encoding="utf-8")
+    (audit_env["sessions"] / basename).write_text(text, encoding="utf-8")
+    assert _scan(audit_env) == []
+
+
+def test_own_output_dir_excluded(audit_env):
+    """Restore backups written by this check's own apply() are not re-audited."""
+    basename = "2026-04-09-foo-aaaa.md"
+    run_dir = (audit_env["backups"] / _run_dirname(_days_ago(5))
+               / "audit-historic-repairs" / "claude-insights")
+    run_dir.mkdir(parents=True)
+    (run_dir / basename).write_text(
+        _insight_text("2026-04-09", "sid-x", "2026-04-09-proj1-xxxx"),
+        encoding="utf-8")
+    (audit_env["insights"] / basename).write_text(
+        _insight_text("2026-04-09", "sid-y", "2026-04-10-proj1-yyyy"),
+        encoding="utf-8")
+    assert _scan(audit_env) == []
+
+
+def test_project_filter(audit_env):
+    _seed(audit_env, "2026-04-09-foo-bbbb.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-10-proj1-bbbb", project="proj1")
+    assert len(_scan(audit_env, project="proj1")) == 1
+    assert _scan(audit_env, project="other") == []
+
+
+def test_oldest_backup_wins(audit_env):
+    """With multiple runs touching the same note, the oldest is the original."""
+    basename = "2026-04-09-foo-cccc.md"
+    # Oldest run: true original (same-day → category A vs current)
+    _seed(audit_env, basename, _days_ago(60),
+          "sid-true-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-11-proj1-cccc")
+    # Newer run: intermediate doctor iteration (wrong-day)
+    run_dir = (audit_env["backups"] / _run_dirname(_days_ago(10))
+               / "proj1" / "claude-insights")
+    run_dir.mkdir(parents=True)
+    (run_dir / basename).write_text(
+        _insight_text("2026-04-09", "sid-intermediate", "2026-04-10-proj1-bbbb"),
+        encoding="utf-8")
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    assert issues[0].extra["orig_sid"] == "sid-true-orig"
+    assert issues[0].extra["category"] == "A"
+
+
+# --------------------------------------------------------------------- apply
+
+def test_apply_restores_category_a(audit_env, tmp_path):
+    _seed(audit_env, "2026-04-09-foo-dddd.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-10-proj1-bbbb")
+    issues = _scan(audit_env)
+    assert len(issues) == 1 and issues[0].extra["category"] == "A"
+
+    apply_root = tmp_path / "apply-backup"
+    results = ahr.apply(issues, str(apply_root))
+    assert len(results) == 1
+    assert results[0].status == "applied"
+
+    restored = (audit_env["insights"] / "2026-04-09-foo-dddd.md").read_text(
+        encoding="utf-8")
+    assert "source_session: sid-orig" in restored
+    assert 'source_session_note: "[[2026-04-09-proj1-aaaa]]"' in restored
+    assert "# Insight body" in restored  # body preserved
+
+    # Own backup written under a check-named nested dir (reversible restore)
+    backup = apply_root / ahr.NAME / "claude-insights" / "2026-04-09-foo-dddd.md"
+    assert backup.is_file()
+    assert "source_session: sid-curr" in backup.read_text(encoding="utf-8")
+
+    # Re-scan after restore: no drift remains
+    assert _scan(audit_env) == []
+
+
+def test_apply_skips_unresolved(audit_env, tmp_path):
+    _seed(audit_env, "2026-04-09-foo-eeee.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-09-proj1-bbbb")  # category C
+    issues = _scan(audit_env)
+    before = (audit_env["insights"] / "2026-04-09-foo-eeee.md").read_text(
+        encoding="utf-8")
+    results = ahr.apply(issues, str(tmp_path / "apply-backup"))
+    assert results[0].status == "unresolved"
+    after = (audit_env["insights"] / "2026-04-09-foo-eeee.md").read_text(
+        encoding="utf-8")
+    assert before == after
+
+
+def test_apply_refuses_non_a_resolvable(tmp_path):
+    """Defense-in-depth: a non-A issue marked resolvable is a programming error."""
+    bogus = Issue(
+        check=ahr.NAME, note_path=str(tmp_path / "x.md"), project="p",
+        current_source="[[c]]", proposed_source="[[o]]",
+        reason="bogus", confidence=0.9,
+        extra={"category": "C", "unresolved": False,
+               "orig_sid": "s", "orig_basename": "o"},
+    )
+    with pytest.raises(RuntimeError, match="refuses category"):
+        ahr.apply([bogus], str(tmp_path / "apply-backup"))
+
+
+# ------------------------------------------------------------------ registry
+
+def test_opt_in_excluded_from_default_sweep():
+    names = [m.NAME for m in vault_doctor_checks.all_checks()]
+    assert ahr.NAME not in names
+
+
+def test_opt_in_reachable_via_get_check():
+    mod = vault_doctor_checks.get_check(ahr.NAME)
+    assert mod is ahr

--- a/tests/test_vault_doctor_audit_historic_repairs.py
+++ b/tests/test_vault_doctor_audit_historic_repairs.py
@@ -1,6 +1,11 @@
 """Tests for the audit-historic-repairs vault_doctor check module (#95)."""
 
+import json
+import os
+import re
+import subprocess
 import sys
+import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -157,15 +162,35 @@ def test_missing_current_note_skipped(audit_env):
     assert _scan(audit_env) == []
 
 
-def test_non_source_session_backup_skipped(audit_env):
-    """Backups from other checks (e.g. session notes) have no source_session."""
+def test_non_source_session_backup_skipped(audit_env, capsys):
+    """T1(a): backup and current both lack source fields → no issues, no corrupt warning."""
     basename = "2026-04-09-proj1-9999.md"
     run_dir = audit_env["backups"] / _run_dirname(_days_ago(30)) / "snapshot-integrity"
     run_dir.mkdir(parents=True)
     text = "---\ntype: claude-session\ndate: 2026-04-09\nproject: proj1\n---\n# S\n"
     (run_dir / basename).write_text(text, encoding="utf-8")
     (audit_env["sessions"] / basename).write_text(text, encoding="utf-8")
-    assert _scan(audit_env) == []
+    issues = _scan(audit_env)
+    assert issues == []
+    _, err = capsys.readouterr()
+    assert "may be corrupted" not in err
+
+
+def test_corrupt_backup_warns(audit_env, capsys):
+    """T1(b): backup with NO frontmatter; current WITH source fields → no issues, stderr warns."""
+    basename = "2026-04-09-proj1-corrupt.md"
+    run_dir = audit_env["backups"] / _run_dirname(_days_ago(30)) / "snapshot-integrity"
+    run_dir.mkdir(parents=True)
+    # Backup has no frontmatter at all
+    (run_dir / basename).write_text("# just body\nsome content here\n", encoding="utf-8")
+    # Current note has both source fields
+    (audit_env["sessions"] / basename).write_text(
+        _insight_text("2026-04-09", "sid-curr", "2026-04-09-proj1-xxxx"),
+        encoding="utf-8")
+    issues = _scan(audit_env)
+    assert issues == []
+    _, err = capsys.readouterr()
+    assert "may be corrupted" in err
 
 
 def test_own_output_dir_excluded(audit_env):
@@ -277,3 +302,348 @@ def test_opt_in_excluded_from_default_sweep():
 def test_opt_in_reachable_via_get_check():
     mod = vault_doctor_checks.get_check(ahr.NAME)
     assert mod is ahr
+
+
+# ---------------------------------------------------------------- new tests (FIX 2-7 coverage)
+
+def test_sid_only_drift_detected(audit_env):
+    """T2: same source_session_note backlink (same-day) but different sids → 1 issue, cat C."""
+    _seed(audit_env, "2026-04-09-foo-t2t2.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",  # same-day backlink
+          "sid-curr", "2026-04-09-proj1-aaaa")   # same backlink, different sid
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    assert issues[0].extra["category"] == "C"
+
+
+def test_backlink_only_drift_detected(audit_env):
+    """T3: same sid both sides; orig backlink same-day, curr different-day → cat A, not unresolved."""
+    _seed(audit_env, "2026-04-09-foo-t3t3.md", _days_ago(30),
+          "sid-same", "2026-04-09-proj1-aaaa",  # orig: same-day backlink
+          "sid-same", "2026-04-10-proj1-bbbb")   # curr: different-day (drift)
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    i = issues[0]
+    assert i.extra["category"] == "A"
+    assert i.extra["unresolved"] is False
+
+
+def test_category_a_without_orig_sid_is_unresolved(audit_env):
+    """T4 (FIX 6): backup has source_session_note (same-day) but NO source_session → cat A, unresolved."""
+    basename = "2026-04-09-foo-t4t4.md"
+    date = "2026-04-09"
+    run_dir = audit_env["backups"] / _run_dirname(_days_ago(30)) / "proj1" / "claude-insights"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    # Backup: has source_session_note (same-day) but NO source_session field
+    backup_text = (
+        f"---\n"
+        f"type: claude-insight\n"
+        f"date: {date}\n"
+        f'source_session_note: "[[{date}-proj1-aaaa]]"\n'
+        f"project: proj1\n"
+        f"---\n"
+        f"# body\n"
+    )
+    (run_dir / basename).write_text(backup_text, encoding="utf-8")
+    # Current note has both fields, but backlink is different-day (drift)
+    (audit_env["insights"] / basename).write_text(
+        _insight_text(date, "sid-curr", "2026-04-10-proj1-bbbb"),
+        encoding="utf-8")
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    i = issues[0]
+    assert i.extra["category"] == "A"
+    assert i.extra["unresolved"] is True
+    assert i.confidence == 0.0
+
+
+def test_cli_end_to_end_scan_apply_rescan(tmp_path):
+    """T5: subprocess test for full scan → apply → rescan lifecycle."""
+    # --- Build vault ---
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+
+    backup_root = tmp_path / ".claude" / "obsidian-brain-doctor-backup"
+    backup_root.mkdir(parents=True)
+
+    # Seed a category-A fixture in a run INSIDE the backup_root
+    basename = "2026-04-09-proj1-t5t5.md"
+    date = "2026-04-09"
+    run_dir = backup_root / _run_dirname(_days_ago(30)) / "proj1" / "claude-insights"
+    run_dir.mkdir(parents=True)
+    (run_dir / basename).write_text(
+        _insight_text(date, "sid-orig-t5", "2026-04-09-proj1-t5orig"),
+        encoding="utf-8")
+    # Current note: drifted (different-day backlink)
+    (vault / "claude-insights" / basename).write_text(
+        _insight_text(date, "sid-curr-t5", "2026-04-10-proj1-t5curr"),
+        encoding="utf-8")
+
+    script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
+    env = {
+        "HOME": str(tmp_path),
+        "OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT": str(backup_root),
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+    }
+
+    # Step 1: scan with --check → exit 1; 1 issue with signal_class historic-restore; no "extra" top-level key
+    r = subprocess.run(
+        [sys.executable, str(script),
+         "--check", "audit-historic-repairs",
+         "--json",
+         "--vault", str(vault),
+         "--sessions-folder", "claude-sessions",
+         "--insights-folder", "claude-insights"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 1, f"step1 exit: expected 1, got {r.returncode}:\n{r.stderr}"
+    payload = json.loads(r.stdout)
+    assert payload["total_issues"] == 1
+    row = payload["issues"][0]
+    assert row["signal_class"] == "historic-restore"
+    assert "extra" not in row
+
+    # Step 2: full sweep (no --check) → OPT_IN exclusion, no audit-historic-repairs rows
+    r2 = subprocess.run(
+        [sys.executable, str(script),
+         "--json",
+         "--vault", str(vault),
+         "--sessions-folder", "claude-sessions",
+         "--insights-folder", "claude-insights"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r2.returncode in (0, 1), r2.stderr
+    p2 = json.loads(r2.stdout)
+    for row2 in p2.get("issues", []):
+        assert row2.get("check") != "audit-historic-repairs", \
+            "OPT_IN check must not appear in default sweep"
+
+    # Step 3: apply with --yes → exit 1; note content restored
+    r3 = subprocess.run(
+        [sys.executable, str(script),
+         "--check", "audit-historic-repairs",
+         "--apply", "--yes",
+         "--vault", str(vault),
+         "--sessions-folder", "claude-sessions",
+         "--insights-folder", "claude-insights"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r3.returncode in (0, 1), f"step3 exit: got {r3.returncode}:\n{r3.stderr}"
+    restored = (vault / "claude-insights" / basename).read_text(encoding="utf-8")
+    assert "source_session: sid-orig-t5" in restored
+    assert "2026-04-09-proj1-t5orig" in restored
+
+    # Step 4: rescan → clean (exit 0); own restore backups under audit-historic-repairs/ not re-audited
+    r4 = subprocess.run(
+        [sys.executable, str(script),
+         "--check", "audit-historic-repairs",
+         "--json",
+         "--vault", str(vault),
+         "--sessions-folder", "claude-sessions",
+         "--insights-folder", "claude-insights"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r4.returncode == 0, f"step4 exit: expected 0 (clean), got {r4.returncode}:\n{r4.stderr}"
+
+
+def test_apply_errors_on_frontmatterless_note(tmp_path):
+    """T6: category-A Issue whose note_path has no frontmatter → error result, file unchanged."""
+    note = tmp_path / "2026-04-09-proj1-t6t6.md"
+    note.write_text("# just body\nno frontmatter here\n", encoding="utf-8")
+    original = note.read_text(encoding="utf-8")
+
+    issue = Issue(
+        check=ahr.NAME,
+        note_path=str(note),
+        project="proj1",
+        current_source="[[2026-04-10-proj1-curr]]",
+        proposed_source="[[2026-04-09-proj1-orig]]",
+        reason="category A: ...",
+        confidence=0.9,
+        extra={
+            "category": "A",
+            "signal_class": "historic-restore",
+            "unresolved": False,
+            "orig_sid": "sid-orig-t6",
+            "orig_basename": "2026-04-09-proj1-orig",
+            "backup_path": str(tmp_path / "backup.md"),
+        },
+    )
+    apply_root = tmp_path / "apply-backup"
+    results = ahr.apply([issue], str(apply_root))
+    assert len(results) == 1
+    r = results[0]
+    assert r.status == "error"
+    assert "frontmatter" in r.error.lower()
+    assert note.read_text(encoding="utf-8") == original  # file unchanged
+    # backup file should exist (written before the rewrite attempt)
+    backup = apply_root / ahr.NAME / note.parent.name / note.name
+    assert backup.is_file()
+
+
+def test_dateless_note_basename_is_category_d(audit_env):
+    """T7: backed-up note with no date prefix and drift → 1 issue, category D."""
+    basename = "nodate-note.md"
+    run_dir = audit_env["backups"] / _run_dirname(_days_ago(30)) / "proj1" / "claude-insights"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / basename).write_text(
+        "---\ntype: claude-insight\ndate: 2026-04-09\n"
+        "source_session: sid-orig\n"
+        'source_session_note: "[[2026-04-09-proj1-orig]]"\n'
+        "project: proj1\n---\n# body\n",
+        encoding="utf-8")
+    (audit_env["insights"] / basename).write_text(
+        "---\ntype: claude-insight\ndate: 2026-04-09\n"
+        "source_session: sid-curr\n"
+        'source_session_note: "[[2026-04-10-proj1-curr]]"\n'
+        "project: proj1\n---\n# body\n",
+        encoding="utf-8")
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    assert issues[0].extra["category"] == "D"
+
+
+def test_missing_current_backlink_renders_missing(audit_env):
+    """T8: current note has source_session but NO source_session_note → current_source == '(missing)', cat D."""
+    basename = "2026-04-09-foo-t8t8.md"
+    date = "2026-04-09"
+    run_dir = audit_env["backups"] / _run_dirname(_days_ago(30)) / "proj1" / "claude-insights"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    # Backup has both fields
+    (run_dir / basename).write_text(
+        _insight_text(date, "sid-orig", "2026-04-09-proj1-orig"),
+        encoding="utf-8")
+    # Current note has source_session but NO source_session_note
+    (audit_env["insights"] / basename).write_text(
+        f"---\ntype: claude-insight\ndate: {date}\n"
+        f"source_session: sid-curr\n"
+        f"project: proj1\n---\n# body\n",
+        encoding="utf-8")
+    issues = _scan(audit_env)
+    assert len(issues) == 1
+    i = issues[0]
+    assert i.current_source == "(missing)"
+    assert i.extra["category"] == "D"
+
+
+def test_excluded_old_run_warns(audit_env, capsys):
+    """T9: only aged-out run (200 days old), scan days=180 → no issues, warns about older runs."""
+    _seed(audit_env, "2026-04-09-foo-t9t9.md", _days_ago(200),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-10-proj1-bbbb")
+    issues = _scan(audit_env, days=180)
+    assert issues == []
+    _, err = capsys.readouterr()
+    assert "older than --days=180" in err
+
+
+def test_scan_emits_coverage_summary(audit_env, capsys):
+    """T10: any seeded fixture → stderr contains 'audited' and 'classified'."""
+    _seed(audit_env, "2026-04-09-foo-t10.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-10-proj1-bbbb")
+    _scan(audit_env)
+    _, err = capsys.readouterr()
+    assert "audited" in err
+    assert "classified" in err
+
+
+def test_opt_in_non_bool_raises():
+    """T11 (FIX 7): OPT_IN with a non-bool value raises TypeError from all_checks()."""
+    fake_mod = types.SimpleNamespace(
+        NAME="fake-optin",
+        scan=lambda *a, **kw: [],
+        apply=lambda *a, **kw: [],
+        OPT_IN="true",  # string, not bool
+    )
+    vault_doctor_checks._discover()  # ensure _CHECKS is populated
+    original = vault_doctor_checks._CHECKS.copy()
+    try:
+        vault_doctor_checks._CHECKS["fake-optin"] = fake_mod
+        with pytest.raises(TypeError, match="OPT_IN must be bool"):
+            vault_doctor_checks.all_checks()
+    finally:
+        vault_doctor_checks._CHECKS.clear()
+        vault_doctor_checks._CHECKS.update(original)
+
+
+# ------------------------------------------------------- round-2: unreadable path (R2-1/R2-2)
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+def test_unreadable_note_emits_unresolved_issue(audit_env):
+    """R2-4(a): unreadable current note → unresolved historic-unreadable issue (project=None)."""
+    basename = "2026-04-09-foo-r2a.md"
+    _seed(audit_env, basename, _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-10-proj1-bbbb")
+    current = audit_env["insights"] / basename
+    current.chmod(0o000)
+    try:
+        issues = _scan(audit_env)
+    finally:
+        current.chmod(0o600)  # restore so tmp_path cleanup works everywhere
+    assert len(issues) == 1
+    i = issues[0]
+    assert i.extra["signal_class"] == "historic-unreadable"
+    assert i.extra["unresolved"] is True
+    assert i.project == "unknown"
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+def test_unreadable_note_emitted_under_project_filter(audit_env):
+    """R2-4(b): with --project set, the unreadable issue is STILL emitted (R2-1)."""
+    basename = "2026-04-09-foo-r2b.md"
+    _seed(audit_env, basename, _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-10-proj1-bbbb")
+    current = audit_env["insights"] / basename
+    current.chmod(0o000)
+    try:
+        issues = _scan(audit_env, project="proj1")
+    finally:
+        current.chmod(0o600)
+    assert len(issues) == 1
+    assert issues[0].extra["signal_class"] == "historic-unreadable"
+    assert issues[0].extra["unresolved"] is True
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+def test_coverage_summary_partitions(audit_env, capsys):
+    """R2-4(c): summary buckets partition the audited count; classified excludes unreadable."""
+    # 1 classified (category A)
+    _seed(audit_env, "2026-04-09-foo-r2c1.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-aaaa",
+          "sid-curr", "2026-04-10-proj1-bbbb")
+    # 1 unreadable
+    _seed(audit_env, "2026-04-09-foo-r2c2.md", _days_ago(30),
+          "sid-orig", "2026-04-09-proj1-cccc",
+          "sid-curr", "2026-04-10-proj1-dddd")
+    unreadable_note = audit_env["insights"] / "2026-04-09-foo-r2c2.md"
+    unreadable_note.chmod(0o000)
+    # 1 no-drift
+    _seed(audit_env, "2026-04-09-foo-r2c3.md", _days_ago(30),
+          "sid-same", "2026-04-09-proj1-eeee",
+          "sid-same", "2026-04-09-proj1-eeee")
+    try:
+        issues = _scan(audit_env)
+    finally:
+        unreadable_note.chmod(0o600)
+    # issues: 1 classified + 1 unreadable
+    assert len(issues) == 2
+
+    _, err = capsys.readouterr()
+    m = re.search(
+        r"audited (\d+) backed-up note\(s\): (\d+) classified, (\d+) missing-current,"
+        r" (\d+) non-source-session, (\d+) no-drift, (\d+) unreadable,"
+        r" (\d+) project-filtered",
+        err,
+    )
+    assert m, f"summary line not found in stderr:\n{err}"
+    audited, classified, missing, non_src, no_drift, unreadable, proj_filt = map(
+        int, m.groups())
+    assert audited == 3
+    assert classified == 1
+    assert unreadable == 1
+    assert no_drift == 1
+    assert classified + missing + non_src + no_drift + unreadable + proj_filt == audited

--- a/tests/test_vault_doctor_audit_historic_repairs.py
+++ b/tests/test_vault_doctor_audit_historic_repairs.py
@@ -304,7 +304,7 @@ def test_opt_in_reachable_via_get_check():
     assert mod is ahr
 
 
-# ---------------------------------------------------------------- new tests (FIX 2-7 coverage)
+# ------------------------------------- drift variants, CLI e2e, apply errors
 
 def test_sid_only_drift_detected(audit_env):
     """T2: same source_session_note backlink (same-day) but different sids → 1 issue, cat C."""
@@ -329,7 +329,7 @@ def test_backlink_only_drift_detected(audit_env):
 
 
 def test_category_a_without_orig_sid_is_unresolved(audit_env):
-    """T4 (FIX 6): backup has source_session_note (same-day) but NO source_session → cat A, unresolved."""
+    """T4: backup has source_session_note (same-day) but NO source_session → cat A, unresolved (no restore data)."""
     basename = "2026-04-09-foo-t4t4.md"
     date = "2026-04-09"
     run_dir = audit_env["backups"] / _run_dirname(_days_ago(30)) / "proj1" / "claude-insights"
@@ -550,7 +550,7 @@ def test_scan_emits_coverage_summary(audit_env, capsys):
 
 
 def test_opt_in_non_bool_raises():
-    """T11 (FIX 7): OPT_IN with a non-bool value raises TypeError from all_checks()."""
+    """T11: OPT_IN with a non-bool value raises TypeError from all_checks()."""
     fake_mod = types.SimpleNamespace(
         NAME="fake-optin",
         scan=lambda *a, **kw: [],
@@ -568,11 +568,11 @@ def test_opt_in_non_bool_raises():
         vault_doctor_checks._CHECKS.update(original)
 
 
-# ------------------------------------------------------- round-2: unreadable path (R2-1/R2-2)
+# ------------------------------------------- unreadable notes + coverage summary
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
 def test_unreadable_note_emits_unresolved_issue(audit_env):
-    """R2-4(a): unreadable current note → unresolved historic-unreadable issue (project=None)."""
+    """Unreadable current note → unresolved historic-unreadable issue (project=None)."""
     basename = "2026-04-09-foo-r2a.md"
     _seed(audit_env, basename, _days_ago(30),
           "sid-orig", "2026-04-09-proj1-aaaa",
@@ -592,7 +592,7 @@ def test_unreadable_note_emits_unresolved_issue(audit_env):
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
 def test_unreadable_note_emitted_under_project_filter(audit_env):
-    """R2-4(b): with --project set, the unreadable issue is STILL emitted (R2-1)."""
+    """With --project set, the unreadable issue is STILL emitted — the filter must not hide audit failures."""
     basename = "2026-04-09-foo-r2b.md"
     _seed(audit_env, basename, _days_ago(30),
           "sid-orig", "2026-04-09-proj1-aaaa",
@@ -610,7 +610,7 @@ def test_unreadable_note_emitted_under_project_filter(audit_env):
 
 @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
 def test_coverage_summary_partitions(audit_env, capsys):
-    """R2-4(c): summary buckets partition the audited count; classified excludes unreadable."""
+    """Summary buckets partition the audited count; classified excludes unreadable."""
     # 1 classified (category A)
     _seed(audit_env, "2026-04-09-foo-r2c1.md", _days_ago(30),
           "sid-orig", "2026-04-09-proj1-aaaa",
@@ -647,3 +647,53 @@ def test_coverage_summary_partitions(audit_env, capsys):
     assert unreadable == 1
     assert no_drift == 1
     assert classified + missing + non_src + no_drift + unreadable + proj_filt == audited
+
+
+# --------------------------------------------- cross-folder basename collisions
+
+def test_cross_folder_collision_pairs_correctly(audit_env):
+    """Same basename in two note folders → two independent audit entries,
+    each backup paired with the note in ITS OWN folder (never the other's)."""
+    basename = "2026-04-09-foo-coll.md"
+    date = "2026-04-09"
+    decisions = audit_env["vault"] / "claude-decisions"
+    decisions.mkdir()
+
+    # Current notes: same basename in claude-insights AND claude-decisions,
+    # both drifted (different-day backlinks).
+    (audit_env["insights"] / basename).write_text(
+        _insight_text(date, "sid-curr-ins", "2026-04-10-proj1-ins-curr"),
+        encoding="utf-8")
+    (decisions / basename).write_text(
+        _insight_text(date, "sid-curr-dec", "2026-04-11-proj1-dec-curr"),
+        encoding="utf-8")
+
+    # One backup run with a folder-qualified backup under EACH folder dir,
+    # both same-day originals (category A) with distinct orig sids.
+    run_root = audit_env["backups"] / _run_dirname(_days_ago(30)) / "proj1"
+    for folder, orig_sid, orig_link in (
+        ("claude-insights", "sid-orig-ins", "2026-04-09-proj1-ins-orig"),
+        ("claude-decisions", "sid-orig-dec", "2026-04-09-proj1-dec-orig"),
+    ):
+        bdir = run_root / folder
+        bdir.mkdir(parents=True, exist_ok=True)
+        (bdir / basename).write_text(
+            _insight_text(date, orig_sid, orig_link), encoding="utf-8")
+
+    issues = _scan(audit_env)
+    assert len(issues) == 2, [i.note_path for i in issues]
+
+    expected_orig_sid = {
+        "claude-insights": "sid-orig-ins",
+        "claude-decisions": "sid-orig-dec",
+    }
+    seen_folders = set()
+    for i in issues:
+        note_folder = Path(i.note_path).parent.name
+        backup_folder = Path(i.extra["backup_path"]).parent.name
+        assert note_folder == backup_folder, \
+            f"backup from {backup_folder} paired with note in {note_folder}"
+        assert i.extra["orig_sid"] == expected_orig_sid[note_folder]
+        assert i.extra["category"] == "A"
+        seen_folders.add(note_folder)
+    assert seen_folders == {"claude-insights", "claude-decisions"}

--- a/tests/test_vault_doctor_integration.py
+++ b/tests/test_vault_doctor_integration.py
@@ -85,7 +85,7 @@ def test_end_to_end_scan_apply_verify(tmp_path):
 
     # --- 1. Dry-run → exit 1, file untouched ---
     r = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "10000",
          "--project", "proj1", "--json"],
         capture_output=True, text=True, env=env,
     )
@@ -98,7 +98,7 @@ def test_end_to_end_scan_apply_verify(tmp_path):
 
     # --- 2. Apply with --yes (non-interactive) ---
     r = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "10000",
          "--project", "proj1", "--apply", "--yes"],
         capture_output=True, text=True, env=env,
     )
@@ -124,7 +124,7 @@ def test_end_to_end_scan_apply_verify(tmp_path):
 
     # --- 4. Re-scan → exit 0 (clean) ---
     r = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "10000",
          "--project", "proj1", "--json"],
         capture_output=True, text=True, env=env,
     )
@@ -208,7 +208,7 @@ def test_json_payload_has_top_level_signal_and_convergence_keys(tmp_path):
 
     script = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
     r = subprocess.run(
-        [sys.executable, str(script), "--check", "source-sessions", "--days", "60",
+        [sys.executable, str(script), "--check", "source-sessions", "--days", "10000",
          "--project", "convproj", "--json"],
         capture_output=True, text=True, env=env,
     )

--- a/tests/test_vault_doctor_source_sessions.py
+++ b/tests/test_vault_doctor_source_sessions.py
@@ -106,7 +106,7 @@ def test_scan_ignores_correct_insight(doctor_vault, monkeypatch):
         a_start + 1800,
     )
 
-    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=60, project="proj1")
+    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=10000, project="proj1")
     assert issues == []
 
 
@@ -169,7 +169,7 @@ def test_scan_marks_unresolved_when_no_window_matches(doctor_vault, monkeypatch)
         gap_mtime,
     )
 
-    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=60, project="proj1")
+    issues = check.scan(str(v), "claude-sessions", "claude-insights", days=10000, project="proj1")
     assert len(issues) == 1, f"expected exactly 1 unresolved issue, got {len(issues)}"
     iss = issues[0]
     assert iss.extra.get("unresolved") is True
@@ -234,7 +234,7 @@ def test_apply_rewrites_only_source_session_fields(doctor_vault, tmp_path, monke
     original_body = original_text.split("---\n", 2)[-1]
 
     issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
+        str(v), "claude-sessions", "claude-insights", days=10000, project="proj1"
     )
     assert len(issues) == 1, f"expected 1 issue, got {len(issues)}"
 
@@ -413,7 +413,7 @@ def test_scan_latest_start_wins_on_boundary_tie(doctor_vault, monkeypatch):
     os.utime(insight_path, (insight_mtime, insight_mtime))  # restore mtime after write
 
     issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
+        str(v), "claude-sessions", "claude-insights", days=10000, project="proj1"
     )
     assert len(issues) == 1
     # Latest first_ts wins: sid-b (started at 14:00) beats sid-a (started at 10:00)
@@ -515,7 +515,7 @@ def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
     )
 
     issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
+        str(v), "claude-sessions", "claude-insights", days=10000, project="proj1"
     )
     assert len(issues) == 1
 
@@ -533,7 +533,7 @@ def test_apply_preserves_note_mtime(doctor_vault, tmp_path, monkeypatch):
     # And a re-scan with the patched note should find nothing (proves the
     # self-reinforcing bug is not reintroduced)
     rescan_issues = check.scan(
-        str(v), "claude-sessions", "claude-insights", days=60, project="proj1"
+        str(v), "claude-sessions", "claude-insights", days=10000, project="proj1"
     )
     assert rescan_issues == [], f"re-scan should be clean, got: {rescan_issues}"
 


### PR DESCRIPTION
## Summary

Implements the one-shot `audit-historic-repairs` vault-doctor check (#95): walks the doctor backup runs under `~/.claude/obsidian-brain-doctor-backup/`, diffs each backed-up note's `source_session`/`source_session_note` against the note's current state (oldest backup = true pre-doctor original), and classifies every historic repair by date agreement:

| Category | Meaning | Action |
|---|---|---|
| A `historic-restore` | original backlink matched the note date; current doesn't | restore on `fix` (conf 0.9) |
| B `historic-keep` | current matches; original didn't | report only — legit fix |
| C `historic-ambiguous` | both same-day, different sessions | report only — human review |
| D `historic-both-wrong` | neither matches | report only — human review |

Design points (per issue spec):
- **Folder-qualified pairing**: backups resolve to their target note via the backup layout's folder dir (legacy project-layout backups fall back to ordered search); the oldest-backup index is keyed on the resolved target, so cross-folder basename collisions audit independently.
- **Own restores are reversible**: apply() backs up under `<run>/audit-historic-repairs/<folder>/` (with the repo's containment guard), and scan() excludes that subtree — post-restore re-scan is clean (convergence covered by a CLI e2e test).
- **Opt-in registry attribute** (`OPT_IN = True`, validated bool): never runs in the default all-checks sweep; run via `--check audit-historic-repairs`. `--days` bounds backup-run age (default 180) and warns when older runs are excluded.
- **Loud audit semantics**: unreadable notes emit unresolved `historic-unreadable` rows (visible to `--json` in every invocation mode); suspicious empty-frontmatter backups warn; an end-of-scan coverage summary partitions every audited backup into exactly one bucket; the dispatcher now prints each error Result's detail.
- Category-A rows lacking a complete original sid/backlink pair are forced unresolved; apply() refuses non-A categories loudly.

Also fixes #205 (standalone commit): 12 test call sites scanned hardcoded April-2026 fixtures with 60-day windows and started failing 2026-06-09 when the fixtures aged out; widened to the established `days=10000` convention.

## Deep review (converged)

- **Phase 1** (3 reviewers × 3 rounds): 1 critical + 8 important fixed (dispatcher error-detail printing, silent-skip paths, vacuous test, single-field-drift coverage, CLI e2e crash-masking, scan-reachable apply error). All dimensions CONVERGED in the same round; new guards proven fail-first.
- **Phase 2** (Claude↔Gemini adversarial, 3 rounds): 4 survivors cross-confirmed and fixed (folder-qualified pairing, backup containment check, OPT_IN docstring, comment hygiene). Gemini's TOCTOU finding was refuted with evidence and conceded (single-user HOME tree, established sibling pattern). One judgment call left open: shared `INDEFINITE_DAYS_WINDOW` test constant vs the existing bare-literal convention (not adopted; noted for maintainers).

## Dogfood (live vault, dry-run)

63 historic repairs classified: **A=13, B=20, C=29, D=1** (stable across pre/post-hardening runs). All three category-A samples named in #95 surface with correct restore proposals. Coverage partition verified: 128 audited = 63 classified + 7 missing-current + 58 non-source-session. Restores remain opt-in via `fix --check audit-historic-repairs`.

## Tests

32 tests in the new file (categories, single-field drift, window aging + exclusion warning, oldest-backup-wins, cross-folder collision pairing, own-output exclusion, unreadable paths, summary partition, apply/backup/atomicity/containment, CLI e2e scan→apply→re-scan convergence, OPT_IN registry gating + bool validation). Full suite: 1360 passed.

Closes #95
Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
