### PR TITLE
fix(vault-doctor): combined deep-review of epic #170 — cross-PR interaction fixes (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the default all-checks sweep via the new registry `OPT_IN` attribute.
 
 ### Fixed
+- **Reconstructable session-coverage gaps now carry confidence 0.9 (#215)** —
+  `vault-doctor --check session-coverage --reconstruct` previously emitted every
+  gap with `confidence=0.0`, so any `--min-confidence` threshold > 0 silently
+  nullified `--reconstruct` (the gaps were filtered out before apply). Resolvable
+  gaps (reconstruct mode) now carry `confidence=0.9`, consistent with other
+  applyable repairs (canonicalization proposals, audit category-A restores);
+  unresolved gaps keep `0.0`. The `--min-confidence` help text was updated to
+  match.
+- **`audit-historic-repairs` is no longer silent on a missing/empty backup root
+  (#215)** — a nonexistent backup root now prints a stderr notice
+  (`backup root <path> not found — no doctor backups to audit (no-op, not a
+  clean bill of health)`), and the end-of-scan coverage summary prints
+  unconditionally, so an empty audit shows `audited 0 backed-up note(s)`
+  instead of nothing.
+- **Per-check crash containment in the `vault_doctor` dispatcher (#215)** — a
+  check whose `scan()` or `apply()` raises no longer takes down the whole run.
+  The crash is printed to stderr with a full traceback, the check is recorded
+  in a new `crashed_checks` JSON key (present only when non-empty) and in the
+  human report header, and the remaining checks still run and report. A run
+  with crashed checks always exits 2; with 0 issues it prints
+  `vault_doctor: 0 issues, but N check(s) crashed — results incomplete`
+  instead of the plain clean line. An `apply()` crash additionally warns that
+  some fixes may already be applied (pointing at the backup root).
+- **`--min-confidence` drop attribution by signal class (#215)** — dropped
+  issues that carry a `signal_class` (e.g. the audit's `historic-keep` /
+  `historic-unreadable` infrastructure rows) are now broken out per class in
+  the human header (`; by class: audit-historic-repairs: 1 historic-keep,
+  1 historic-unreadable`) and in a new conditional `dropped_per_signal_class`
+  JSON key, so filtered-out infrastructure failures stay visible. Attribution
+  only — no filter exemption.
+- **Unconditional end-of-scan summaries (#215)** — `session-coverage` and
+  `project-name-canonicalization` now print their end-of-scan summary lines
+  even when nothing was scanned (zero counts visible); a silent scan was
+  indistinguishable from a scan that never ran. The check registry also warns
+  on stderr when a module loads but does not expose the check interface,
+  instead of silently skipping it.
 - **`vault-doctor source-sessions` skips imported notes (#104)** — notes carrying
   `imported: true` in frontmatter OR a `claude/imported` list item under the
   `tags:` key are now silently skipped by the source-sessions check (the tag

--- a/scripts/dev-test/test-issue-106-fixture.py
+++ b/scripts/dev-test/test-issue-106-fixture.py
@@ -16,7 +16,7 @@ subprocess, and asserts the full taxonomy invariants.
 # Spec-vs-current-code reconciliations (PRs #103 + #104, post-issue-#106):
 #
 # 1. (#103) --min-confidence flag added. Not tested here (covered by unit
-#    tests). The script passes --days=36500 (100 years) to avoid the cutoff
+#    tests). The script passes --days=10000 (wide window) to avoid the cutoff
 #    window filtering out fixture notes.
 #
 # 2. (#104) Imported notes are skipped. The fixture does NOT seed imported
@@ -334,7 +334,7 @@ def run_doctor(*extra_args: str) -> subprocess.CompletedProcess:
             "--vault", str(VAULT),
             "--sessions-folder", "claude-sessions",
             "--insights-folder", "claude-insights",
-            "--days", "36500",   # 100 years — never filters by cutoff
+            "--days", "10000",   # wide window — never filters by cutoff
             "--json",
             *extra_args,
         ],

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -15,7 +15,9 @@ Config priority:
 Exit codes:
   0 — clean, no issues
   1 — issues found (dry-run or successful apply)
-  2 — apply errors (one or more fixes failed)
+  2 — apply errors, or one or more checks crashed (scan or apply;
+      results incomplete — see crashed_checks in --json / "CHECK CRASHED"
+      on stderr)
   3 — usage error (bad args, no config)
 """
 
@@ -26,6 +28,7 @@ import json
 import math
 import os
 import sys
+import traceback
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -141,7 +144,10 @@ def _build_parser() -> argparse.ArgumentParser:
             "Applies to both the dry-run report and --apply — the preview always "
             "matches the apply scope. "
             "Note: unresolved issues have confidence=0.0 and are filtered out "
-            "when threshold > 0.0, since their proposed repair is unknown."
+            "when threshold > 0.0, since their proposed repair is unknown. "
+            "Reconstructable session-coverage gaps (--reconstruct) are "
+            "resolvable and carry confidence=0.9, so they survive thresholds "
+            "up to 0.9."
         ),
     )
     return p
@@ -200,8 +206,11 @@ def _confidence_passes(issue, threshold: float) -> bool:
 
 def _print_report_human(issues_by_check: dict, min_confidence: float = 0.0,
                         dropped_per_check: dict | None = None,
-                        multi_check: bool = False) -> None:
+                        multi_check: bool = False,
+                        dropped_per_signal_class: dict | None = None,
+                        crashed_checks: list | None = None) -> None:
     dropped_per_check = dropped_per_check or {}
+    dropped_per_signal_class = dropped_per_signal_class or {}
     dropped_total = sum(dropped_per_check.values())
     total = sum(len(v) for v in issues_by_check.values())
     header = f"\nvault_doctor report — {total} issue(s) across {len(issues_by_check)} check(s)"
@@ -214,7 +223,23 @@ def _print_report_human(issues_by_check: dict, min_confidence: float = 0.0,
         if multi_check and dropped_per_check:
             breakdown = ", ".join(f"{k}: {v}" for k, v in dropped_per_check.items())
             header += f" ({breakdown})"
+        # Signal-class attribution for dropped issues (always, including
+        # single-check runs): infrastructure rows like historic-unreadable
+        # must stay visible when swallowed by the filter.
+        if dropped_per_signal_class:
+            cls_parts = "; ".join(
+                f"{chk}: " + ", ".join(
+                    f"{n} {cls}" for cls, n in classes.items()
+                )
+                for chk, classes in dropped_per_signal_class.items()
+            )
+            header += f"; by class: {cls_parts}"
         header += "]"
+    if crashed_checks:
+        header += (
+            f" [{len(crashed_checks)} check(s) crashed:"
+            f" {', '.join(crashed_checks)} — results incomplete]"
+        )
     print(header, file=sys.stderr)
     for check_name, issues in issues_by_check.items():
         by_project: dict[str, list] = {}
@@ -277,9 +302,23 @@ def main() -> int:
             return 3
 
     issues_by_check: dict = {}
+    # Checks whose scan() or apply() raised: contained per check so one buggy
+    # check cannot take down the whole run. Any entry forces the exit-2 path
+    # — the results are incomplete and must not read as clean.
+    crashed_checks: list[str] = []
     for mod in modules:
         days = args.days if args.days is not None else getattr(mod, "DEFAULT_WINDOW_DAYS", 7)
-        issues = _run_scan(mod, cfg, days, args.project, args=args)
+        try:
+            issues = _run_scan(mod, cfg, days, args.project, args=args)
+        except Exception as exc:  # noqa: BLE001 — per-check crash containment
+            print(
+                f"[vault_doctor] CHECK CRASHED: {mod.NAME}: "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+            traceback.print_exc(file=sys.stderr)
+            crashed_checks.append(mod.NAME)
+            continue
         if issues:
             issues_by_check[mod.NAME] = issues
 
@@ -293,10 +332,24 @@ def main() -> int:
     # attribution it would be indistinguishable from a clean check.
     dropped_by_confidence = 0
     dropped_per_check: dict[str, int] = {}
+    # Per-signal_class attribution for dropped issues (attribution only — no
+    # filter exemption): infrastructure rows (e.g. historic-unreadable) carry
+    # confidence=0.0 and would otherwise vanish indistinguishably from
+    # ordinary low-confidence proposals. Shape: {check: {signal_class: n}};
+    # dropped issues without a signal_class only count in dropped_per_check.
+    dropped_per_signal_class: dict[str, dict[str, int]] = {}
     if args.min_confidence > 0.0:
         filtered: dict = {}
         for check_name, issues in issues_by_check.items():
-            kept = [i for i in issues if _confidence_passes(i, args.min_confidence)]
+            kept = []
+            for i in issues:
+                if _confidence_passes(i, args.min_confidence):
+                    kept.append(i)
+                    continue
+                scls = i.extra.get("signal_class", "")
+                if scls:
+                    per_cls = dropped_per_signal_class.setdefault(check_name, {})
+                    per_cls[scls] = per_cls.get(scls, 0) + 1
             n_dropped = len(issues) - len(kept)
             if n_dropped:
                 dropped_per_check[check_name] = n_dropped
@@ -359,14 +412,34 @@ def main() -> int:
             payload["min_confidence"] = args.min_confidence
             payload["dropped_by_confidence"] = dropped_by_confidence
             payload["dropped_per_check"] = dropped_per_check
+            # Signal-class attribution: only when at least one dropped issue
+            # carried a signal_class (conditional-key convention).
+            if dropped_per_signal_class:
+                payload["dropped_per_signal_class"] = dropped_per_signal_class
+        # Crash containment: key only present when a check crashed
+        # (conditional-key convention — clean runs are byte-identical).
+        if crashed_checks:
+            payload["crashed_checks"] = crashed_checks
         print(json.dumps(payload, indent=2))
     else:
         _print_report_human(issues_by_check,
                             min_confidence=args.min_confidence,
                             dropped_per_check=dropped_per_check,
-                            multi_check=len(modules) > 1)
+                            multi_check=len(modules) > 1,
+                            dropped_per_signal_class=dropped_per_signal_class,
+                            crashed_checks=crashed_checks)
 
     if total_issues == 0:
+        if crashed_checks:
+            # NOT clean: one or more checks never finished scanning. Saying
+            # "clean" would be a literal falsehood — and exit 2 (not 0) so
+            # automation can't mistake an incomplete run for a healthy vault.
+            print(
+                f"vault_doctor: 0 issues, but {len(crashed_checks)} check(s) "
+                f"crashed — results incomplete",
+                file=sys.stderr,
+            )
+            return 2
         if dropped_by_confidence > 0:
             # All issues were filtered out — saying just "clean" would be a
             # literal falsehood. Exit stays 0 by decision (no new exit code);
@@ -382,7 +455,9 @@ def main() -> int:
         return 0
 
     if not args.apply:
-        return 1  # issues found, not applied (dry-run default)
+        # Issues found, not applied (dry-run default). A crashed check still
+        # forces exit 2 — the report above is incomplete.
+        return 2 if crashed_checks else 1
 
     # --apply: per-project confirmation
     backup_root = os.path.expanduser(
@@ -412,7 +487,24 @@ def main() -> int:
                 if answer not in ("y", "yes"):
                     print(f"  skipped {proj}", file=sys.stderr)
                     continue
-            results = mod.apply(resolvable, backup_root)
+            try:
+                results = mod.apply(resolvable, backup_root)
+            except Exception as exc:  # noqa: BLE001 — per-check crash containment
+                print(
+                    f"[vault_doctor] APPLY CRASHED: {mod.NAME}: "
+                    f"{type(exc).__name__}: {exc} — apply for this check "
+                    f"aborted mid-run; some fixes may already be applied "
+                    f"(check the backup root: {backup_root})",
+                    file=sys.stderr,
+                )
+                traceback.print_exc(file=sys.stderr)
+                if mod.NAME not in crashed_checks:
+                    crashed_checks.append(mod.NAME)
+                any_errors = True
+                # Skip this check's remaining projects (the next apply() call
+                # would most likely crash the same way) and move on to the
+                # next check.
+                break
             for r in results:
                 status_mark = {"applied": "+", "unresolved": "!", "error": "x", "skipped": "-"}.get(
                     r.status, "?"
@@ -426,7 +518,7 @@ def main() -> int:
                 if r.error:
                     print(f"      {r.error}", file=sys.stderr)
 
-    return 2 if any_errors else 1
+    return 2 if (any_errors or crashed_checks) else 1
 
 
 if __name__ == "__main__":

--- a/scripts/vault_doctor.py
+++ b/scripts/vault_doctor.py
@@ -204,6 +204,40 @@ def _confidence_passes(issue, threshold: float) -> bool:
     return c >= threshold
 
 
+def _issue_row(i) -> dict:
+    row = {
+        "check": i.check,
+        "note_path": i.note_path,
+        "project": i.project,
+        "current_source": i.current_source,
+        "proposed_source": i.proposed_source,
+        "reason": i.reason,
+        "confidence": i.confidence,
+        "unresolved": i.extra.get("unresolved", False),
+        "signal_class": i.extra.get("signal_class", ""),
+        "capture_signal": i.extra.get("capture_signal", ""),
+        "capture_confidence": i.extra.get("capture_confidence", 0.0),
+        # convergence_warning/convergence_count are deprecated as of #106
+        # (UUID-first matching obsoleted the convergence guard). Kept in the
+        # payload as hard-coded defaults for downstream schema stability;
+        # consumers should migrate to signal_class for triage.
+        "convergence_warning": i.extra.get("convergence_warning", False),
+        "convergence_count": i.extra.get("convergence_count", 0),
+    }
+    # Conditionally surfaced extras (currently from session-coverage,
+    # #98): only added when the issue's extra dict carries them, so
+    # rows from other checks are byte-identical to the prior schema.
+    if "sid" in i.extra:
+        row["sid"] = i.extra["sid"]
+    if "strict_fail" in i.extra:
+        row["strict_fail"] = i.extra["strict_fail"]
+    if "jsonl_path" in i.extra:
+        row["jsonl_path"] = i.extra["jsonl_path"]
+    if "referenced_by" in i.extra:
+        row["referenced_by_count"] = len(i.extra.get("referenced_by", []))
+    return row
+
+
 def _print_report_human(issues_by_check: dict, min_confidence: float = 0.0,
                         dropped_per_check: dict | None = None,
                         multi_check: bool = False,
@@ -362,39 +396,6 @@ def main() -> int:
 
     # JSON output for skill consumption
     if args.json_out:
-        def _issue_row(i) -> dict:
-            row = {
-                "check": i.check,
-                "note_path": i.note_path,
-                "project": i.project,
-                "current_source": i.current_source,
-                "proposed_source": i.proposed_source,
-                "reason": i.reason,
-                "confidence": i.confidence,
-                "unresolved": i.extra.get("unresolved", False),
-                "signal_class": i.extra.get("signal_class", ""),
-                "capture_signal": i.extra.get("capture_signal", ""),
-                "capture_confidence": i.extra.get("capture_confidence", 0.0),
-                # convergence_warning/convergence_count are deprecated as of #106
-                # (UUID-first matching obsoleted the convergence guard). Kept in the
-                # payload as hard-coded defaults for downstream schema stability;
-                # consumers should migrate to signal_class for triage.
-                "convergence_warning": i.extra.get("convergence_warning", False),
-                "convergence_count": i.extra.get("convergence_count", 0),
-            }
-            # Conditionally surfaced extras (currently from session-coverage,
-            # #98): only added when the issue's extra dict carries them, so
-            # rows from other checks are byte-identical to the prior schema.
-            if "sid" in i.extra:
-                row["sid"] = i.extra["sid"]
-            if "strict_fail" in i.extra:
-                row["strict_fail"] = i.extra["strict_fail"]
-            if "jsonl_path" in i.extra:
-                row["jsonl_path"] = i.extra["jsonl_path"]
-            if "referenced_by" in i.extra:
-                row["referenced_by_count"] = len(i.extra.get("referenced_by", []))
-            return row
-
         payload = {
             "timestamp": _iso_now(),
             "total_issues": total_issues,

--- a/scripts/vault_doctor_checks/__init__.py
+++ b/scripts/vault_doctor_checks/__init__.py
@@ -54,6 +54,8 @@ def _discover() -> None:
     Per-module exceptions (ImportError, SyntaxError, etc.) are logged to
     stderr and the offending module is skipped, so one broken check cannot
     take down the whole dispatcher. This keeps the system pluggable.
+    Modules that import cleanly but do not expose the check interface
+    (NAME + callable scan/apply) are also warned about on stderr.
     """
     if _CHECKS:
         return
@@ -72,6 +74,15 @@ def _discover() -> None:
         name = getattr(mod, "NAME", None)
         if name and callable(getattr(mod, "scan", None)) and callable(getattr(mod, "apply", None)):
             _CHECKS[name] = mod
+        else:
+            # A module that imports fine but lacks the interface (typo'd
+            # NAME/scan/apply, helper accidentally dropped into the package)
+            # must not vanish silently — its check would simply never run.
+            print(
+                f"[vault_doctor] module {mod_info.name} loaded but does not "
+                f"expose the check interface; skipped",
+                file=_sys.stderr,
+            )
 
 
 def list_checks() -> list[str]:

--- a/scripts/vault_doctor_checks/audit_historic_repairs.py
+++ b/scripts/vault_doctor_checks/audit_historic_repairs.py
@@ -439,7 +439,7 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
         tmp = None
         try:
             fd, tmp = tempfile.mkstemp(
-                dir=str(note_path.parent), prefix=".vd-audithist-", suffix=".tmp",
+                dir=str(note_path.parent), prefix=".vd-audithist-", suffix=".md.tmp",
             )
             try:
                 os.write(fd, new_content.encode("utf-8"))

--- a/scripts/vault_doctor_checks/audit_historic_repairs.py
+++ b/scripts/vault_doctor_checks/audit_historic_repairs.py
@@ -150,6 +150,13 @@ def scan(
     vault = Path(vault_path)
     root = _backup_root()
     if not root.is_dir():
+        # Loud no-op: a missing backup root means NOTHING was audited — a
+        # silent [] return would read as a clean bill of health.
+        print(
+            f"[audit-historic-repairs] backup root {root} not found — no "
+            f"doctor backups to audit (no-op, not a clean bill of health)",
+            file=sys.stderr,
+        )
         return []
 
     now = datetime.now(timezone.utc).timestamp()
@@ -339,17 +346,17 @@ def scan(
     # targets plus the distinct backups whose note no longer exists; the six
     # buckets partition it exactly. Every unreadable note also appended an
     # issue above, so subtract it from the classified count to avoid
-    # double-counting.
+    # double-counting. Printed UNCONDITIONALLY — an empty partition
+    # ("audited 0 backed-up note(s)") must be visible, not silent.
     audited = len(oldest) + len(missing)
-    if audited:
-        classified = len(issues) - unreadable
-        print(
-            f"[audit-historic-repairs] audited {audited} backed-up note(s):"
-            f" {classified} classified, {len(missing)} missing-current,"
-            f" {non_source} non-source-session, {no_drift} no-drift,"
-            f" {unreadable} unreadable, {project_filtered} project-filtered",
-            file=sys.stderr,
-        )
+    classified = len(issues) - unreadable
+    print(
+        f"[audit-historic-repairs] audited {audited} backed-up note(s):"
+        f" {classified} classified, {len(missing)} missing-current,"
+        f" {non_source} non-source-session, {no_drift} no-drift,"
+        f" {unreadable} unreadable, {project_filtered} project-filtered",
+        file=sys.stderr,
+    )
 
     return issues
 

--- a/scripts/vault_doctor_checks/project_name_canonicalization.py
+++ b/scripts/vault_doctor_checks/project_name_canonicalization.py
@@ -429,6 +429,9 @@ def scan(
 
             note_project = fm.get("project", "") or ""
             session_id = fm.get("session_id", "") or ""
+            # NOTE: _parse_frontmatter already strips surrounding quotes from
+            # values; this extra strip is belt-and-suspenders (harmless on
+            # already-clean values, protective if the parser ever changes).
             project_path_raw = (fm.get("project_path", "") or "").strip('"').strip("'")
 
             # -- derive outcome (always, BEFORE the project filter) ---------
@@ -718,31 +721,32 @@ def scan(
         + p2_warn_empty_project + p2_no_source_session
         + p2_project_filtered + p2_unreadable
     )
-    if p1_total > 0 or p2_total > 0:
-        print(
-            f"[{NAME}] phase1 (sessions): {p1_total} scanned:"
-            f" {p1_already_canonical} already-canonical, {p1_proposed} proposed,"
-            f" {p1_warn_no_project_path} warn-no-project-path,"
-            f" {p1_warn_not_found} warn-path-not-found,"
-            f" {p1_warn_unavailable} warn-git-unavailable,"
-            f" {p1_warn_git_error} warn-git-error,"
-            f" {p1_warn_empty_project} warn-empty-project,"
-            f" {p1_left_alone_not_a_repo} left-alone-non-git,"
-            f" {p1_project_filtered} project-filtered,"
-            f" {p1_unreadable} unreadable,"
-            f" {p1_snapshots_skipped} snapshots-skipped",
-            file=sys.stderr,
-        )
-        print(
-            f"[{NAME}] phase2 (insights): {p2_total} scanned:"
-            f" {p2_already_canonical} already-canonical, {p2_proposed} proposed,"
-            f" {p2_warn_unresolved_session} warn-unresolved-session,"
-            f" {p2_warn_empty_project} warn-empty-project,"
-            f" {p2_no_source_session} no-source-session,"
-            f" {p2_project_filtered} project-filtered,"
-            f" {p2_unreadable} unreadable",
-            file=sys.stderr,
-        )
+    # Printed UNCONDITIONALLY (even when both phases scanned nothing) — a
+    # silent scan is indistinguishable from a scan that never ran.
+    print(
+        f"[{NAME}] phase1 (sessions): {p1_total} scanned:"
+        f" {p1_already_canonical} already-canonical, {p1_proposed} proposed,"
+        f" {p1_warn_no_project_path} warn-no-project-path,"
+        f" {p1_warn_not_found} warn-path-not-found,"
+        f" {p1_warn_unavailable} warn-git-unavailable,"
+        f" {p1_warn_git_error} warn-git-error,"
+        f" {p1_warn_empty_project} warn-empty-project,"
+        f" {p1_left_alone_not_a_repo} left-alone-non-git,"
+        f" {p1_project_filtered} project-filtered,"
+        f" {p1_unreadable} unreadable,"
+        f" {p1_snapshots_skipped} snapshots-skipped",
+        file=sys.stderr,
+    )
+    print(
+        f"[{NAME}] phase2 (insights): {p2_total} scanned:"
+        f" {p2_already_canonical} already-canonical, {p2_proposed} proposed,"
+        f" {p2_warn_unresolved_session} warn-unresolved-session,"
+        f" {p2_warn_empty_project} warn-empty-project,"
+        f" {p2_no_source_session} no-source-session,"
+        f" {p2_project_filtered} project-filtered,"
+        f" {p2_unreadable} unreadable",
+        file=sys.stderr,
+    )
 
     return issues
 

--- a/scripts/vault_doctor_checks/project_name_canonicalization.py
+++ b/scripts/vault_doctor_checks/project_name_canonicalization.py
@@ -972,7 +972,7 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
             fd, tmp = tempfile.mkstemp(
                 dir=str(note_path.parent),
                 prefix=".vd-projcanon-",
-                suffix=".tmp",
+                suffix=".md.tmp",
             )
             try:
                 os.write(fd, new_content.encode("utf-8"))

--- a/scripts/vault_doctor_checks/session_coverage.py
+++ b/scripts/vault_doctor_checks/session_coverage.py
@@ -81,8 +81,10 @@ Flags:
   ``--strict``      emit FAIL (not WARN) when any note references the orphaned
                     session via ``source_session``. Changes the reason prefix
                     only — not the exit code.
-  ``--reconstruct`` mark issues as resolvable (``unresolved=False``) and enable
-                    ``apply()``.
+  ``--reconstruct`` mark issues as resolvable (``unresolved=False``,
+                    ``confidence=0.9`` — consistent with other applyable
+                    repairs) and enable ``apply()``. Without it, gaps are
+                    unresolved and carry ``confidence=0.0``.
 """
 
 from __future__ import annotations
@@ -576,7 +578,9 @@ def scan(
         project:         If set, only surface gaps for this project name
                          (cwd-basename slug — see module docstring).
         strict:          If True, emit FAIL prefix when any insight references the gap.
-        reconstruct:     If True, mark issues resolvable (unresolved=False) to enable apply().
+        reconstruct:     If True, mark issues resolvable (unresolved=False,
+                         confidence=0.9) to enable apply(). Otherwise gaps are
+                         unresolved with confidence=0.0.
     """
     vault = Path(vault_path)
     # Path.home() reads $HOME on POSIX (tests monkeypatch it) and falls back
@@ -768,7 +772,13 @@ def scan(
                     current_source=f"{sid}.jsonl ({size} bytes)",
                     proposed_source=f"[[{expected_basename[:-3]}]]",  # strip .md
                     reason=reason,
-                    confidence=0.0,
+                    # Resolvable gaps (reconstruct mode) carry 0.9 — the
+                    # repair is known and applyable, consistent with other
+                    # applyable repairs (canonicalization proposals, audit
+                    # category-A restores). Unresolved gaps stay 0.0 so a
+                    # --min-confidence threshold > 0 filters them, and never
+                    # silently nullifies --reconstruct.
+                    confidence=0.9 if reconstruct else 0.0,
                     extra={
                         "unresolved": not reconstruct,
                         "signal_class": "session-coverage-gap",
@@ -786,19 +796,20 @@ def scan(
 
     # Step 7: end-of-scan stderr summary. The five buckets partition the
     # scanned JSONLs exactly; unreadable session notes are an index-side
-    # (note-side) counter appended for operator visibility.
+    # (note-side) counter appended for operator visibility. Printed
+    # UNCONDITIONALLY (even when nothing was scanned) — a silent scan is
+    # indistinguishable from a scan that never ran.
     total_scanned = n_gaps + n_covered + n_below_threshold + n_unparsable + n_project_filtered
-    if total_scanned > 0 or n_project_dirs > 0:
-        print(
-            f"[session-coverage] scanned {total_scanned} jsonl(s) across"
-            f" {n_project_dirs} project dir(s):"
-            f" {n_gaps} gaps, {n_covered} covered,"
-            f" {n_below_threshold} below-threshold,"
-            f" {n_unparsable} unparsable,"
-            f" {n_project_filtered} project-filtered;"
-            f" {n_unreadable_notes} unreadable session note(s)",
-            file=sys.stderr,
-        )
+    print(
+        f"[session-coverage] scanned {total_scanned} jsonl(s) across"
+        f" {n_project_dirs} project dir(s):"
+        f" {n_gaps} gaps, {n_covered} covered,"
+        f" {n_below_threshold} below-threshold,"
+        f" {n_unparsable} unparsable,"
+        f" {n_project_filtered} project-filtered;"
+        f" {n_unreadable_notes} unreadable session note(s)",
+        file=sys.stderr,
+    )
 
     return issues
 
@@ -953,17 +964,44 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
             )
             continue
 
-        outcome = out.get("outcome", "UNKNOWN")
+        # Coerce outcome to str defensively: a malformed replay payload with
+        # a non-string outcome (number, null) must fall through to the
+        # per-issue error path below, not raise AttributeError on
+        # .startswith() and abort the whole sweep.
+        outcome = str(out.get("outcome", "UNKNOWN"))
         if outcome in _SUCCESS_OUTCOMES:
             # vault_writes is the replay's ground truth for what was written
             # (the predicted issue.note_path may differ in date — see docstring:
             # the hook's _first_seen_date returns TODAY for never-written
             # sessions, while the scan predicted from the JSONL first timestamp).
+            # Shape-guard the [path, bytes] entries: a malformed payload
+            # (non-list outer, empty/non-list inner) becomes a per-issue
+            # error Result instead of a TypeError/IndexError crash.
             vault_writes = out.get("vault_writes", [])
-            if vault_writes:
-                actual_path = vault_writes[0][0]
+            first_entry = None
+            if isinstance(vault_writes, list) and vault_writes:
+                candidate = vault_writes[0]
+                if isinstance(candidate, (list, tuple)) and candidate:
+                    first_entry = candidate
+            if first_entry is not None:
+                actual_path = str(first_entry[0])
                 results.append(
                     Result(check=NAME, note_path=actual_path, status="applied")
+                )
+            elif vault_writes:
+                results.append(
+                    Result(
+                        check=NAME,
+                        note_path=issue.note_path,
+                        status="error",
+                        error=(
+                            f"replay reported success ({outcome}) but its "
+                            f"vault_writes is malformed "
+                            f"({str(vault_writes)[:120]!r}); "
+                            f"check whether the note now exists before "
+                            f"re-running"
+                        ),
+                    )
                 )
             else:
                 results.append(
@@ -973,7 +1011,8 @@ def apply(issues: list[Issue], backup_root: str) -> list[Result]:
                         status="error",
                         error=(
                             f"replay reported success ({outcome}) but wrote "
-                            f"nothing (vault_writes empty)"
+                            f"nothing (vault_writes empty); check whether "
+                            f"the note now exists before re-running"
                         ),
                     )
                 )

--- a/scripts/vault_doctor_checks/session_coverage.py
+++ b/scripts/vault_doctor_checks/session_coverage.py
@@ -587,7 +587,7 @@ def scan(
     # to pwd-database lookups when unset — sibling-module convention, more
     # defensive than expanduser-and-walk-up.
     home = Path.home()
-    projects_root = Path("~/.claude/projects").expanduser()
+    projects_root = home / ".claude" / "projects"
 
     now = datetime.now(timezone.utc).timestamp()
     cutoff = now - days * 86400

--- a/skills/vault-doctor/SKILL.md
+++ b/skills/vault-doctor/SKILL.md
@@ -85,7 +85,7 @@ Capture stdout as the JSON report. Exit codes:
 
 - `0` — clean vault, nothing to do
 - `1` — issues found (expected for a dry-run that finds things)
-- `2` — apply errors
+- `2` — apply errors OR one or more checks crashed (results incomplete; see `crashed_checks` in JSON)
 - `3` — usage error (bad args, missing config)
 
 If exit code is `3`, surface the stderr message directly to the user and stop.
@@ -116,6 +116,14 @@ convergence_warning/convergence_count fields are deprecated as of #106
 (UUID-first matching obsoleted the convergence guard) — they remain in the
 JSON payload as hard-coded defaults for output schema stability but should
 not drive rendering.
+
+The `crashed_checks` key is conditional — it is only present when one or
+more checks crashed during the scan or apply phase (exit code 2 on a
+dry-run). If the payload contains `crashed_checks`, tell the user which
+checks crashed and that the report is **INCOMPLETE** — do not present it
+as a complete scan. Example: "Warning: checks [source-sessions] crashed
+during this scan — results are incomplete. Re-run after the crash is
+resolved to get a full report."
 
 Example:
 
@@ -188,7 +196,10 @@ vault_doctor apply complete
 Backups saved to: ~/.claude/obsidian-brain-doctor-backup/2026-04-11T17-04-22+00-00/
 ```
 
-If any errors occurred (exit code 2), surface them prominently and recommend the user diff one of the backup files under the backup root to understand what went wrong.
+If exit code is 2, distinguish the source:
+
+- **Apply errors (fixes failed):** Surface the failed-fix lines from stderr prominently and recommend the user diff one of the backup files under the backup root to understand what went wrong.
+- **"CHECK CRASHED" or "APPLY CRASHED" on stderr:** Report which check(s) crashed by name. For an apply crash, warn that fixes for that check may be **partially applied** (backups exist under the backup root for anything that ran before the crash). For a scan crash, note that nothing was applied for that check and **no backups exist** for it.
 
 ### Step 6 — Offer next steps
 

--- a/tests/test_vault_doctor.py
+++ b/tests/test_vault_doctor.py
@@ -4,6 +4,8 @@ import importlib
 import sys
 from pathlib import Path
 
+import pytest
+
 _SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(_SCRIPTS_DIR))
 
@@ -257,6 +259,249 @@ def test_spurious_wikilinks_apply_escapes_and_backs_up(tmp_path):
     # Backup contains original
     backup_content = Path(results[0].backup_path).read_text(encoding="utf-8")
     assert "[[" in backup_content
+
+
+def test_registry_warns_on_interfaceless_module(tmp_path, capsys, monkeypatch):
+    """A module that imports fine but lacks NAME/scan/apply must produce a
+    one-line stderr warning instead of being silently skipped (a typo'd
+    NAME/scan symbol would otherwise make a check vanish without trace)."""
+    import vault_doctor_checks
+
+    fake_pkg_dir = tmp_path / "fake_checks"
+    fake_pkg_dir.mkdir()
+    (fake_pkg_dir / "no_interface.py").write_text(
+        "X = 1  # imports fine, exposes no check interface\n", encoding="utf-8"
+    )
+
+    original = vault_doctor_checks._CHECKS.copy()
+    try:
+        vault_doctor_checks._CHECKS.clear()
+        monkeypatch.setattr(vault_doctor_checks, "__path__", [str(fake_pkg_dir)])
+        vault_doctor_checks._discover()
+        err = capsys.readouterr().err
+        assert "no_interface" in err, f"warning must name the module: {err!r}"
+        assert "does not expose the check interface" in err
+        assert "skipped" in err
+        assert vault_doctor_checks._CHECKS == {}
+    finally:
+        vault_doctor_checks._CHECKS.clear()
+        vault_doctor_checks._CHECKS.update(original)
+        sys.modules.pop("vault_doctor_checks.no_interface", None)
+
+
+class TestCrashContainment:
+    """Per-check crash containment in the dispatcher: one buggy check must
+    not take down the whole run; the crash is surfaced loudly (stderr +
+    crashed_checks + exit 2) instead of a traceback-and-die.
+
+    Injection follows the registry-pollution pattern from
+    test_vault_doctor_audit_historic_repairs.py (snapshot/restore _CHECKS in
+    finally) and drives vault_doctor.main() in-process.
+    """
+
+    @staticmethod
+    def _fake_issue(check_name, note_path="/tmp/fake-crash-note.md"):
+        from vault_doctor_checks import Issue
+        return Issue(
+            check=check_name,
+            note_path=note_path,
+            project="crashproj",
+            current_source="[[old]]",
+            proposed_source="[[new]]",
+            reason="synthetic issue from crash-containment fixture",
+            confidence=0.9,
+            extra={"unresolved": False},
+        )
+
+    @pytest.fixture
+    def doctor_env(self, tmp_path, monkeypatch):
+        vault = tmp_path / "vault"
+        (vault / "claude-sessions").mkdir(parents=True)
+        (vault / "claude-insights").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("OBSIDIAN_BRAIN_VAULT", str(vault))
+        monkeypatch.setenv("OBSIDIAN_BRAIN_SESSIONS_FOLDER", "claude-sessions")
+        monkeypatch.setenv("OBSIDIAN_BRAIN_INSIGHTS_FOLDER", "claude-insights")
+        return vault
+
+    def _patched_checks(self, extra_mods):
+        """Context: pollute _CHECKS with extra modules; caller restores."""
+        import vault_doctor_checks
+        vault_doctor_checks._discover()
+        original = vault_doctor_checks._CHECKS.copy()
+        for mod in extra_mods:
+            vault_doctor_checks._CHECKS[mod.NAME] = mod
+        return original
+
+    def test_scan_crash_contained_other_issues_still_reported(
+        self, doctor_env, monkeypatch, capsys
+    ):
+        """A check whose scan() raises is recorded in crashed_checks; a later
+        check's issues are still scanned and reported; exit 2."""
+        import json
+        import types
+        import vault_doctor
+        import vault_doctor_checks
+
+        def _raise(*a, **kw):
+            raise RuntimeError("boom-scan")
+
+        crasher = types.SimpleNamespace(
+            NAME="fake-crash", scan=_raise, apply=lambda *a, **kw: [])
+        producer = types.SimpleNamespace(
+            NAME="fake-issues",
+            scan=lambda *a, **kw: [self._fake_issue("fake-issues")],
+            apply=lambda *a, **kw: [])
+
+        original = self._patched_checks([crasher, producer])
+        try:
+            monkeypatch.setattr(sys, "argv", ["vault_doctor", "--json"])
+            rc = vault_doctor.main()
+        finally:
+            vault_doctor_checks._CHECKS.clear()
+            vault_doctor_checks._CHECKS.update(original)
+
+        out, err = capsys.readouterr()
+        assert rc == 2, f"crashed check must force exit 2, got {rc}\n{err}"
+        payload = json.loads(out)
+        assert payload["crashed_checks"] == ["fake-crash"]
+        assert any(i["check"] == "fake-issues" for i in payload["issues"]), (
+            "issues from the check AFTER the crasher must still be reported"
+        )
+        assert "CHECK CRASHED: fake-crash: RuntimeError: boom-scan" in err
+        assert "Traceback" in err  # full traceback printed for diagnosis
+
+    def test_zero_issues_with_crash_no_plain_clean_exit_2(
+        self, doctor_env, monkeypatch, capsys
+    ):
+        """0 issues + a crashed check must NOT print the plain clean line —
+        the results are incomplete; exit 2."""
+        import types
+        import vault_doctor
+        import vault_doctor_checks
+
+        def _raise(*a, **kw):
+            raise ValueError("boom-clean")
+
+        crasher = types.SimpleNamespace(
+            NAME="fake-crash-clean", scan=_raise, apply=lambda *a, **kw: [])
+
+        original = self._patched_checks([crasher])
+        try:
+            monkeypatch.setattr(sys, "argv", ["vault_doctor"])
+            rc = vault_doctor.main()
+        finally:
+            vault_doctor_checks._CHECKS.clear()
+            vault_doctor_checks._CHECKS.update(original)
+
+        _, err = capsys.readouterr()
+        assert rc == 2, f"expected exit 2, got {rc}\n{err}"
+        assert "vault_doctor: clean" not in err, (
+            "a run with crashed checks must not claim a clean bill of health"
+        )
+        assert "0 issues, but 1 check(s) crashed" in err
+        assert "results incomplete" in err
+        # The human header also surfaces the crash.
+        assert "crashed" in err
+
+    def test_apply_crash_contained_exit_2_with_warning(
+        self, doctor_env, monkeypatch, capsys
+    ):
+        """A check whose apply() raises mid-run is contained: stderr warns
+        that some fixes may already be applied (pointing at the backup root),
+        the check lands in crashed_checks, and the run exits 2."""
+        import types
+        import vault_doctor
+        import vault_doctor_checks
+
+        def _apply_raise(*a, **kw):
+            raise RuntimeError("boom-apply")
+
+        mod = types.SimpleNamespace(
+            NAME="fake-apply-crash",
+            scan=lambda *a, **kw: [self._fake_issue("fake-apply-crash")],
+            apply=_apply_raise)
+
+        original = self._patched_checks([mod])
+        try:
+            monkeypatch.setattr(
+                sys, "argv", ["vault_doctor", "--apply", "--yes"])
+            rc = vault_doctor.main()
+        finally:
+            vault_doctor_checks._CHECKS.clear()
+            vault_doctor_checks._CHECKS.update(original)
+
+        _, err = capsys.readouterr()
+        assert rc == 2, f"apply crash must take the exit-2 path, got {rc}\n{err}"
+        assert "APPLY CRASHED: fake-apply-crash: RuntimeError: boom-apply" in err
+        assert "aborted mid-run" in err
+        assert "may already be applied" in err
+        assert "backup root" in err
+
+    def test_apply_crash_in_earlier_check_does_not_block_later_check(
+        self, doctor_env, monkeypatch, capsys
+    ):
+        """An apply() crash in check A must not prevent check B's apply from
+        running. The break on crash exits only the per-project inner loop for
+        check A; the outer per-check loop continues to check B.
+
+        Coverage pin: this test passes immediately because the break is
+        scoped to the inner for-project loop, not the outer for-mod loop.
+        """
+        import types
+        import vault_doctor
+        import vault_doctor_checks
+        from vault_doctor_checks import Result
+
+        applied_by = []
+
+        def _apply_raise(*a, **kw):
+            raise RuntimeError("boom-apply-early")
+
+        def _apply_ok(issues, backup_root):
+            for i in issues:
+                applied_by.append(i.check)
+            return [
+                Result(
+                    check=i.check,
+                    note_path=i.note_path,
+                    status="applied",
+                    backup_path=None,
+                    error=None,
+                )
+                for i in issues
+            ]
+
+        # crasher comes first (dict insertion order is preserved in Python 3.7+
+        # and _CHECKS is a plain dict; _patched_checks inserts in list order).
+        crasher = types.SimpleNamespace(
+            NAME="fake-apply-crasher",
+            scan=lambda *a, **kw: [self._fake_issue("fake-apply-crasher")],
+            apply=_apply_raise,
+        )
+        succeeder = types.SimpleNamespace(
+            NAME="fake-apply-succeeder",
+            scan=lambda *a, **kw: [self._fake_issue("fake-apply-succeeder")],
+            apply=_apply_ok,
+        )
+
+        original = self._patched_checks([crasher, succeeder])
+        try:
+            monkeypatch.setattr(
+                sys, "argv", ["vault_doctor", "--apply", "--yes"])
+            rc = vault_doctor.main()
+        finally:
+            vault_doctor_checks._CHECKS.clear()
+            vault_doctor_checks._CHECKS.update(original)
+
+        _, err = capsys.readouterr()
+        assert rc == 2, f"apply crash forces exit 2, got {rc}\n{err}"
+        assert "APPLY CRASHED: fake-apply-crasher" in err, (
+            "crash in the first check must be reported"
+        )
+        assert "fake-apply-succeeder" in applied_by, (
+            "later check's apply must still run after earlier check crashed"
+        )
 
 
 def test_cli_missing_vault_errors(tmp_path, monkeypatch):

--- a/tests/test_vault_doctor_audit_historic_repairs.py
+++ b/tests/test_vault_doctor_audit_historic_repairs.py
@@ -649,6 +649,182 @@ def test_coverage_summary_partitions(audit_env, capsys):
     assert classified + missing + non_src + no_drift + unreadable + proj_filt == audited
 
 
+# --------------------------------- missing/empty backup root must not be silent
+
+def test_missing_backup_root_warns_not_silent(tmp_path, monkeypatch, capsys):
+    """A nonexistent backup root must print a stderr notice — an early []
+    return with no output reads as a clean bill of health when it actually
+    means 'nothing was audited'."""
+    vault = tmp_path / "vault"
+    (vault / "claude-insights").mkdir(parents=True)
+    (vault / "claude-sessions").mkdir(parents=True)
+    missing_root = tmp_path / "does-not-exist"
+    monkeypatch.setenv("OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT", str(missing_root))
+
+    issues = ahr.scan(str(vault), "claude-sessions", "claude-insights", 180)
+    assert issues == []
+    _, err = capsys.readouterr()
+    assert "backup root" in err
+    assert str(missing_root) in err
+    assert "not found" in err
+    assert "no-op, not a clean bill of health" in err
+
+
+def test_empty_backup_root_prints_zero_audited_summary(audit_env, capsys):
+    """Backup root exists but contains no runs → the coverage summary still
+    prints, with 'audited 0 backed-up note(s)' (no silent empty partition)."""
+    issues = _scan(audit_env)
+    assert issues == []
+    _, err = capsys.readouterr()
+    assert "audited 0 backed-up note(s)" in err
+
+
+# ----------------------- --min-confidence interplay (attribution + apply scope)
+
+def _build_min_conf_env(tmp_path, with_unreadable=False):
+    """Vault + backup root with one category-A (conf 0.9) and one category-B
+    (historic-keep, conf 0.0) fixture; optionally one unreadable current note
+    (historic-unreadable, conf 0.0). Returns (vault, env, note_a, note_b,
+    note_unreadable_or_None)."""
+    vault = tmp_path / "vault"
+    (vault / "claude-sessions").mkdir(parents=True)
+    (vault / "claude-insights").mkdir(parents=True)
+    backup_root = tmp_path / "doctor-backup"
+    run_dir = backup_root / _run_dirname(_days_ago(30)) / "proj1" / "claude-insights"
+    run_dir.mkdir(parents=True)
+
+    # Category A: original same-day, current drifted → conf 0.9, applyable.
+    basename_a = "2026-04-09-proj1-mca.md"
+    (run_dir / basename_a).write_text(
+        _insight_text("2026-04-09", "sid-orig-a", "2026-04-09-proj1-aorig"),
+        encoding="utf-8")
+    note_a = vault / "claude-insights" / basename_a
+    note_a.write_text(
+        _insight_text("2026-04-09", "sid-curr-a", "2026-04-10-proj1-acurr"),
+        encoding="utf-8")
+
+    # Category B: original wrong-day, current same-day → historic-keep, conf 0.0.
+    basename_b = "2026-04-09-proj1-mcb.md"
+    (run_dir / basename_b).write_text(
+        _insight_text("2026-04-09", "sid-orig-b", "2026-04-08-proj1-borig"),
+        encoding="utf-8")
+    note_b = vault / "claude-insights" / basename_b
+    note_b.write_text(
+        _insight_text("2026-04-09", "sid-curr-b", "2026-04-09-proj1-bcurr"),
+        encoding="utf-8")
+
+    note_u = None
+    if with_unreadable:
+        basename_u = "2026-04-09-proj1-mcu.md"
+        (run_dir / basename_u).write_text(
+            _insight_text("2026-04-09", "sid-orig-u", "2026-04-09-proj1-uorig"),
+            encoding="utf-8")
+        note_u = vault / "claude-insights" / basename_u
+        note_u.write_text(
+            _insight_text("2026-04-09", "sid-curr-u", "2026-04-10-proj1-ucurr"),
+            encoding="utf-8")
+        note_u.chmod(0o000)
+
+    env = {
+        "HOME": str(tmp_path),
+        "OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT": str(backup_root),
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+        "OBSIDIAN_BRAIN_VAULT": str(vault),
+        "OBSIDIAN_BRAIN_SESSIONS_FOLDER": "claude-sessions",
+        "OBSIDIAN_BRAIN_INSIGHTS_FOLDER": "claude-insights",
+    }
+    return vault, env, note_a, note_b, note_u
+
+
+_SCRIPT = Path(__file__).parent.parent / "scripts" / "vault_doctor.py"
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="root ignores file permissions")
+def test_min_confidence_drop_attribution_by_signal_class(tmp_path):
+    """Dropped infrastructure rows must stay attributable: --min-confidence 0.5
+    drops the cat-B (historic-keep) and unreadable (historic-unreadable) rows;
+    the JSON payload carries a per-signal_class breakdown and the human header
+    names the classes."""
+    vault, env, note_a, note_b, note_u = _build_min_conf_env(
+        tmp_path, with_unreadable=True)
+    try:
+        r = subprocess.run(
+            [sys.executable, str(_SCRIPT),
+             "--check", "audit-historic-repairs",
+             "--min-confidence", "0.5", "--json"],
+            capture_output=True, text=True, env=env,
+        )
+        assert r.returncode == 1, f"cat-A survives → exit 1; got {r.returncode}:\n{r.stderr}"
+        payload = json.loads(r.stdout)
+        assert payload["total_issues"] == 1
+        assert payload["issues"][0]["signal_class"] == "historic-restore"
+        assert payload["dropped_per_check"] == {"audit-historic-repairs": 2}
+        assert payload["dropped_per_signal_class"] == {
+            "audit-historic-repairs": {
+                "historic-keep": 1,
+                "historic-unreadable": 1,
+            }
+        }, f"signal-class attribution missing/wrong: {payload}"
+
+        # Human header carries the class names too.
+        r2 = subprocess.run(
+            [sys.executable, str(_SCRIPT),
+             "--check", "audit-historic-repairs",
+             "--min-confidence", "0.5"],
+            capture_output=True, text=True, env=env,
+        )
+        header_line = next(
+            (line for line in r2.stderr.splitlines()
+             if "vault_doctor report" in line), None)
+        assert header_line is not None, f"header missing:\n{r2.stderr}"
+        assert "historic-keep" in header_line, header_line
+        assert "historic-unreadable" in header_line, header_line
+    finally:
+        if note_u is not None:
+            note_u.chmod(0o600)
+
+
+def test_min_confidence_no_signal_class_key_without_flag(tmp_path):
+    """Back-compat: without --min-confidence the dropped_per_signal_class key
+    must NOT appear in the JSON payload."""
+    vault, env, note_a, note_b, _ = _build_min_conf_env(tmp_path)
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT),
+         "--check", "audit-historic-repairs", "--json"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 1, r.stderr
+    payload = json.loads(r.stdout)
+    assert "dropped_per_signal_class" not in payload
+
+
+def test_min_confidence_apply_restores_only_category_a(tmp_path):
+    """--min-confidence 0.5 --apply --yes: only the cat-A (conf 0.9) note is
+    restored; the cat-B (conf 0.0) note is byte-identical; the dry-run report
+    (emitted before apply) carries the dropped attribution."""
+    vault, env, note_a, note_b, _ = _build_min_conf_env(tmp_path)
+    original_b = note_b.read_text(encoding="utf-8")
+
+    r = subprocess.run(
+        [sys.executable, str(_SCRIPT),
+         "--check", "audit-historic-repairs",
+         "--min-confidence", "0.5", "--apply", "--yes", "--json"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode == 1, f"expected 1 (successful apply), got {r.returncode}:\n{r.stderr}"
+
+    payload = json.loads(r.stdout)
+    assert payload["dropped_by_confidence"] == 1
+    assert payload["dropped_per_check"] == {"audit-historic-repairs": 1}
+
+    restored = note_a.read_text(encoding="utf-8")
+    assert "source_session: sid-orig-a" in restored, "cat-A note must be restored"
+    assert "2026-04-09-proj1-aorig" in restored
+    assert note_b.read_text(encoding="utf-8") == original_b, (
+        "cat-B note (conf 0.0, dropped by filter) must be untouched"
+    )
+
+
 # --------------------------------------------- cross-folder basename collisions
 
 def test_cross_folder_collision_pairs_correctly(audit_env):

--- a/tests/test_vault_doctor_min_confidence.py
+++ b/tests/test_vault_doctor_min_confidence.py
@@ -41,60 +41,66 @@ def _make_issue(confidence: float, note_path: str = "/tmp/fake.md") -> Issue:
 
 
 # ---------------------------------------------------------------------------
-# Unit: filter semantics
+# Unit: filter semantics (calls the PRODUCTION predicate, vault_doctor.
+# _confidence_passes — the same function main() uses to filter issues; a
+# locally re-implemented comprehension would keep passing even if the
+# production operator regressed)
 # ---------------------------------------------------------------------------
 
 class TestMinConfidenceFilter:
-    """Verify the >= filter semantics described in the issue test plan."""
+    """Verify the >= filter semantics via the production predicate."""
 
     def test_threshold_0_9_keeps_two_of_four(self):
         """Issues with conf [0.4, 0.6, 0.99, 0.99] → threshold 0.9 keeps 2."""
+        import vault_doctor
         issues = [
             _make_issue(0.4),
             _make_issue(0.6),
             _make_issue(0.99),
             _make_issue(0.99),
         ]
-        threshold = 0.9
-        kept = [i for i in issues if i.confidence >= threshold]
+        kept = [i for i in issues if vault_doctor._confidence_passes(i, 0.9)]
         assert len(kept) == 2
-        assert all(i.confidence >= threshold for i in kept)
+        assert all(i.confidence >= 0.9 for i in kept)
 
     def test_threshold_0_0_keeps_all_four(self):
         """Issues with conf [0.4, 0.6, 0.99, 0.99] → threshold 0.0 keeps all 4."""
+        import vault_doctor
         issues = [
             _make_issue(0.4),
             _make_issue(0.6),
             _make_issue(0.99),
             _make_issue(0.99),
         ]
-        threshold = 0.0
-        kept = [i for i in issues if i.confidence >= threshold]
+        kept = [i for i in issues if vault_doctor._confidence_passes(i, 0.0)]
         assert len(kept) == 4
 
     def test_threshold_1_0_excludes_0_99(self):
-        """Threshold 1.0 uses >= semantics → confidence=0.99 must be excluded.
-
-        Fail-first discipline: mutate >= to > and the test reverses (len==2
-        instead of 0 for [0.99, 0.99]). Document the invariant.
-        """
+        """Threshold 1.0 uses >= semantics → confidence=0.99 must be excluded."""
+        import vault_doctor
         issues = [_make_issue(0.99), _make_issue(0.99)]
-        threshold = 1.0
-        kept_ge = [i for i in issues if i.confidence >= threshold]
-        assert len(kept_ge) == 0, (
+        kept = [i for i in issues if vault_doctor._confidence_passes(i, 1.0)]
+        assert len(kept) == 0, (
             "threshold=1.0 with >= semantics must exclude conf=0.99"
         )
 
     def test_threshold_1_0_keeps_exactly_1_0(self):
         """A confidence of exactly 1.0 is kept when threshold=1.0 (>= inclusive)."""
+        import vault_doctor
         issues = [_make_issue(1.0), _make_issue(0.99)]
-        threshold = 1.0
-        kept = [i for i in issues if i.confidence >= threshold]
+        kept = [i for i in issues if vault_doctor._confidence_passes(i, 1.0)]
         assert len(kept) == 1
         assert kept[0].confidence == 1.0
 
+    def test_boundary_equal_confidence_passes(self):
+        """conf == threshold passes (>= not >): a mutation to strict > in
+        _confidence_passes reverses this assertion."""
+        import vault_doctor
+        assert vault_doctor._confidence_passes(_make_issue(0.99), 0.99) is True
+
     def test_unresolved_confidence_zero_filtered_at_threshold_gt_0(self):
         """Unresolved issues have confidence=0.0; threshold > 0.0 drops them."""
+        import vault_doctor
         unresolved = Issue(
             check="source-sessions",
             note_path="/tmp/unresolved.md",
@@ -105,32 +111,7 @@ class TestMinConfidenceFilter:
             confidence=0.0,
             extra={"unresolved": True, "signal_class": "unresolved"},
         )
-        kept = [i for i in [unresolved] if i.confidence >= 0.9]
-        assert len(kept) == 0
-
-
-# ---------------------------------------------------------------------------
-# Fail-first discipline evidence
-# ---------------------------------------------------------------------------
-
-class TestFailFirst:
-    """Demonstrate that changing the filter operator from >= to > reverses the
-    threshold=1.0 test and confirms confidence=0.99 handling is correct."""
-
-    def test_mutated_gt_includes_0_99_as_control(self):
-        """Using > (not >=) for threshold=1.0 would keep 0.99 — confirming
-        our production >= is the correct, tighter semantics."""
-        issues = [_make_issue(0.99), _make_issue(0.99)]
-        threshold = 1.0
-        # Deliberately use > to show the mutation would make the test pass
-        kept_gt = [i for i in issues if i.confidence > threshold]
-        # > does NOT include 0.99 when threshold=1.0 either (0.99 > 1.0 is False)
-        # Let's use threshold=0.9 to show >= vs > difference
-        threshold_sub = 0.99
-        kept_ge = [i for i in issues if i.confidence >= threshold_sub]
-        kept_gt_sub = [i for i in issues if i.confidence > threshold_sub]
-        assert len(kept_ge) == 2, ">= 0.99 includes conf=0.99"
-        assert len(kept_gt_sub) == 0, "> 0.99 excludes conf=0.99 — mutation reverses the test"
+        assert vault_doctor._confidence_passes(unresolved, 0.9) is False
 
 
 # ---------------------------------------------------------------------------
@@ -379,6 +360,9 @@ class TestMinConfidenceCLI:
         )
         assert "dropped_by_confidence" not in payload, (
             "back-compat: dropped_by_confidence must NOT appear in JSON without the flag"
+        )
+        assert "crashed_checks" not in payload, (
+            "back-compat: crashed_checks must NOT appear in JSON on a clean run"
         )
 
     def test_apply_yes_min_confidence_0_9_modifies_only_high_conf(self, tmp_path):

--- a/tests/test_vault_doctor_project_name_canonicalization.py
+++ b/tests/test_vault_doctor_project_name_canonicalization.py
@@ -792,6 +792,16 @@ def test_stderr_summary_partition(canon_vault, tmp_path, capsys):
     assert "proposed" in captured.err
 
 
+def test_summary_printed_even_when_nothing_scanned(canon_vault, capsys):
+    """Empty vault folders → both phase summaries still print with zero
+    counts; a silent scan is indistinguishable from a scan that never ran."""
+    issues = _scan(canon_vault)
+    assert issues == []
+    captured = capsys.readouterr()
+    assert "[project-name-canonicalization] phase1 (sessions): 0 scanned" in captured.err
+    assert "[project-name-canonicalization] phase2 (insights): 0 scanned" in captured.err
+
+
 # ---------------------------------------------------------------------------
 # OPT_IN and NAME
 # ---------------------------------------------------------------------------
@@ -801,6 +811,19 @@ def test_module_opt_in_and_name():
     assert check.NAME == "project-name-canonicalization"
     assert check.OPT_IN is True
     assert check.DEFAULT_WINDOW_DAYS == 9999
+
+
+def test_registry_excluded_from_default_sweep():
+    """Registry-level OPT_IN assertion (matches the audit/session-coverage
+    pattern): the check must NOT appear in the default all-checks sweep —
+    OPT_IN=True on the module alone is not enough if all_checks() regressed."""
+    names = [m.NAME for m in vault_doctor_checks.all_checks()]
+    assert check.NAME not in names
+
+
+def test_registry_reachable_via_get_check():
+    """...but it must stay reachable when explicitly named via --check."""
+    assert vault_doctor_checks.get_check(check.NAME) is check
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vault_doctor_session_coverage.py
+++ b/tests/test_vault_doctor_session_coverage.py
@@ -699,6 +699,30 @@ class TestReconstruct:
         assert len(issues) == 1
         assert issues[0].extra["unresolved"] is True
 
+    def test_reconstruct_true_sets_confidence_0_9(self, sc_env):
+        """reconstruct=True makes the gap resolvable, so it carries an
+        applyable-repair confidence of 0.9 (consistent with canonicalization
+        proposals and audit category-A restores) — otherwise --min-confidence
+        would silently nullify --reconstruct."""
+        sid = "reconstruct-conf-sid-0003"
+        cwd = "/path/to/my-proj"
+        _write_jsonl(sc_env["projects"], "-proj", sid, cwd, n_user=5, duration_minutes=10)
+
+        issues = _scan(sc_env, reconstruct=True)
+        assert len(issues) == 1
+        assert issues[0].confidence == 0.9
+
+    def test_reconstruct_false_keeps_confidence_0_0(self, sc_env):
+        """Without reconstruct, the gap is unresolved — confidence stays 0.0
+        (no proposed repair)."""
+        sid = "reconstruct-conf-sid-0004"
+        cwd = "/path/to/my-proj"
+        _write_jsonl(sc_env["projects"], "-proj", sid, cwd, n_user=5, duration_minutes=10)
+
+        issues = _scan(sc_env, reconstruct=False)
+        assert len(issues) == 1
+        assert issues[0].confidence == 0.0
+
 
 # ---------------------------------------------------------------------------
 # Test 8: project filter
@@ -1262,6 +1286,116 @@ class TestApply:
         with pytest.raises(RuntimeError, match="refuses signal_class"):
             sc.apply([issue], str(tmp_path / "backup"))
 
+    def test_apply_non_string_outcome_is_error_not_crash(self, tmp_path, monkeypatch):
+        """A malformed replay payload with a NON-STRING outcome (e.g. a JSON
+        number) must map to a per-issue 'error' Result — not raise
+        AttributeError on outcome.startswith()."""
+        issue = self._make_issue(
+            "apply-bad-outcome-sid-0008",
+            str(tmp_path / "apply-bad-outcome-sid-0008.jsonl"),
+            "/path/to/my-proj",
+            str(tmp_path / "2026-04-24-my-proj-qqqq.md"),
+        )
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"outcome": 123, "vault_writes": []})
+        mock_result.stderr = ""
+        monkeypatch.setattr(subprocess, "run", MagicMock(return_value=mock_result))
+
+        results = sc.apply([issue], str(tmp_path / "backup"))
+        assert len(results) == 1
+        assert results[0].status == "error"
+        assert "123" in (results[0].error or "")
+
+    def test_apply_none_outcome_is_error_not_crash(self, tmp_path, monkeypatch):
+        """outcome: null in the replay payload → per-issue error, no crash."""
+        issue = self._make_issue(
+            "apply-null-outcome-sid-0009",
+            str(tmp_path / "apply-null-outcome-sid-0009.jsonl"),
+            "/path/to/my-proj",
+            str(tmp_path / "2026-04-24-my-proj-rrrr.md"),
+        )
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = json.dumps({"outcome": None, "vault_writes": []})
+        mock_result.stderr = ""
+        monkeypatch.setattr(subprocess, "run", MagicMock(return_value=mock_result))
+
+        results = sc.apply([issue], str(tmp_path / "backup"))
+        assert len(results) == 1
+        assert results[0].status == "error"
+
+    def test_apply_non_list_vault_writes_is_error_and_sweep_continues(
+        self, tmp_path, monkeypatch
+    ):
+        """Success outcome with a NON-LIST vault_writes (broken replay
+        contract) → per-issue 'error'; the sweep continues to the next issue
+        instead of raising TypeError/IndexError."""
+        issue_bad = self._make_issue(
+            "apply-malformed-writes-sid-0010",
+            str(tmp_path / "apply-malformed-writes-sid-0010.jsonl"),
+            "/path/to/my-proj",
+            str(tmp_path / "2026-04-24-my-proj-ssss.md"),
+        )
+        issue_ok = self._make_issue(
+            "apply-malformed-writes-sid-0011",
+            str(tmp_path / "apply-malformed-writes-sid-0011.jsonl"),
+            "/path/to/my-proj",
+            str(tmp_path / "2026-04-24-my-proj-tttt.md"),
+        )
+        bad = MagicMock()
+        bad.returncode = 0
+        bad.stdout = json.dumps(
+            {"outcome": "OK_RAW_NOTE_ONLY", "vault_writes": "not-a-list"}
+        )
+        bad.stderr = ""
+        actual = str(tmp_path / "2026-06-09-my-proj-tttt.md")
+        good = _mock_replay_result("OK_RAW_NOTE_ONLY", vault_writes=[[actual, 99]])
+        monkeypatch.setattr(subprocess, "run", MagicMock(side_effect=[bad, good]))
+
+        results = sc.apply([issue_bad, issue_ok], str(tmp_path / "backup"))
+        assert len(results) == 2, "sweep must continue past the malformed payload"
+        assert results[0].status == "error"
+        assert "vault_writes" in (results[0].error or "")
+        assert results[1].status == "applied"
+        assert results[1].note_path == actual
+
+    def test_apply_empty_inner_vault_writes_entry_is_error(self, tmp_path, monkeypatch):
+        """vault_writes=[[]] (empty inner entry) → per-issue 'error', not
+        IndexError on vault_writes[0][0]."""
+        issue = self._make_issue(
+            "apply-empty-inner-sid-0012",
+            str(tmp_path / "apply-empty-inner-sid-0012.jsonl"),
+            "/path/to/my-proj",
+            str(tmp_path / "2026-04-24-my-proj-uuuu.md"),
+        )
+        monkeypatch.setattr(subprocess, "run", MagicMock(
+            return_value=_mock_replay_result("OK_RAW_NOTE_ONLY", vault_writes=[[]]),
+        ))
+        results = sc.apply([issue], str(tmp_path / "backup"))
+        assert len(results) == 1
+        assert results[0].status == "error"
+        assert "vault_writes" in (results[0].error or "")
+
+    def test_apply_empty_vault_writes_error_mentions_note_check(
+        self, tmp_path, monkeypatch
+    ):
+        """The 'wrote nothing' error guides the operator to verify the note
+        before re-running (the replay may have partially succeeded)."""
+        issue = self._make_issue(
+            "apply-empty-writes-hint-sid-0013",
+            str(tmp_path / "apply-empty-writes-hint-sid-0013.jsonl"),
+            "/path/to/my-proj",
+            str(tmp_path / "2026-04-24-my-proj-vvvv.md"),
+        )
+        monkeypatch.setattr(subprocess, "run", MagicMock(
+            return_value=_mock_replay_result("OK_RAW_NOTE_ONLY", vault_writes=[]),
+        ))
+        results = sc.apply([issue], str(tmp_path / "backup"))
+        assert len(results) == 1
+        assert results[0].status == "error"
+        assert "check whether the note now exists" in (results[0].error or "")
+
     def test_replay_script_exists_in_repo(self):
         """apply() shells out to replay-sessionend.py — pin its in-repo path
         so a rename/move breaks loudly here, not silently at apply-time."""
@@ -1369,6 +1503,15 @@ class TestSummaryPartition:
         assert bt == 1
         assert unparsable == 1
         assert gaps + covered + bt + unparsable + proj_filt == total
+
+    def test_summary_printed_even_when_nothing_scanned(self, sc_env, capsys):
+        """An empty projects root (dir exists, no project dirs) still prints
+        the end-of-scan summary with zero counts — a silent scan is
+        indistinguishable from a scan that never ran."""
+        issues = _scan(sc_env)
+        assert issues == []
+        _, err = capsys.readouterr()
+        assert "scanned 0 jsonl(s) across 0 project dir(s)" in err
 
 
 # ---------------------------------------------------------------------------
@@ -1487,6 +1630,51 @@ class TestCLIE2E:
             f"expected usage error (3), got {r.returncode}:\n{r.stderr}"
         )
         assert "--strict is only consumed by an opt-in check" in r.stderr
+
+    def test_named_non_consumer_check_with_strict_is_usage_error(self, sc_env):
+        """--check source-sessions --strict → exit 3 (the guard also fires
+        when a NAMED check doesn't consume the flag, not only on the default
+        sweep). Coverage pin for vault_doctor.py's unconsumed-flag guard."""
+        r = self._run(sc_env, "--strict", check="source-sessions")
+        assert r.returncode == 3, (
+            f"expected usage error (3), got {r.returncode}:\n{r.stderr}"
+        )
+        assert "--strict is only consumed by an opt-in check" in r.stderr
+        assert "--check session-coverage" in r.stderr
+
+    def test_reconstruct_gap_survives_min_confidence(self, sc_env):
+        """--reconstruct + --min-confidence 0.5: a resolvable gap carries
+        confidence 0.9 and must SURVIVE the filter (reported, exit 1) —
+        otherwise --min-confidence silently nullifies --reconstruct."""
+        sid = "cli-e2e-minconf-reconstruct-0001"
+        cwd = "/Users/abhishek/dev/claude_workspace/obsidian-brain"
+        _write_jsonl(sc_env["projects"], "-ob", sid, cwd, n_user=5, duration_minutes=10)
+
+        r = self._run(sc_env, "--reconstruct", "--min-confidence", "0.5")
+        assert r.returncode == 1, (
+            f"expected 1 (gap survives filter), got {r.returncode}:\n{r.stderr}"
+        )
+        payload = json.loads(r.stdout)
+        assert payload["total_issues"] == 1
+        row = payload["issues"][0]
+        assert row["confidence"] == 0.9
+        assert row["unresolved"] is False
+
+    def test_unresolved_gap_dropped_by_min_confidence(self, sc_env):
+        """Without --reconstruct the gap is unresolved (confidence 0.0) and
+        --min-confidence 0.5 drops it: qualified clean line, exit 0."""
+        sid = "cli-e2e-minconf-noreconstruct-0002"
+        cwd = "/Users/abhishek/dev/claude_workspace/obsidian-brain"
+        _write_jsonl(sc_env["projects"], "-ob", sid, cwd, n_user=5, duration_minutes=10)
+
+        r = self._run(sc_env, "--min-confidence", "0.5")
+        assert r.returncode == 0, (
+            f"expected 0 (gap filtered), got {r.returncode}:\n{r.stderr}"
+        )
+        payload = json.loads(r.stdout)
+        assert payload["total_issues"] == 0
+        assert payload["dropped_by_confidence"] == 1
+        assert "clean at --min-confidence 0.5" in r.stderr
 
     def test_full_sweep_without_extra_flags_unaffected(self, sc_env):
         """Default sweep WITHOUT --strict/--reconstruct stays on the normal


### PR DESCRIPTION
## Summary

Combined `/deep-review` of all six epic #170 PRs (#206 #207 #208 #210 #211 #213) as one system — the cross-PR interactions were never reviewed as a unit. Two commits:

**Phase 1 — iterative convergence (3 reviewers × 3 rounds):**
- **session-coverage × --min-confidence**: reconstructable gaps now carry confidence 0.9, so `--reconstruct --apply --min-confidence N` no longer silently drops every repair and reports "clean" (convergent finding from all 3 reviewers)
- **audit-historic-repairs**: missing/empty backup root now warns loudly + unconditional coverage summary (was indistinguishable from a clean audit)
- **dispatcher crash containment**: per-check try/except on scan and apply; `crashed_checks` in JSON + header; "results incomplete" instead of plain "clean"; exit 2 (was exit-1 collision with "issues found" and silent loss of partial-apply records)
- **dropped_per_signal_class** attribution so infrastructure-failure rows are visible under `--min-confidence`
- exit-code contract docs synced (vault_doctor.py docstring + SKILL.md crash-vs-apply-error remediation branches)
- robustness: unconditional scan summaries, registry interface warning, replay-JSON shape guards; min-confidence tests rewired to production `_confidence_passes`
- +25 tests (16 proven fail-first); suite 1510 → 1534

**Phase 2 — Claude↔Gemini adversarial (R1 blind / R2 cross-judge / R3 counter-round):**
- Survivors fixed: `_issue_row` lifted to module level; `projects_root` via `Path.home()` convention; fixture `--days` 36500→10000; mkstemp suffix `.tmp`→`.md.tmp`
- Dismissed: stale SKILL.md tagline (originator conceded — pre-existing, trivial)
- Escalated judgment call (unresolved, intentionally not fixed): G-001 — add `p.is_dir()` precondition before `git -C` in `_derive_canonical` vs relying on the already-surfaced git stderr; Claude refuted (disposition already WARN-safe, label-only change), Gemini defended (precondition validation is cleaner). Maintainer's call.

## Test plan

- [x] Full suite: 1534 passed (baseline 1510)
- [x] 16 new guards proven fail-first
- [x] Preflight (secrets, version-sync, tests ≥90% coverage) green on both commits

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
