### PR TITLE
docs: deep architecture page + fix GitHub Pages Jekyll build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Deep architecture reference page** (`docs/architecture/architecture.json` + self-contained `docs/architecture/architecture.html`) — layer/flow/design views with data flows rendered as inline-SVG sequence diagrams. Generated via the `architecture-page` skill and verified against live source.
+
+### Fixed
+- **GitHub Pages** — add `docs/.nojekyll` so the legacy Jekyll build stops failing on every `develop` push (the `docs/` tree holds internal specs/plans, not a Jekyll site) and so the static architecture page serves verbatim.
+
 ## [2.7.0] - 2026-06-11
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,20 @@ Machine-local config at `~/.claude/obsidian-brain-config.json` (outside the vaul
 
 All frontmatter tags use the `claude/` prefix: `claude/session`, `claude/insight`, `claude/decision`, `claude/error-fix`, `claude/snapshot`, `claude/imported`, `claude/standup`, `claude/retro`, `claude/project/<name>`, `claude/topic/<topic>`, `claude/auto`.
 
+### Keeping the architecture page current
+
+`docs/architecture/architecture.json` is the canonical, machine-readable architecture of this plugin (rendered to `docs/architecture/architecture.html`). It is consumed by future agents, so it must not drift from the code.
+
+**Whenever a change adds, removes, or renames a hook, skill, vault-doctor check, CLI/support module, datastore, env var, or alters a data flow, update the architecture artifacts in the same PR:**
+
+- Edit `docs/architecture/architecture.json` (layers / components / flows / types / environment), keeping `lastUpdated` set to the change date and `version` in sync with `plugin.json`. Every `flows[].steps[].from`/`to` must reference a real `layers[].components[].id`, and every component `files[]` path must exist on disk.
+- Re-render the viewer: `~/.claude/skills/architecture-page/scripts/render-html.sh --json docs/architecture/architecture.json --output docs/architecture/architecture.html`
+- Validate before committing: `~/.claude/skills/architecture-page/scripts/smoke-test.sh --json docs/architecture/architecture.json` — both `[main]` and `[sparse]` must pass.
+- For a large or structural change, regenerate from scratch via the `architecture-page` skill rather than hand-editing.
+- Ground every claim in live source (run `wc -l`, read the actual file) — never copy a number or path from prose/docs that may be stale.
+
+`docs/.nojekyll` keeps GitHub Pages serving these files verbatim; do not remove it.
+
 ## Conventions
 
 - **Commits:** Use conventional commit format — `feat(obsidian-brain):`, `fix:`, `chore:`, `docs:`

--- a/docs/architecture/architecture.html
+++ b/docs/architecture/architecture.html
@@ -1,0 +1,785 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Architecture</title>
+<style>
+  :root {
+    --bg: #0a0a14;
+    --bg-elev: #11111d;
+    --bg-elev-2: #181828;
+    --border: #26263a;
+    --border-bright: #3a3a5a;
+    --text: #e5e7f0;
+    --text-dim: #9aa0b8;
+    --text-faint: #6b7088;
+    --accent: #7df9ff;
+    --accent-warm: #ffb86b;
+    --shadow: 0 1px 0 rgba(125, 249, 255, .06) inset, 0 0 0 1px var(--border);
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  }
+  :root[data-theme="light"] {
+    --bg: #f6f7fb;
+    --bg-elev: #ffffff;
+    --bg-elev-2: #f0f2f8;
+    --border: #d8dbe6;
+    --border-bright: #b8bccd;
+    --text: #1a1d2e;
+    --text-dim: #4a5070;
+    --text-faint: #7a8099;
+    --accent: #0c8a9e;
+    --accent-warm: #c25a00;
+  }
+
+  /* Theme toggle button */
+  .theme-toggle {
+    position: absolute; top: 20px; right: 24px;
+    width: 36px; height: 36px;
+    border: 1px solid var(--border); border-radius: 8px;
+    background: var(--bg-elev); color: var(--text-dim);
+    font-size: 16px; cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+    transition: background .15s, color .15s, border-color .15s, transform .1s;
+  }
+  .theme-toggle:hover { background: var(--bg-elev-2); color: var(--text); border-color: var(--border-bright); }
+  .theme-toggle:active { transform: scale(.95); }
+  header.hero { position: relative; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--text); font: 14.5px/1.55 -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Inter, system-ui, sans-serif; }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  code, pre, .mono { font-family: var(--mono); font-size: 13px; }
+
+  header.hero {
+    padding: 48px 32px 28px;
+    border-bottom: 1px solid var(--border);
+    background: linear-gradient(180deg, rgba(125,249,255,.04), transparent 70%);
+  }
+  .hero h1 { margin: 0 0 4px; font-size: 32px; font-weight: 600; letter-spacing: -.5px; }
+  .hero .codename { color: var(--accent); font-family: var(--mono); font-size: 14px; opacity: .8; }
+  .hero p.tagline { margin: 14px 0 0; color: var(--text-dim); max-width: 820px; font-size: 16px; }
+  .hero .meta { margin-top: 18px; display: flex; gap: 14px 22px; flex-wrap: wrap; font-size: 13px; color: var(--text-faint); }
+  .hero .meta b { color: var(--text-dim); font-weight: 500; }
+
+  nav.tabs {
+    position: sticky; top: 0; z-index: 10;
+    display: flex; gap: 2px; padding: 0 32px; background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    overflow-x: auto;
+  }
+  nav.tabs button {
+    background: transparent; border: 0; color: var(--text-dim);
+    padding: 14px 16px; font-size: 13px; font-family: inherit; cursor: pointer;
+    border-bottom: 2px solid transparent; white-space: nowrap;
+  }
+  nav.tabs button:hover { color: var(--text); }
+  nav.tabs button.active { color: var(--accent); border-bottom-color: var(--accent); }
+
+  main { padding: 28px 32px 80px; max-width: 1400px; margin: 0 auto; }
+  section.panel { display: none; }
+  section.panel.active { display: block; }
+  section h2 { margin: 0 0 6px; font-size: 22px; font-weight: 600; letter-spacing: -.3px; }
+  section h2 + p { margin: 0 0 24px; color: var(--text-dim); max-width: 760px; }
+  h3 { margin: 28px 0 10px; font-size: 16px; font-weight: 600; }
+
+  /* Layers grid */
+  .layers { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 14px; }
+  .layer-card {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 16px;
+    cursor: pointer;
+    transition: border-color .15s, transform .15s;
+    position: relative;
+    overflow: hidden;
+  }
+  .layer-card:hover { border-color: var(--border-bright); transform: translateY(-1px); }
+  .layer-card .accent-bar { position: absolute; left: 0; top: 0; bottom: 0; width: 4px; background: var(--layer-color); }
+  .layer-card h4 { margin: 0 0 4px; font-size: 15px; color: var(--layer-color); font-weight: 600; padding-left: 8px; }
+  .layer-card .desc { margin: 0 0 10px; color: var(--text-dim); font-size: 13px; padding-left: 8px; min-height: 36px; }
+  .layer-card .count { color: var(--text-faint); font-size: 12px; padding-left: 8px; font-family: var(--mono); }
+
+  /* Layer detail (expanded view) */
+  .layer-detail {
+    margin-top: 22px;
+    padding: 22px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--layer-color, var(--accent));
+    border-radius: 10px;
+    display: none;
+  }
+  .layer-detail.open { display: block; }
+  .layer-detail h3 { margin-top: 0; font-size: 18px; color: var(--layer-color, var(--text)); }
+  .layer-detail .components { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 12px; margin-top: 12px; }
+  .component {
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 12px 14px;
+  }
+  .component .name { font-weight: 600; font-size: 14px; }
+  .component .kind {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 1px 7px;
+    border-radius: 4px;
+    background: var(--border);
+    color: var(--text-dim);
+    font-family: var(--mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: .3px;
+  }
+  .component .files { margin: 6px 0 8px; font-family: var(--mono); font-size: 12px; color: var(--text-faint); word-break: break-all; }
+  .component .files .file { display: block; }
+  .component .purpose { margin: 0; color: var(--text-dim); font-size: 13px; }
+  .component .extra { margin-top: 6px; font-size: 12px; color: var(--text-faint); }
+
+  /* Flow cards */
+  .flow {
+    margin: 16px 0;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: var(--bg-elev);
+    overflow: hidden;
+  }
+  .flow-header { padding: 14px 18px; cursor: pointer; user-select: none; display: flex; align-items: center; justify-content: space-between; }
+  .flow-header:hover { background: var(--bg-elev-2); }
+  .flow-header .name { font-weight: 600; font-size: 15px; }
+  .flow-header .desc { color: var(--text-dim); font-size: 13px; margin-top: 2px; }
+  .flow-header .chevron { color: var(--text-faint); transition: transform .15s; }
+  .flow.open .flow-header .chevron { transform: rotate(90deg); }
+  .flow-body { display: none; padding: 4px 18px 18px; }
+  .flow.open .flow-body { display: block; }
+  /* Sequence diagrams (flows) */
+  .seq-wrap { overflow-x: auto; padding: 8px 0 4px; }
+  svg.seq { display: block; font-family: -apple-system, system-ui, sans-serif; }
+  svg.seq .lifeline { stroke: var(--border); stroke-width: 1.5; stroke-dasharray: 4 5; }
+  svg.seq .participant rect { fill: var(--bg-elev-2); stroke-width: 1.5; }
+  svg.seq .participant text { fill: var(--text); font-size: 11.5px; font-weight: 600; }
+  svg.seq .participant { cursor: pointer; }
+  svg.seq .participant:hover rect { stroke: var(--accent); }
+  svg.seq .participant:hover text { fill: var(--accent); }
+  svg.seq .row-band { fill: var(--text-faint); opacity: .06; }
+  svg.seq .msg-line { stroke: var(--text-dim); stroke-width: 1.5; fill: none; }
+  svg.seq .msg-head { fill: var(--text-dim); stroke: none; }
+  svg.seq .msg-label { fill: var(--text-dim); font-size: 11px; }
+  svg.seq .seq-num { fill: var(--text-faint); font-size: 10px; }
+
+  /* Endpoints */
+  table.endpoints { width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 13.5px; }
+  table.endpoints th { text-align: left; padding: 10px 12px; background: var(--bg-elev-2); border-bottom: 1px solid var(--border); color: var(--text-dim); font-weight: 500; font-size: 12px; text-transform: uppercase; letter-spacing: .4px; }
+  table.endpoints td { padding: 12px; border-bottom: 1px solid var(--border); vertical-align: top; }
+  table.endpoints tr:hover td { background: var(--bg-elev); }
+  .method { font-family: var(--mono); font-weight: 600; padding: 2px 7px; border-radius: 4px; font-size: 11.5px; letter-spacing: .3px; }
+  .method.GET { background: rgba(125, 249, 255, .12); color: var(--accent); }
+  .method.POST { background: rgba(255, 184, 107, .15); color: var(--accent-warm); }
+  td.path { font-family: var(--mono); }
+  td.params { font-family: var(--mono); font-size: 12px; color: var(--text-dim); }
+
+  /* Diagram */
+  .diagram-wrap { margin-top: 12px; padding: 28px; background: var(--bg-elev); border: 1px solid var(--border); border-radius: 10px; overflow-x: auto; }
+  .diagram { display: grid; grid-template-columns: repeat(3, minmax(180px, 1fr)); gap: 18px; min-width: 720px; }
+  .dnode {
+    background: var(--bg-elev-2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 14px;
+    text-align: center;
+    font-size: 13px;
+    position: relative;
+  }
+  .dnode .label { font-weight: 600; }
+  .dnode .sub { display: block; color: var(--text-dim); font-size: 11.5px; margin-top: 4px; font-family: var(--mono); }
+  .dnode.full { grid-column: 1 / -1; background: linear-gradient(180deg, var(--bg-elev-2), var(--bg-elev)); }
+  .arrow-down { text-align: center; color: var(--text-faint); font-size: 18px; line-height: 1; padding: 4px 0; grid-column: 1 / -1; }
+  .arrow-down .lbl { font-size: 11px; color: var(--text-dim); font-family: var(--mono); display: block; }
+
+  /* Lists */
+  ul.tight { margin: 8px 0; padding-left: 22px; color: var(--text-dim); }
+  ul.tight li { margin: 4px 0; }
+  ul.tight code { color: var(--text); background: var(--bg-elev-2); padding: 1px 6px; border-radius: 3px; }
+
+  .kv { display: grid; grid-template-columns: max-content 1fr; gap: 6px 18px; margin-top: 10px; font-size: 13.5px; }
+  .kv dt { font-family: var(--mono); color: var(--accent); }
+  .kv dd { margin: 0; color: var(--text-dim); }
+
+  .pill {
+    display: inline-block; padding: 3px 9px; border-radius: 999px;
+    background: var(--bg-elev-2); border: 1px solid var(--border);
+    font-size: 12px; color: var(--text-dim); margin: 2px 4px 2px 0;
+    font-family: var(--mono);
+  }
+
+  /* Search */
+  .search-wrap { margin: 0 0 18px; }
+  .search-wrap input {
+    width: 100%; padding: 10px 14px; font-size: 14px; font-family: inherit;
+    background: var(--bg-elev); border: 1px solid var(--border); border-radius: 8px;
+    color: var(--text);
+  }
+  .search-wrap input:focus { outline: none; border-color: var(--accent); }
+  .hit-mark { background: rgba(255, 184, 107, .22); color: var(--accent-warm); padding: 0 2px; border-radius: 2px; }
+
+  footer { padding: 32px; border-top: 1px solid var(--border); color: var(--text-faint); font-size: 12.5px; text-align: center; }
+  footer a { color: var(--text-dim); }
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle dark / light theme" title="Toggle theme">☾</button>
+  <div class="codename" id="hero-codename"></div>
+  <h1 id="hero-name"></h1>
+  <p class="tagline" id="hero-tagline"></p>
+  <div class="meta" id="hero-meta"></div>
+</header>
+
+<nav class="tabs" id="tabs">
+  <button data-tab="overview" class="active">Overview</button>
+  <button data-tab="diagram">Architecture diagram</button>
+  <button data-tab="layers">Layers</button>
+  <button data-tab="flows">Data flows</button>
+  <button data-tab="endpoints">HTTP API</button>
+  <button data-tab="design">Design</button>
+  <button data-tab="testing">Testing</button>
+  <button data-tab="ops">Operations</button>
+  <button data-tab="docs">Docs</button>
+</nav>
+
+<main>
+
+<section class="panel active" id="panel-overview">
+  <h2>Overview</h2>
+  <p id="overview-tagline"></p>
+
+  <h3>Tech stack</h3>
+  <dl class="kv" id="tech-kv"></dl>
+
+  <h3>Environment variables</h3>
+  <table class="endpoints"><thead><tr><th>Name</th><th>Default</th><th>Purpose</th></tr></thead><tbody id="env-tbody"></tbody></table>
+
+  <h3>Scripts</h3>
+  <table class="endpoints"><thead><tr><th style="width: 180px">Name</th><th>Command</th></tr></thead><tbody id="scripts-tbody"></tbody></table>
+</section>
+
+<section class="panel" id="panel-diagram">
+  <h2>Architecture diagram</h2>
+  <p id="diagram-intro" style="color: var(--text-dim); max-width: 820px"></p>
+  <div id="diagram-content" class="diagram-wrap"></div>
+  <div id="diagram-notes"></div>
+</section>
+
+<section class="panel" id="panel-layers">
+  <h2>Layers</h2>
+  <p>Ten architectural layers, from JSONL source through to the kanban UI. Click a card to expand its components.</p>
+  <div class="search-wrap"><input id="layer-search" placeholder="Filter layers and components (e.g. 'push', 'device-cursor', 'IDB')…" /></div>
+  <div class="layers" id="layers-grid"></div>
+  <div class="layer-detail" id="layer-detail"></div>
+</section>
+
+<section class="panel" id="panel-flows">
+  <h2>Data flows</h2>
+  <p>End-to-end paths through the system, drawn as sequence diagrams. Click a flow to expand its diagram; click any participant box to jump to its definition.</p>
+  <div id="flows-list"></div>
+</section>
+
+<section class="panel" id="panel-endpoints">
+  <h2>HTTP API</h2>
+  <p>All routes are Next.js App Router handlers (<code>app/api/**/route.ts</code>). Dev-only endpoints 404 outside <code>NODE_ENV</code> = development/test.</p>
+  <table class="endpoints"><thead><tr><th style="width:70px">Method</th><th style="width:280px">Path</th><th>Purpose</th><th>Params / body</th></tr></thead><tbody id="endpoints-tbody"></tbody></table>
+</section>
+
+<section class="panel" id="panel-design">
+  <h2>Design principles &amp; tradeoffs</h2>
+  <p>Why the architecture is the way it is — including the iOS Safari constraints that shaped the journal + push-prewarm design.</p>
+
+  <h3>Principles</h3>
+  <ul class="tight" id="principles-list"></ul>
+
+  <h3>Hard constraints</h3>
+  <ul class="tight" id="constraints-list"></ul>
+
+  <h3>Tradeoffs</h3>
+  <div id="tradeoffs-list"></div>
+
+  <h3>Key types</h3>
+  <div id="types-list"></div>
+</section>
+
+<section class="panel" id="panel-testing">
+  <h2>Testing</h2>
+  <p>763 unit tests under Vitest, plus 8 Playwright E2E specs (Chromium + iPhone 13 WebKit).</p>
+  <div id="testing-blocks"></div>
+</section>
+
+<section class="panel" id="panel-ops">
+  <h2>Operations</h2>
+  <p>macOS launchd auto-start, watchdog that re-installs the agent if cleaner apps delete it, and an audit stream for forensic capture.</p>
+  <div class="components" id="ops-components" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:12px"></div>
+
+  <h3>Git Flow</h3>
+  <dl class="kv" id="gitflow-kv"></dl>
+</section>
+
+<section class="panel" id="panel-docs">
+  <h2>Documentation</h2>
+  <p>Design specs and implementation plans under <code>docs/superpowers/</code>.</p>
+  <ul class="tight" id="docs-list"></ul>
+</section>
+
+</main>
+
+<footer>
+  Source: <code id="json-source-path">docs/architecture/architecture.json</code> (in repo) &nbsp;·&nbsp;
+  <a id="json-link" href="./architecture.json">View raw JSON</a> (live)
+</footer>
+
+<script id="arch-data" type="application/json">{"name": "obsidian-brain", "displayName": "Obsidian Brain", "version": "2.7.1", "tagline": "A Claude Code plugin that turns an Obsidian vault into a persistent brain across sessions — auto-logging, curated knowledge capture, snapshot-on-compact, and fast cross-project recall, all via direct filesystem writes.", "lastUpdated": "2026-06-12", "repository": "https://github.com/abhattacherjee/obsidian-brain", "defaultBranch": "main", "techStack": {"language": {"name": "Python", "version": "3.12", "strict": true, "notes": "stdlib only — no pip dependencies; deterministic hooks safe to run at session boundaries"}, "framework": {"name": "Claude Code Plugin", "version": "2.7.1", "router": "lifecycle hooks + prompt-based skills"}, "runtime": {"name": "Python", "minVersion": "3.12"}, "ui": {"library": "Obsidian Dataview", "version": "community plugin (JS + inline queries)", "notes": "dashboards only — the plugin itself requires no Obsidian plugin to write notes"}, "persistence": {"primary": "Markdown vault (filesystem)", "secondary": ["SQLite + FTS5 search index", "JSON config", "append-only telemetry logs"]}, "realtime": {"protocol": "none", "endpoint": "direct filesystem writes — no MCP server, no REST API, no daemon"}, "ai": {"provider": "Claude CLI (claude -p)", "model": "haiku default; escalates haiku to sonnet to opus on empty output (#165)", "notes": "summarization deferred from hooks to /recall"}, "vectorSearch": {"engine": "SQLite FTS5 (BM25) + 7-signal rerank; TF-IDF cosine themes with ACT-R activation and Free-Energy surprise"}, "tests": {"unit": {"runner": "pytest", "count": 64, "environments": ["python3.12"], "coverage": {"lines": 90}}}, "packageManager": "none (stdlib only)"}, "diagram": {"intro": "Two execution modes feed one store. Auto-running Python hooks fire on Claude Code session-lifecycle events and write raw notes immediately (write-first); prompt-based skills run on demand to summarize, search, triage and repair. A shared stdlib core (obsidian_utils) is the spine; a SQLite+FTS5 index powers ranked recall. Everything is a direct, atomic filesystem write — it works even when Obsidian is closed.", "tiers": [{"arrowLabel": null, "nodes": [{"label": "Claude Code", "sub": "session lifecycle", "color": "#7B61FF", "full": true}]}, {"arrowLabel": "SessionEnd · SessionStart · PreCompact", "nodes": [{"label": "Lifecycle Hooks", "sub": "log · hint · snapshot · reaper", "color": "#7B61FF", "full": true}]}, {"arrowLabel": "shared spine (stdlib)", "nodes": [{"label": "obsidian_utils", "sub": "config · session-ctx · summarize · atomic write · scrub", "color": "#22D3EE", "full": true}]}, {"arrowLabel": "persist (write-first, atomic, 0600)", "nodes": [{"label": "Markdown Vault", "sub": "sessions / insights / snapshots", "color": "#F97316"}, {"label": "SQLite + FTS5", "sub": "7-signal rank · themes", "color": "#10B981"}, {"label": "Config + Telemetry", "sub": "~/.claude", "color": "#84CC16"}]}, {"arrowLabel": "on demand (18 skills)", "nodes": [{"label": "Capture / Recall", "sub": "compress · recall · vault-ask · standup", "color": "#8B5CF6"}, {"label": "vault-doctor", "sub": "9 pluggable checks", "color": "#EC4899"}, {"label": "check-items", "sub": "AI triage pipeline", "color": "#F59E0B"}]}], "notes": ["Hooks never import vault_index — indexing is a deliberate skill-side concern, keeping hooks fast and deterministic (they must exit 0).", "Summarization (claude -p haiku) is deferred from SessionEnd to /recall, because a SessionEnd subprocess is SIGKILLed when the session process-tree exits.", "All vault writes are atomic temp+rename, mode 0600, path-contained via resolve()+is_relative_to() against the vault root.", "A cross-plugin O_EXCL dedup lock (fail-open, 15s TTL) lets the monorepo and standalone installs coexist without double-writing."]}, "layers": [{"id": "lifecycle-hooks", "name": "Lifecycle Hooks (auto-running Python)", "color": "#7B61FF", "description": "Stdlib Python scripts registered in hooks/hooks.json, triggered by Claude Code session-lifecycle events. Each reads JSON from stdin (1 MB cap), always exits 0, and writes atomically. Implements the write-first pattern: raw notes saved immediately, AI summarization deferred to /recall.", "components": [{"id": "hook-session-log", "name": "obsidian_session_log.py", "kind": "module", "files": ["hooks/obsidian_session_log.py"], "purpose": "SessionEnd: writes the raw session note immediately. Discovers sibling snapshots (cross-midnight), applies message-count + duration thresholds (snapshot presence bypasses skips), dedup-claims before the expensive raw-body build, and logs a structured outcome line for every exit path."}, {"id": "hook-session-hint", "name": "obsidian_session_hint.py", "kind": "module", "files": ["hooks/obsidian_session_hint.py"], "purpose": "SessionStart (matcher startup|resume|clear|compact): refreshes the bootstrap sid-file atomically, invokes the orphan reaper, and injects a read-only last-session context hint via hookSpecificOutput.additionalContext."}, {"id": "hook-context-snapshot", "name": "obsidian_context_snapshot.py", "kind": "module", "files": ["hooks/obsidian_context_snapshot.py"], "purpose": "PreCompact: saves a context snapshot before compression. Gates on snapshot_on_compact/snapshot_on_clear, scrubs secrets, and writes a snapshot note backlinked to its parent session. Stderr-only telemetry (no hook-log line)."}, {"id": "hook-session-reaper", "name": "obsidian_session_reaper.py", "kind": "module", "files": ["hooks/obsidian_session_reaper.py"], "purpose": "Called by SessionStart: reconstructs session notes for orphaned JSONL transcripts where SessionEnd never fired (SIGKILL, worktree teardown). Watermark-bounded, 5s budget, permission-canary guarded; writes notes tagged claude/reconstructed."}, {"id": "hooks-registration", "name": "hooks.json", "kind": "registration", "files": ["hooks/hooks.json"], "purpose": "Registers SessionEnd to session_log, SessionStart to session_hint, PreCompact to context_snapshot. Commands invoke python3 with the plugin-root hook path."}]}, {"id": "shared-core", "name": "Shared Core (obsidian_utils)", "color": "#22D3EE", "description": "The ~5.5k-line stdlib spine (4.3k code lines) imported by every hook and many skills: config + session resolution, transcript parsing, deferred summarization (shells out to claude -p), atomic vault writes, secret scrubbing, the cross-plugin dedup lock, and telemetry. Every function self-catches and logs to stderr.", "components": [{"id": "load-config", "name": "load_config()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Reads the machine-local config JSON over deepcopy(_DEFAULTS), session-scoped cached by cwd-derived SID. Side-effect: auto-chmods the config to 0600 if group/world bits are set."}, {"id": "session-context", "name": "get_session_context() / SID resolution", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Single source of truth for session id, 4-char hash, project, and session-note name. Layered SID chain: project-basename to bootstrap fast-path to slow JSONL glob to recent-bootstrap scan to unknown. SID filenames validated against a safe charset to block path traversal."}, {"id": "canonical-project-name", "name": "canonical_project_name()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Resolves the main-repo basename via the git common-dir so all worktrees of a repo collapse under one logical project; normalizes spaces/underscores to hyphens; one-shot stderr warning only on genuine git failure."}, {"id": "transcript-parser", "name": "read_transcript() / extract_*_messages()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Parses CC JSONL transcripts (nested message.content and flat shapes), extracting user/assistant messages and tool uses."}, {"id": "session-metadata", "name": "extract_session_metadata()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Derives project, project_path, git_branch, files_touched (<=60), errors (<=30), duration_minutes, and commits from a transcript."}, {"id": "summarizer", "name": "generate_summary() / generate_snapshot_summary()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Builds a structured prompt and runs the Claude CLI in print mode with timeout+retry. Two-layer open-item dedup, model escalation on empty output, and conservative summary recovery (_normalize_summary). Returns (text, reason)."}, {"id": "write-vault-note", "name": "write_vault_note()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "The single atomic-write primitive: path-traversal check (resolve + is_relative_to vault root) BEFORE any side effect, then mkstemp + chmod 0600 + os.rename. Returns None on success or a non-empty error string."}, {"id": "scrub-secrets", "name": "scrub_secrets() / escape_wikilinks()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Best-effort redaction of GitHub/AWS tokens, password/secret/api_key assignments, PEM headers and Bearer values before any user content reaches the vault; escapes double-brackets so bash test brackets do not create phantom Obsidian links."}, {"id": "hook-dedup-lock", "name": "claim_hook_run() / release_hook_run()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "O_CREAT|O_EXCL lock files under the secure working dir (15s TTL, fail-open, PID-checked release) coordinating the double-install (monorepo + standalone) case so a hook never fires twice."}, {"id": "gather-evidence", "name": "gather_session_evidence()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "For /retro: collects all snapshots + insights/decisions/error-fixes whose frontmatter source_session matches the active session, with discovery_errors captured rather than raised."}, {"id": "telemetry-log", "name": "_append_sessionend_log() / _append_reaper_log()", "kind": "ops", "files": ["hooks/obsidian_utils.py"], "purpose": "Writes one-line key=value outcome records to the hook telemetry log, rotating at 100 KB, 0600, sanitizing newlines/tabs. Primary diagnostic surface for sessions that did not produce a vault note."}]}, {"id": "search-index", "name": "Search & Index (SQLite + FTS5)", "color": "#10B981", "description": "A local SQLite database (WAL mode, FTS5) that enables fast full-text and ranked recall across the vault. Lazy mtime-incremental sync, a 7-signal reranker, ACT-R activation from an access log, and TF-IDF cosine themes with a Free-Energy surprise signal. Hooks never touch this — it is skill-side only.", "components": [{"id": "ensure-index", "name": "ensure_index() / _sync()", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Create-or-update the DB: schema init statement-by-statement (FTS5 IF NOT EXISTS), column migrations, mtime-incremental sync inside BEGIN IMMEDIATE, and corruption recovery that deletes+recreates db/-wal/-shm.", "overrideEnv": "OBSIDIAN_BRAIN_DB"}, {"id": "search-vault", "name": "search_vault()", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Sanitizes the query to AND-mode FTS5 (hyphens to spaces), runs bm25 with title 10x and tags 5x weighting, OR-fallback when AND is empty, reranks, batch-logs access, strips body before returning."}, {"id": "rerank", "name": "rerank_results() — 7-signal scorer", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Weighted sum: proximity 0.25, bm25 0.20, activation 0.20, type 0.10, recency 0.10, importance 0.10, density 0.05. Type score is context-adaptive (debugging/standup/emerge/search/general)."}, {"id": "access-log", "name": "log_access() / batch_activations()", "kind": "datastore-client", "files": ["hooks/vault_index.py"], "purpose": "Records access events (cascading snapshot accesses to the parent session) and computes ACT-R base-level activation, reserving 0.0 for notes with no history."}, {"id": "themes", "name": "assign_to_theme() / detect_surprise()", "kind": "module", "files": ["hooks/vault_index.py"], "purpose": "TF-IDF (smoothed IDF, sparse top-50) cosine clustering into running-average centroids (threshold 0.3); Free-Energy surprise = negation-proximity over top shared terms. term_df maintained via ON CONFLICT DO UPDATE, never blind REPLACE."}, {"id": "rebuild-index", "name": "rebuild_index() — Friston-preserving", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Default non-destructive rebuild preserves access_log, themes and theme_members (activation/centroid/surprise), with an absolute-path safety guard that skips orphan-prune on path-format drift. full=True is the legacy total wipe for corrupt schema."}, {"id": "upsert-note", "name": "_upsert_note() — DELETE-then-INSERT", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Deliberately avoids INSERT OR REPLACE: explicit DELETE+INSERT preserving the prior importance value, and issuing the contentless-FTS5 delete op with old column values so the FTS index never accumulates orphans."}, {"id": "vault-stats-compute", "name": "compute_stats()", "kind": "function", "files": ["hooks/vault_stats.py"], "purpose": "Read-only aggregation for /vault-stats: signal coverage (per-note activation + importance), access-by-context, top-accessed, importance distribution, and snapshot integrity metrics (orphans, broken backlinks, summarized fraction)."}]}, {"id": "triage-pipeline", "name": "Triage Pipeline (check-items / emerge / standup-deep)", "color": "#F59E0B", "description": "The Python support layer behind /check-items, /standup deep and /emerge. A staged pipeline — L1 cache to token grouping to semantic merge to evidence gather to L2 deterministic prefilter to chunked LLM classification to partition to dashboard — with tight false-positive guards and a heuristic fallback.", "components": [{"id": "check-items-args", "name": "check_items_args.py", "kind": "module", "files": ["hooks/check_items_args.py"], "purpose": "Order-independent Scope parsing: mode (current/vault/project), Nd window, --show-all/--dry-run/--no-cache, and project detection against known workspace dirs."}, {"id": "check-items-prefilter", "name": "check_items_prefilter.py", "kind": "module", "files": ["hooks/check_items_prefilter.py"], "purpose": "L2 deterministic triage: classifies items with no plausible completion evidence without dispatching a sub-agent. Distinctiveness gate (snake_case / len>=8 / interior mixed-case) is the key false-positive guard against generic short words.", "overrideEnv": "CHECK_ITEMS_PREFILTER"}, {"id": "check-items-cache", "name": "check_items_cache.py", "kind": "module", "files": ["hooks/check_items_cache.py"], "purpose": "Persistent classification cache keyed by a 16-hex canonical content hash. Invalidation: force to new to head_changed to mtime_changed to ttl_expired (DONE/STALE 24h, ACTIVE 7d). Atomic 0600 store."}, {"id": "check-items-cli", "name": "check_items_cli.py", "kind": "module", "files": ["hooks/check_items_cli.py"], "purpose": "Holds the semantic-merge and classifier prompts and the Claude CLI dispatch. Solves the timeout problem by chunking to <=25 groups/call (well under the 300s ceiling) so chunks stay on Haiku; strips json fences and validates the 6-field payload.", "overrideEnv": "CHECK_ITEMS_CLASSIFIER_CHUNK_SIZE"}, {"id": "check-items-report", "name": "check_items_report.py", "kind": "module", "files": ["hooks/check_items_report.py"], "purpose": "Writes the per-scope dashboard note (Done/Needs-Action/Stale/Active sections + classifier-mode frontmatter), always written even on --dry-run, path-contained and atomic."}, {"id": "open-item-dedup", "name": "open_item_dedup.py", "kind": "module", "files": ["hooks/open_item_dedup.py"], "purpose": "Cross-note open-item dedup (exact to distinctive-token to fuzzy set-intersection), cascade-checkoff with verify-before-edit, the heuristic fallback classifier (distinctive token AND completion phrase within +/-120 chars), and the deep_analysis_pipeline evidence engine."}, {"id": "compress-guard", "name": "compress_guard.py", "kind": "module", "files": ["hooks/compress_guard.py"], "purpose": "is_high_confidence_match() predicate for /compress dedup: absolute-strength gate (top rank <= -5.0) AND rank-delta gate (top minus runner-up > 0.25), tuned against compress_rank_gap_corpus.json."}, {"id": "deep-cli", "name": "deep_cli.py", "kind": "module", "files": ["hooks/deep_cli.py"], "purpose": "Thin CLI backing /standup deep: runs the deep pipeline, renders the presentation, and applies path-contained batch edits with a 24h acted-on store so items are not re-recommended."}, {"id": "emerge-cli", "name": "emerge_cli.py", "kind": "module", "files": ["hooks/emerge_cli.py"], "purpose": "Thin CLI backing /emerge: collects a vault corpus over a window (snapshots excluded by default), re-collects post-upgrade, and assembles the claude-emerge note with source_notes wikilinks."}, {"id": "summarizer-metrics", "name": "summarizer_metrics.py", "kind": "ops", "files": ["hooks/summarizer_metrics.py"], "purpose": "Append-only JSONL telemetry for upgrade_batch() runs; rotates at 100 KB; never raises (best-effort stderr warn only)."}]}, {"id": "vault-doctor", "name": "Vault Doctor (pluggable repair engine)", "color": "#EC4899", "description": "A dispatcher plus an auto-discovered registry of repair checks. Each check implements scan() to list[Issue] and apply() to list[Result]. Dry-run by default; per-check crash containment; a --min-confidence filter that is override-safe because apply() raises on any non-canonical signal_class. Exit-code 2 escalates even at 0 issues when a check crashes.", "components": [{"id": "doctor-dispatcher", "name": "vault_doctor.py", "kind": "module", "files": ["scripts/vault_doctor.py"], "purpose": "CLI dispatcher: config resolution (CLI > env > file, bypassing the session cache), flag forwarding via EXTRA_SCAN_FLAGS, per-check scan/apply crash containment with crashed_checks, the confidence filter with dropped_per_signal_class attribution, timestamped backup root, and the 0/1/2/3 exit-code contract."}, {"id": "check-registry", "name": "vault_doctor_checks/__init__.py", "kind": "registration", "files": ["scripts/vault_doctor_checks/__init__.py"], "purpose": "Auto-discovers checks via pkgutil; defines the Issue/Result dataclasses and the scan/apply module contract; all_checks() excludes OPT_IN=True checks; broken modules are warned-and-skipped, never fatal."}, {"id": "check-source-sessions", "name": "source-sessions", "kind": "module", "files": ["scripts/vault_doctor_checks/source_sessions.py"], "purpose": "UUID-first stale source_session backlink detector across insights/decisions/error-fixes/retros. Skips imported notes; preserves mtime on repair so fixed notes do not re-enter the window; apply() raises on non uuid-basename-stale signal_class (conf 0.99)."}, {"id": "check-session-coverage", "name": "session-coverage (opt-in)", "kind": "module", "files": ["scripts/vault_doctor_checks/session_coverage.py"], "purpose": "Detects JSONL transcripts with no session note (SessionEnd missed), replicating hook thresholds + snapshot-anchor bypass. --reconstruct shells out to replay-sessionend.py to write the note (conf 0.9); replay-JSON shape-guarded."}, {"id": "check-snapshot-integrity", "name": "snapshot-integrity", "kind": "module", "files": ["scripts/vault_doctor_checks/snapshot_integrity.py"], "purpose": "Five sub-checks: orphan snapshots, broken backlinks, stale/missing session snapshot-lists, and summary-status mismatch. Project-blind sid-collision detection routes colliding sids to unresolved before any parent-based fix."}, {"id": "check-snapshot-migration", "name": "snapshot-migration", "kind": "module", "files": ["scripts/vault_doctor_checks/snapshot_migration.py"], "purpose": "Ordered legacy-format migrations (filename HHMMSS, missing status/backlink, session snapshot-list). Tracks renamed paths/stems, re-checks collisions before os.rename, and rolls back a rename only if zero vault-wide wikilink rewrites succeeded."}, {"id": "check-project-canonicalization", "name": "project-name-canonicalization (opt-in)", "kind": "module", "files": ["scripts/vault_doctor_checks/project_name_canonicalization.py"], "purpose": "Backfills the canonical main-repo project name vs worktree slug via git rev-parse, with a GIT_DIR env scrub so ambient vars cannot certify one bogus name vault-wide; strict UTF-8 decode in apply (defers to encoding-corruption)."}, {"id": "check-project-normalization", "name": "project-name-normalization", "kind": "module", "files": ["scripts/vault_doctor_checks/project_name_normalization.py"], "purpose": "Detects underscores in project frontmatter (personal_ws to personal-ws) and the matching project tag; frontmatter-only regex; conf 1.0."}, {"id": "check-spurious-wikilinks", "name": "spurious-wikilinks", "kind": "module", "files": ["scripts/vault_doctor_checks/spurious_wikilinks.py"], "purpose": "Escapes unescaped double-brackets in conversation/tool-usage lines (bash test brackets parsed by Obsidian as phantom wikilinks); session folder only; conf 1.0."}, {"id": "check-encoding-corruption", "name": "encoding-corruption", "kind": "module", "files": ["scripts/vault_doctor_checks/encoding_corruption.py"], "purpose": "Detects invalid UTF-8 bytes (grep Binary file matches); re-encodes with errors=replace; backs up raw original bytes before the atomic rewrite."}, {"id": "check-audit-historic", "name": "audit-historic-repairs (opt-in)", "kind": "module", "files": ["scripts/vault_doctor_checks/audit_historic_repairs.py"], "purpose": "One-shot audit of prior doctor backups: classifies each note A (restore mtime-drift corruption) / B (keep) / C (ambiguous) / D (both-wrong); only category A auto-applies, restoring the oldest backup backlink. Loud no-op if the backup root is missing.", "overrideEnv": "OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT"}]}, {"id": "skills", "name": "Skills (prompt-based procedures)", "color": "#8B5CF6", "description": "18 SKILL.md prompt procedures (no code files) that Claude Code follows step-by-step, reaching the backing Python via a cache glob. Grouped by lifecycle: SETUP, CAPTURE, RECALL/QUERY, MAINTENANCE, TRIAGE. Some fan out to sub-agents; most run inline.", "components": [{"id": "sk-obsidian-setup", "name": "/obsidian-setup", "kind": "module", "files": ["skills/obsidian-setup/SKILL.md"], "purpose": "SETUP. First-run/upgrade config: vault path, folders, dashboards install, optional deps; writes the config JSON and rebuilds the index."}, {"id": "sk-vault-config", "name": "/vault-config", "kind": "module", "files": ["skills/vault-config/SKILL.md"], "purpose": "SETUP. Interactive numbered-menu editor for config (toggles, thresholds, snapshot flags) with atomic config rewrite."}, {"id": "sk-compress", "name": "/compress", "kind": "module", "files": ["skills/compress/SKILL.md"], "purpose": "CAPTURE. Saves curated session insights (multi-pick or single-topic, with update-existing path); dedups against the index via compress_guard."}, {"id": "sk-decide", "name": "/decide", "kind": "module", "files": ["skills/decide/SKILL.md"], "purpose": "CAPTURE. Writes ADR-lite decision notes (context/options/decision/rationale/consequences) with active/superseded status."}, {"id": "sk-error-log", "name": "/error-log", "kind": "module", "files": ["skills/error-log/SKILL.md"], "purpose": "CAPTURE. Structured error to root-cause to fix to prevention notes."}, {"id": "sk-retro", "name": "/retro", "kind": "module", "files": ["skills/retro/SKILL.md"], "purpose": "CAPTURE. Honest session retrospective pulling prior-session snapshots/insights as first-class evidence via gather_session_evidence."}, {"id": "sk-recall", "name": "/recall", "kind": "module", "files": ["skills/recall/SKILL.md"], "purpose": "RECALL. Read-only context resume: upgrades unsummarized notes (ThreadPool Haiku pipeline, per-note sub-agent fallback) and presents a context brief."}, {"id": "sk-vault-ask", "name": "/vault-ask", "kind": "module", "files": ["skills/vault-ask/SKILL.md"], "purpose": "RECALL. Synthesized, source-cited answer grounded in vault notes; FTS fast-path + 3 parallel Grep agents + per-file context-shield sub-agents + snapshot summaries."}, {"id": "sk-vault-search", "name": "/vault-search", "kind": "module", "files": ["skills/vault-search/SKILL.md"], "purpose": "RECALL. Ranked keyword/tag/structured search with snippets and snapshot markers via ensure_index + search_vault."}, {"id": "sk-standup", "name": "/standup", "kind": "module", "files": ["skills/standup/SKILL.md"], "purpose": "RECALL. Daily/weekly cross-project standup; deep mode adds the AI item-classification + cascade-checkoff pipeline via deep_cli."}, {"id": "sk-link", "name": "/link", "kind": "module", "files": ["skills/link/SKILL.md"], "purpose": "RECALL. Bidirectional wikilink cross-referencing in Related sections (model-driven ranking, parallel Grep)."}, {"id": "sk-vault-doctor", "name": "/vault-doctor", "kind": "module", "files": ["skills/vault-doctor/SKILL.md"], "purpose": "MAINTENANCE. Orchestrates scripts/vault_doctor.py; dry-run unless fix; documents the exit-code/crashed_checks contract and the crash-vs-apply-error remediation branch."}, {"id": "sk-vault-reindex", "name": "/vault-reindex", "kind": "module", "files": ["skills/vault-reindex/SKILL.md"], "purpose": "MAINTENANCE. Rebuild the FTS5 index; non-destructive by default, --full wipes the Friston tables."}, {"id": "sk-vault-import", "name": "/vault-import", "kind": "module", "files": ["skills/vault-import/SKILL.md"], "purpose": "MAINTENANCE. Backfills historical sessions from the CC projects JSONLs (up to 5 parallel context-shield sub-agents)."}, {"id": "sk-vault-stats", "name": "/vault-stats", "kind": "module", "files": ["skills/vault-stats/SKILL.md"], "purpose": "MAINTENANCE. Vault health + access/importance analytics; saves a trend-tracking note via compute_stats."}, {"id": "sk-dev-test", "name": "/dev-test", "kind": "module", "files": ["skills/dev-test/SKILL.md"], "purpose": "MAINTENANCE. Install/restore/status the dev plugin into the cache for local testing via scripts/test-dev-skill.sh."}, {"id": "sk-check-items", "name": "/check-items", "kind": "module", "files": ["skills/check-items/SKILL.md"], "purpose": "TRIAGE. Two-pass AI triage of open items: auto-checks PR-shipped items, cache-backed, cascades sibling checkoffs. Owns partition() and classifier dispatch over the triage-pipeline modules."}, {"id": "sk-emerge", "name": "/emerge", "kind": "module", "files": ["skills/emerge/SKILL.md"], "purpose": "TRIAGE. Surfaces unnamed cross-note patterns over a window via a synthesis Agent over emerge_cli corpus."}]}, {"id": "note-schema", "name": "Note Schema & Dashboards", "color": "#06B6D4", "description": "Markdown templates define every note type frontmatter and body; the universal claude/ tag prefix and type discriminator are the coupling between writers (templates) and readers (Dataview dashboards).", "components": [{"id": "note-templates", "name": "Note templates", "kind": "module", "files": ["templates/session.md", "templates/snapshot.md", "templates/insight.md", "templates/decision.md", "templates/error-fix.md", "templates/imported-session.md"], "purpose": "Mustache-style templates. Curated notes (insight/decision/error-fix) carry created_at/source_session/source_session_note/project; runtime notes (session/snapshot/imported) carry session_id/git_branch/duration/status. Decision is the only curated type with a status field."}, {"id": "tag-convention", "name": "claude/ tag convention", "kind": "module-inline", "files": ["CLAUDE.md"], "purpose": "Every frontmatter tag uses the claude/ prefix: type tag (claude/session, claude/insight), claude/project/<name>, claude/topic/<topic>, claude/auto, claude/imported, claude/reconstructed, claude/retro, claude/standup. Dashboards filter exclusively on these."}, {"id": "dataview-dashboards", "name": "Dataview dashboards", "kind": "module", "files": ["dashboards/sessions-overview.md", "dashboards/open-items.md", "dashboards/decision-timeline.md", "dashboards/learning-velocity.md", "dashboards/project-index.md", "dashboards/weekly-review.md"], "purpose": "Six Dataview/dataviewjs dashboards over claude-sessions + claude-insights: recent sessions, open items by project, decision timeline, topic/error-pattern velocity, project index, and a 7-day weekly review. Require the Obsidian Dataview plugin."}]}, {"id": "storage-telemetry", "name": "Storage & Telemetry (datastores)", "color": "#F97316", "description": "Where state lives. One markdown vault (the product), one SQLite index (derived, rebuildable), a machine-local JSON config, a 0700 secure working directory for locks/cache/bootstrap/watermark, and append-only telemetry logs.", "components": [{"id": "db-vault", "name": "Markdown Vault", "kind": "datastore", "files": [], "purpose": "The Obsidian vault (live config: a local claude-code-vault folder). Folders claude-sessions/, claude-insights/, claude-check-items/, claude-dashboards/. The source of truth; works when Obsidian is closed."}, {"id": "db-index", "name": "SQLite + FTS5 index", "kind": "datastore", "files": ["hooks/vault_index.py"], "purpose": "The vault index DB (WAL, 0600, ~33 MB). Tables: notes, notes_fts (contentless FTS5), access_log, themes, theme_members, term_df. Derived and fully rebuildable from the vault.", "overrideEnv": "OBSIDIAN_BRAIN_DB"}, {"id": "db-config", "name": "Config file", "kind": "datastore", "files": [], "purpose": "Machine-local config JSON (0600, auto-chmodded). vault_path, folder names, min_messages/min_duration thresholds, summary_model, and feature flags (auto_log_enabled, snapshot_on_compact/clear, log_raw_messages)."}, {"id": "db-secure-workdir", "name": "Secure working dir", "kind": "datastore", "files": [], "purpose": "The 0700 secure working dir: locks/ (O_EXCL hook-dedup), cache-<sid>.json, sid-<project> bootstrap files, reaper-watermark-<project>, and triage/pipeline temp + cache JSON. Replaces /tmp to prevent symlink/cache-poisoning."}, {"id": "db-hook-log", "name": "Hook telemetry log", "kind": "datastore", "files": [], "purpose": "The hook telemetry log (0600, rotates at 100 KB). One key=value line per SessionEnd/SessionStart/Reaper event; the primary diagnostic for sessions that produced no note."}, {"id": "db-summarizer-metrics", "name": "Summarizer metrics JSONL", "kind": "datastore", "files": ["hooks/summarizer_metrics.py"], "purpose": "Append-only summarizer metrics JSONL (0600, rotates at 100 KB). One record per upgrade_batch() run."}]}, {"id": "build-release", "name": "Build, Release & CI", "color": "#84CC16", "description": "No build step (pure Python + Markdown). Validation is the pytest suite + a layered preflight + CI. Distribution is a standalone marketplace from this repo, with plugin.json and marketplace.json version-bumped in lockstep.", "components": [{"id": "ops-bump-version", "name": "bump-version.sh", "kind": "ops", "files": ["scripts/bump-version.sh"], "purpose": "Bumps plugin.json + marketplace.json in lockstep (major|minor|patch|X.Y.Z) with pre-bump validation, atomic marketplace write, and all-or-nothing rollback if the second write fails."}, {"id": "ops-commit-preflight", "name": "commit-preflight.sh", "kind": "ops", "files": ["scripts/commit-preflight.sh"], "purpose": "Creates a 5-minute token consumed by the require-preflight hook. Enforces (always-on) manifest version sync, then secret scan, then pytest with cov-fail-under 90. Flags: --docs-only, --skip-tests, --auto."}, {"id": "ops-ci", "name": "CI workflow", "kind": "ops", "files": [".github/workflows/ci.yml"], "purpose": "Adaptive cost-optimized CI: secret-scan, changelog-check (PRs to main), python-tests (3.12, cov>=90), no-default-db AST guard, security-tests, and an advisory detect-release-merge check."}, {"id": "ops-no-default-db", "name": "no-default-db.py", "kind": "ops", "files": ["scripts/ci-checks/no-default-db.py"], "purpose": "AST guard (GH #46): every ensure_index/rebuild_index/deep_analysis_pipeline call in tests/ must pass explicit db_path= so tests cannot pollute the live vault DB."}, {"id": "ops-pytest", "name": "pytest suite", "kind": "ops", "files": ["tests/"], "purpose": "64 test files, coverage source=hooks, fail_under=90. Hook simulation pattern pipes synthetic JSON into installed hooks; import-time state-dir constants isolated via autouse conftest monkeypatch."}, {"id": "ops-security-tests", "name": "test-security.sh", "kind": "ops", "files": ["scripts/test-security.sh"], "purpose": "Runs the security regression suite (path containment, secret scrub, temp-path safety) with OB_HOOKS_DIR=hooks."}]}], "flows": [{"id": "session-end-autolog", "name": "SessionEnd auto-log (write-first)", "description": "When a Claude Code session ends, the raw note is written immediately; AI summarization is deferred to /recall.", "steps": [{"from": "hooks-registration", "to": "hook-session-log", "label": "SessionEnd JSON via stdin (1 MB cap)"}, {"from": "hook-session-log", "to": "transcript-parser", "label": "read JSONL transcript"}, {"from": "transcript-parser", "to": "session-metadata", "label": "extract project/branch/files/errors"}, {"from": "session-metadata", "to": "hook-dedup-lock", "label": "claim SessionEnd before raw-body build"}, {"from": "hook-session-log", "to": "write-vault-note", "label": "raw note (status: auto-logged)"}, {"from": "write-vault-note", "to": "db-vault", "label": "atomic temp+rename, 0600"}, {"from": "hook-session-log", "to": "telemetry-log", "label": "outcome=OK_RAW_NOTE_ONLY / SKIPPED / WRITE_FAILED"}]}, {"id": "session-start-hint", "name": "SessionStart hint + reaper", "description": "On session start, refresh the bootstrap sid-file, sweep orphaned transcripts, and inject a last-session context hint.", "steps": [{"from": "hooks-registration", "to": "hook-session-hint", "label": "SessionStart (startup|resume|clear|compact)"}, {"from": "hook-session-hint", "to": "db-secure-workdir", "label": "atomic bootstrap sid-<project> write"}, {"from": "hook-session-hint", "to": "hook-session-reaper", "label": "invoke (if reaper_enabled)"}, {"from": "hook-session-hint", "to": "db-vault", "label": "find latest session note"}, {"from": "hook-session-hint", "to": "telemetry-log", "label": "bootstrap_updated=true|false"}]}, {"id": "precompact-snapshot", "name": "PreCompact context snapshot", "description": "Before context compression, persist a scrubbed snapshot backlinked to the parent session.", "steps": [{"from": "hooks-registration", "to": "hook-context-snapshot", "label": "PreCompact (source: compact|clear|auto)"}, {"from": "hook-context-snapshot", "to": "transcript-parser", "label": "read transcript"}, {"from": "hook-context-snapshot", "to": "scrub-secrets", "label": "scrub secrets (redact)"}, {"from": "hook-context-snapshot", "to": "write-vault-note", "label": "snapshot note -snapshot-HHMMSS"}, {"from": "write-vault-note", "to": "db-vault", "label": "atomic write, backlink to parent"}]}, {"id": "orphan-reaper", "name": "Orphan transcript reaper", "description": "Reconstruct notes for sessions where SessionEnd never fired (SIGKILL, worktree teardown).", "steps": [{"from": "hook-session-reaper", "to": "canonical-project-name", "label": "collapse worktrees to one project"}, {"from": "hook-session-reaper", "to": "transcript-parser", "label": "read orphaned JSONL (mtime > watermark)"}, {"from": "hook-session-reaper", "to": "write-vault-note", "label": "reconstructed note (claude/reconstructed)"}, {"from": "write-vault-note", "to": "db-vault", "label": "atomic write"}, {"from": "hook-session-reaper", "to": "db-secure-workdir", "label": "advance reaper-watermark"}]}, {"id": "recall-deferred-summarize", "name": "/recall deferred summarization", "description": "On demand, upgrade raw notes to AI summaries — the deferred half of the write-first pattern.", "steps": [{"from": "sk-recall", "to": "summarizer", "label": "generate_summary (Claude CLI haiku, escalate)"}, {"from": "summarizer", "to": "db-vault", "label": "flip status: auto-logged to summarized"}, {"from": "sk-recall", "to": "search-vault", "label": "build context brief from ranked notes"}]}, {"id": "search-and-rank", "name": "Search & 7-signal rank", "description": "FTS5 BM25 candidate retrieval reranked by 7 signals, with access logged for ACT-R activation.", "steps": [{"from": "sk-vault-search", "to": "ensure-index", "label": "lazy mtime-incremental sync"}, {"from": "ensure-index", "to": "db-index", "label": "upsert changed notes (DELETE-then-INSERT)"}, {"from": "sk-vault-search", "to": "search-vault", "label": "AND-mode FTS5 query"}, {"from": "search-vault", "to": "rerank", "label": "proximity/bm25/activation/type/recency/importance/density"}, {"from": "rerank", "to": "access-log", "label": "batch-log access to activation"}, {"from": "access-log", "to": "db-index", "label": "insert access rows (cascade snapshot to session)"}]}, {"id": "check-items-triage", "name": "/check-items AI triage", "description": "Stage open items through cache to prefilter to chunked LLM classification to partition to dashboard.", "steps": [{"from": "sk-check-items", "to": "check-items-args", "label": "parse scope/window/flags"}, {"from": "check-items-args", "to": "check-items-cache", "label": "partition known vs needs-classify (hash + TTL)"}, {"from": "check-items-cache", "to": "check-items-prefilter", "label": "L2 deterministic no-evidence triage"}, {"from": "check-items-prefilter", "to": "check-items-cli", "label": "classify <=25/chunk (under 300s, stay on Haiku)"}, {"from": "check-items-cli", "to": "open-item-dedup", "label": "cascade sibling checkoffs (verify-before-edit)"}, {"from": "open-item-dedup", "to": "check-items-report", "label": "partition Done/Needs-Action/Stale/Active"}, {"from": "check-items-report", "to": "db-vault", "label": "write per-scope dashboard note"}]}, {"id": "vault-doctor-repair", "name": "/vault-doctor scan & repair", "description": "Dispatch registered checks; dry-run by default; apply() raises on non-canonical signal_class so --min-confidence is override-safe.", "steps": [{"from": "sk-vault-doctor", "to": "doctor-dispatcher", "label": "resolve config (CLI>env>file), select checks"}, {"from": "doctor-dispatcher", "to": "check-registry", "label": "auto-discover checks (exclude OPT_IN)"}, {"from": "check-registry", "to": "check-source-sessions", "label": "scan() to list[Issue] (crash-contained)"}, {"from": "doctor-dispatcher", "to": "check-source-sessions", "label": "apply() under timestamped backup root"}, {"from": "check-source-sessions", "to": "db-vault", "label": "atomic rewrite, mtime preserved"}]}, {"id": "compress-dedup", "name": "/compress insight dedup", "description": "Before saving a curated insight, check the index for a high-confidence existing match to offer update-vs-create.", "steps": [{"from": "sk-compress", "to": "search-vault", "label": "FTS5 search for the topic"}, {"from": "search-vault", "to": "compress-guard", "label": "strength gate (<=-5.0) AND rank-delta gate (>0.25)"}, {"from": "compress-guard", "to": "write-vault-note", "label": "create new OR append Update section"}, {"from": "write-vault-note", "to": "db-vault", "label": "atomic write"}]}, {"id": "release-lockstep", "name": "Git Flow release (version lockstep)", "description": "A release branch from develop, then bump manifests in lockstep, then preflight, then CI, then merge into main with a back-merge to develop.", "steps": [{"from": "ops-bump-version", "to": "ops-commit-preflight", "label": "plugin.json + marketplace.json in lockstep"}, {"from": "ops-commit-preflight", "to": "ops-pytest", "label": "manifest-sync + secret-scan + pytest cov>=90"}, {"from": "ops-pytest", "to": "ops-ci", "label": "PR validation gate"}, {"from": "ops-ci", "to": "ops-no-default-db", "label": "AST guard: no live-DB pollution in tests"}]}], "types": [{"name": "Issue", "file": "scripts/vault_doctor_checks/__init__.py", "kind": "type", "fields": ["check", "note_path", "project", "current_source", "proposed_source", "reason", "confidence", "extra"]}, {"name": "Result", "file": "scripts/vault_doctor_checks/__init__.py", "kind": "type", "fields": ["check", "note_path", "status", "backup_path", "error"], "values": ["applied", "skipped", "error", "unresolved"]}, {"name": "Scope", "file": "hooks/check_items_args.py", "kind": "type", "fields": ["mode", "project", "window_days", "show_all", "dry_run", "no_cache"], "values": ["current", "vault", "project"]}, {"name": "ReaperOutcome", "file": "hooks/obsidian_session_reaper.py", "kind": "type", "fields": ["reaped", "skipped_existing", "skipped_below", "canary_blocked", "timeout", "wall_ms"]}, {"name": "NoteType (frontmatter discriminator)", "file": "templates/", "kind": "enum", "values": ["claude-session", "claude-snapshot", "claude-insight", "claude-decision", "claude-error-fix", "claude-check-items-report", "claude-stats", "claude-retro", "claude-emerge", "imported(claude-session)"]}], "environment": [{"name": "CLAUDE_PLUGIN_ROOT", "default": "(set by Claude Code)", "purpose": "Base path the hook registration uses to invoke the plugin hook scripts."}, {"name": "CLAUDE_PROJECT_DIR", "default": "(set by Claude Code)", "purpose": "Project anchor used as a fallback in the SID resolution chain and statusline anchoring."}, {"name": "OBSIDIAN_BRAIN_DB", "default": "the vault index DB under ~/.claude", "purpose": "Override the SQLite index path (#192); also used by tests to avoid polluting the live DB."}, {"name": "OBSIDIAN_BRAIN_VAULT", "default": "(config file)", "purpose": "vault-doctor config override (with _SESSIONS_FOLDER / _INSIGHTS_FOLDER); takes precedence over the config file."}, {"name": "OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT", "default": "the doctor backup dir under ~/.claude", "purpose": "Scan root for the audit-historic-repairs check (apply always writes under the dispatcher backup root)."}, {"name": "CHECK_ITEMS_PREFILTER", "default": "on", "purpose": "Set to off to disable the L2 deterministic prefilter and send all items to the LLM classifier."}, {"name": "CHECK_ITEMS_SUBAGENT_TIMEOUT_SEC", "default": "300", "purpose": "Inner per-call timeout for the classifier/semantic-merge sub-agents; chunking keeps each call well under it."}, {"name": "CHECK_ITEMS_CLASSIFIER_CHUNK_SIZE", "default": "25", "purpose": "Max groups per classifier sub-agent call — sized to stay on Haiku and under the timeout."}], "design": {"principles": ["Write-first, summarize-later: hooks always persist a raw note immediately; AI summarization is deferred to /recall.", "Direct filesystem writes only — no MCP server, no REST API, no daemon; the vault works even when Obsidian is closed.", "Hooks are pure stdlib, deterministic, and always exit 0; they never import the index (indexing is a skill-side concern).", "Everything is recoverable: the SQLite index is derived and fully rebuildable from the markdown vault.", "Defense in depth on writes: path containment, atomic temp+rename, 0600/0700 perms, secret scrubbing, 1 MB stdin caps."], "constraints": ["Python stdlib only — no pip dependencies (hooks run at session boundaries where install state is unknown).", "All hooks must exit 0 regardless of outcome (a non-zero hook would disrupt the host session).", "All vault writes use temp file + rename — never sed -i or in-place overwrite.", "User-data files are 0600, working dirs 0700; no predictable /tmp paths.", "Test coverage gate: cov-fail-under 90 on hooks; tests must pass explicit db_path= (no live-DB pollution).", "Dashboards require the Obsidian Dataview community plugin (JavaScript + inline queries)."], "tradeoffs": [{"decision": "Defer Claude CLI summarization from SessionEnd to /recall (write-first).", "alternatives": ["Summarize synchronously in the SessionEnd hook", "Background daemon to summarize"], "rationale": "A SessionEnd subprocess is SIGKILLed when the session process-tree exits, so synchronous summarization is unreliable. Writing the raw note first guarantees no session is ever lost; /recall upgrades on demand."}, {"decision": "DELETE-then-INSERT in the index instead of INSERT OR REPLACE.", "alternatives": ["INSERT OR REPLACE", "UPSERT via ON CONFLICT for the whole row"], "rationale": "REPLACE would drop the learned importance value and orphan rows in the contentless FTS5 table. Explicit delete+insert preserves importance and issues the FTS delete op with old values so the index never accumulates orphans."}, {"decision": "Friston-preserving non-destructive rebuild as the default.", "alternatives": ["Always full wipe + rebuild"], "rationale": "access_log activation, theme centroids and Free-Energy surprise are expensive learned signals with no source of truth outside the DB. A blind wipe would discard them; full=True is reserved for corrupt/incompatible schema."}, {"decision": "canonical_project_name() collapses worktrees via the git common-dir.", "alternatives": ["Use the cwd basename verbatim"], "rationale": "Worktrees have distinct cwd basenames but are one logical project; collapsing them keeps a feature branch notes grouped with the main repo and prevents fragmented project scopes."}, {"decision": "Snapshot-anchor bypass: log below-threshold sessions if they have sibling snapshots.", "alternatives": ["Apply message/duration thresholds uniformly"], "rationale": "A short session that nonetheless produced a PreCompact snapshot needs a parent note to anchor that snapshot backlink; dropping it would orphan real captured context."}, {"decision": "vault-doctor apply() raises on any non-canonical signal_class.", "alternatives": ["Apply whatever scan() returned"], "rationale": "Makes the --min-confidence filter override-safe: a low-confidence WARN can never be force-applied, because apply() refuses to act on anything but the one resolvable signal_class it was designed to fix."}, {"decision": "Escalate exit code to 2 when a check crashes, even at 0 issues.", "alternatives": ["Return 0 on a crashed-but-no-issues run"], "rationale": "Automation must not read an incomplete sweep as a clean bill of health; a crash means coverage was partial, so the run is flagged distinctly from a genuine all-clear."}, {"decision": "L2 deterministic prefilter with a distinctiveness gate before the LLM classifier.", "alternatives": ["Send every open item to the classifier"], "rationale": "Most open items have no plausible completion evidence and can be triaged for free; the distinctiveness gate (snake_case / len>=8 / interior mixed-case) stops generic short words like add/fix from accidentally matching unrelated shipped features."}, {"decision": "Classifier chunking at <=25 groups per sub-agent call.", "alternatives": ["One sub-agent call for the whole payload", "Raise the timeout ceiling"], "rationale": "A single large payload risks exceeding the 300s timeout and forces the slower Sonnet tier; chunking keeps each call fast, on Haiku, and recoverable on partial failure."}, {"decision": "Cross-plugin O_EXCL dedup lock that fails open.", "alternatives": ["Assume a single install", "A fail-closed lock"], "rationale": "The monorepo and standalone marketplace copies can both be installed; the lock prevents double-writes, but fails open (empty session_id or any FS error to proceed) so it can never silently swallow a legitimate hook."}]}, "testing": {"unitSuite": {"tool": "pytest", "fileCount": 64, "duration": "fast (stdlib, no network)", "environments": {"python": "3.12"}, "coverage": {"lines": 90, "source": "hooks", "omits": ["obsidian_utils.py (I/O monolith)", "emerge_cli.py", "deep_cli.py"]}}, "manualMatrix": {"doc": "CLAUDE.md (Development Commands)", "devices": ["hook simulation: pipe synthetic SessionEnd/SessionStart/PreCompact JSON into installed hooks", "json.load validation of hooks.json and plugin.json"], "rationale": "No build/test framework for the prompt-based skills; hooks are validated by feeding synthetic lifecycle JSON and asserting vault writes + telemetry outcomes."}}, "scripts": [{"name": "bump-version.sh", "command": "bump plugin.json + marketplace.json in lockstep (major|minor|patch|X.Y.Z) with rollback"}, {"name": "commit-preflight.sh", "command": "preflight gate: manifest-sync + secret-scan + pytest cov>=90; mints the require-preflight token"}, {"name": "pre-commit.sh", "command": "secret detection on staged + lines; blocks .env and credential filenames"}, {"name": "git-flow-finish.sh", "command": "complete a release/hotfix: merge to main + develop, tag, dev-cycle bump"}, {"name": "ci-checks/no-default-db.py", "command": "AST guard: tests must pass explicit db_path= (GH #46)"}, {"name": "test-dev-skill.sh", "command": "/dev-test install — copy the working tree into the plugin cache for local testing"}, {"name": "test-security.sh", "command": "security regression suite (path containment, scrub, temp-path safety)"}, {"name": "verify-hooks.sh", "command": "validate hooks.json / plugin.json structure"}], "gitFlow": {"branches": {"main": "production releases (tagged)", "develop": "integration branch"}, "branchTypes": [{"prefix": "feature/", "baseFrom": "develop", "mergesTo": "develop"}, {"prefix": "release/", "baseFrom": "develop", "mergesTo": ["main", "develop"]}, {"prefix": "hotfix/", "baseFrom": "main", "mergesTo": ["main", "develop"]}], "preflight": "./scripts/commit-preflight.sh — manifest-sync (always-on) + secret-scan + pytest cov>=90; required before every commit", "plugin": "abhattacherjee/git-flow", "currentVersion": "2.7.1"}, "docs": [{"title": "Standalone Marketplace Distribution (plan)", "path": "docs/superpowers/plans/2026-06-01-standalone-marketplace-distribution.md", "scope": "Migration to a standalone marketplace served from this repo (no monorepo sync)."}, {"title": "Standalone Marketplace Design (spec)", "path": "docs/superpowers/specs/2026-06-01-obsidian-brain-standalone-marketplace-design.md", "scope": "Design for the self-authoritative marketplace.json (source: ./) and release flow."}]}</script>
+<script>
+(() => {
+  const DATA = JSON.parse(document.getElementById('arch-data').textContent);
+  document.title = (DATA.displayName || DATA.name || 'Architecture') + ' — Architecture';
+  // Theme toggle (dark default, light via [data-theme="light"], persisted in localStorage)
+  (() => {
+    const root = document.documentElement;
+    const btn = document.getElementById('theme-toggle');
+    const stored = (() => { try { return localStorage.getItem('arch-theme'); } catch { return null; } })();
+    const apply = (mode) => {
+      if (mode === 'light') { root.setAttribute('data-theme', 'light'); btn && (btn.textContent = '☀'); }
+      else { root.removeAttribute('data-theme'); btn && (btn.textContent = '☾'); }
+    };
+    apply(stored === 'light' ? 'light' : 'dark');
+    btn && btn.addEventListener('click', () => {
+      const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+      apply(next);
+      try { localStorage.setItem('arch-theme', next); } catch {}
+    });
+  })();
+
+  const LAYER_BY_ID = {};
+  const COMPONENT_BY_ID = {};
+  for (const layer of (DATA.layers || [])) {
+    LAYER_BY_ID[layer.id] = layer;
+    for (const c of (layer.components || [])) COMPONENT_BY_ID[c.id] = { layer, component: c };
+  }
+
+  // Hero
+  document.getElementById('hero-name').textContent = DATA.displayName;
+  document.getElementById('hero-codename').textContent = DATA.name + ' · v' + DATA.version;
+  document.getElementById('hero-tagline').textContent = DATA.tagline;
+  document.getElementById('overview-tagline').textContent = DATA.tagline;
+  const meta = document.getElementById('hero-meta');
+  meta.innerHTML = [
+    DATA.lastUpdated && `<span><b>Updated</b> ${DATA.lastUpdated}</span>`,
+    DATA.repository && `<span><b>Repo</b> <a href="${DATA.repository}" target="_blank" rel="noopener">${DATA.repository.replace('https://github.com/','')}</a></span>`,
+    `<span><b>Layers</b> ${(DATA.layers || []).length}</span>`,
+    `<span><b>Flows</b> ${(DATA.flows || []).length}</span>`,
+    DATA.endpoints && `<span><b>Endpoints</b> ${DATA.endpoints.length}</span>`,
+  ].filter(Boolean).join('');
+
+  // Tech KV
+  const techKv = document.getElementById('tech-kv');
+  const t = DATA.techStack || {};
+  const join = (...parts) => parts.filter(Boolean).join(' ');
+  const techRows = [
+    t.framework && ['Framework', join(t.framework.name, t.framework.version, t.framework.router && `(${t.framework.router})`)],
+    t.language && ['Language', join(t.language.name, t.language.version, t.language.strict && '(strict)')],
+    t.runtime && ['Runtime', t.runtime.name + (t.runtime.minVersion ? ' ≥ ' + t.runtime.minVersion : '')],
+    t.ui && ['UI', join(t.ui.library, t.ui.version)],
+    t.styling && ['Styling', [t.styling.engine, t.styling.version, t.styling.designSystem].filter(Boolean).join(' · ')],
+    t.server && ['Server', t.server.name + (t.server.file ? ' (' + t.server.file + ')' : '')],
+    t.realtime && ['Realtime', t.realtime.protocol + (t.realtime.endpoint ? ' → ' + t.realtime.endpoint : '')],
+    t.persistence?.primary && ['Persistence (server)', t.persistence.primary],
+    Array.isArray(t.persistence?.secondary) && t.persistence.secondary.length && ['Persistence (client)', t.persistence.secondary.join(', ')],
+    t.push && ['Push', `${t.push.library || '?'} (${t.push.auth || '?'})`],
+    t.serviceWorker && ['Service Worker', `${t.serviceWorker.file || '?'}${t.serviceWorker.linesOfCode != null ? ' (' + t.serviceWorker.linesOfCode + ' LOC)' : ''}`],
+    t.ai && ['AI', [t.ai.provider, t.ai.model, t.ai.streaming && 'streaming', t.ai.promptCaching].filter(Boolean).join(' · ')],
+    t.vectorSearch && ['Vector search', [t.vectorSearch.engine, t.vectorSearch.indexed && 'over ' + t.vectorSearch.indexed].filter(Boolean).join(' · ')],
+    t.tests?.unit && ['Unit tests', [
+      t.tests.unit.runner,
+      t.tests.unit.count != null && `${t.tests.unit.count} tests`,
+      t.tests.unit.coverage && [
+        t.tests.unit.coverage.lines != null && `${t.tests.unit.coverage.lines}% lines`,
+        t.tests.unit.coverage.branches != null && `${t.tests.unit.coverage.branches}% branches`
+      ].filter(Boolean).join(' / ')
+    ].filter(Boolean).join(' · ')],
+    t.tests?.e2e && ['E2E tests', [t.tests.e2e.runner, Array.isArray(t.tests.e2e.browsers) && t.tests.e2e.browsers.join(' + ')].filter(Boolean).join(' · ')],
+    t.packageManager && ['Package manager', t.packageManager],
+  ].filter(Boolean);
+  techKv.innerHTML = techRows.length ? techRows.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join('') : '<dt style="color:var(--text-dim)">No techStack in architecture.json</dt>';
+
+  // Env
+  document.getElementById('env-tbody').innerHTML = (DATA.environment || []).map(e => `
+    <tr><td class="mono">${e.name}</td><td class="mono">${e.default ?? '—'}</td><td>${e.purpose}</td></tr>
+  `).join('');
+
+  // Scripts
+  document.getElementById('scripts-tbody').innerHTML = (DATA.scripts || []).map(s => `
+    <tr><td class="mono">${s.name || ''}</td><td>${s.command || s.purpose || ''}</td></tr>
+  `).join('');
+
+  // Layers
+  const grid = document.getElementById('layers-grid');
+  const detail = document.getElementById('layer-detail');
+  function renderLayerCards(filter = '') {
+    const f = filter.toLowerCase().trim();
+    grid.innerHTML = (DATA.layers || []).map(l => {
+      const compMatches = (l.components || []).filter(c =>
+        !f || c.name.toLowerCase().includes(f) || (c.purpose||'').toLowerCase().includes(f) ||
+        (c.files||[]).some(p => p.toLowerCase().includes(f))
+      );
+      const layerHit = l.name.toLowerCase().includes(f) || l.description.toLowerCase().includes(f);
+      if (f && !layerHit && compMatches.length === 0) return '';
+      return `<div class="layer-card" data-layer="${l.id}" style="--layer-color: ${l.color}">
+        <div class="accent-bar"></div>
+        <h4>${l.name}</h4>
+        <p class="desc">${l.description}</p>
+        <div class="count">${(l.components || []).length} component${(l.components || []).length === 1 ? '' : 's'}${f && compMatches.length !== (l.components || []).length ? ` · ${compMatches.length} match` : ''}</div>
+      </div>`;
+    }).join('');
+    for (const card of grid.querySelectorAll('.layer-card')) {
+      card.addEventListener('click', () => openLayer(card.dataset.layer));
+    }
+  }
+  function openLayer(id) {
+    const l = LAYER_BY_ID[id]; if (!l) return;
+    detail.style.setProperty('--layer-color', l.color);
+    detail.innerHTML = `
+      <h3>${l.name}</h3>
+      <p style="color: var(--text-dim); margin: 0 0 8px">${l.description}</p>
+      <div class="components">
+        ${(l.components || []).map(c => renderComponentCard(c)).join('')}
+      </div>
+    `;
+    detail.classList.add('open');
+    detail.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+  function renderComponentCard(c) {
+    const files = (c.files || (c.location ? [c.location] : [])).map(f => `<span class="file">${f}</span>`).join('');
+    const extras = [];
+    if (c.overrideEnv) extras.push(`override env: <code>${c.overrideEnv}</code>`);
+    if (c.ttlMs) extras.push(`TTL: ${c.ttlMs/60000} min`);
+    if (c.rowCap) extras.push(`row cap: ${c.rowCap.toLocaleString()}`);
+    if (c.intervalSeconds) extras.push(`interval: ${c.intervalSeconds}s`);
+    if (c.values) extras.push(`values: ${c.values.filter(Boolean).join(', ')}${c.values.includes(null) ? ', null' : ''}`);
+    return `<div class="component" id="cmp-${c.id}">
+      <div><span class="name">${c.name}</span><span class="kind">${c.kind || 'module'}</span></div>
+      ${files ? `<div class="files">${files}</div>` : ''}
+      <p class="purpose">${c.purpose || ''}</p>
+      ${extras.length ? `<div class="extra">${extras.join(' · ')}</div>` : ''}
+    </div>`;
+  }
+  renderLayerCards();
+  document.getElementById('layer-search').addEventListener('input', e => {
+    detail.classList.remove('open');
+    renderLayerCards(e.target.value);
+  });
+
+  // Flows — rendered as sequence diagrams
+  const flowsList = document.getElementById('flows-list');
+  flowsList.innerHTML = (DATA.flows || []).map(f => `
+    <div class="flow" data-flow="${f.id}">
+      <div class="flow-header">
+        <div>
+          <div class="name">${f.name}</div>
+          <div class="desc">${f.description}</div>
+        </div>
+        <div class="chevron">▶</div>
+      </div>
+      <div class="flow-body">
+        <div class="seq-wrap">${renderSequence(f)}</div>
+      </div>
+    </div>
+  `).join('');
+  function nodeLabel(id) {
+    const m = COMPONENT_BY_ID[id];
+    return m ? `${m.component.name}` : id;
+  }
+  function seqEsc(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+  function seqTrunc(s, n) { s = String(s == null ? '' : s); return s.length > n ? s.slice(0, n - 1) + '…' : s; }
+  function seqLayerColor(id) {
+    const m = COMPONENT_BY_ID[id];
+    return (m && m.layer && m.layer.color) ? m.layer.color : 'var(--border)';
+  }
+  function renderSequence(f) {
+    const steps = (f.steps || []).filter(s => s && s.from && s.to);
+    if (!steps.length) return '<div class="desc" style="padding:10px 2px">No steps defined for this flow.</div>';
+    const order = [], seen = new Set();
+    for (const s of steps) for (const id of [s.from, s.to]) if (!seen.has(id)) { seen.add(id); order.push(id); }
+    const idx = {}; order.forEach((id, i) => idx[id] = i);
+    const n = order.length;
+    const LEFT = 22, BOXW = 150, BOXH = 40, GAP = 184, TOP = 60, ROWH = 54, BOT = 26;
+    const cx = i => LEFT + BOXW / 2 + i * GAP;
+    const W = LEFT + BOXW + (n - 1) * GAP + 22;
+    const H = TOP + steps.length * ROWH + BOT;
+    let o = `<svg class="seq" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" role="img" aria-label="${seqEsc(f.name)} sequence diagram">`;
+    for (let k = 0; k < steps.length; k++) if (k % 2 === 1) o += `<rect class="row-band" x="0" y="${TOP + k * ROWH}" width="${W}" height="${ROWH}"/>`;
+    order.forEach((id, i) => {
+      const x = cx(i), color = seqLayerColor(id), full = nodeLabel(id);
+      o += `<line class="lifeline" x1="${x}" y1="${12 + BOXH}" x2="${x}" y2="${H - 8}"/>`;
+      o += `<g class="participant" data-cmp="${seqEsc(id)}"><title>${seqEsc(full)}</title>`
+         + `<rect x="${x - BOXW / 2}" y="12" width="${BOXW}" height="${BOXH}" rx="7" style="stroke:${color}"/>`
+         + `<text x="${x}" y="${12 + BOXH / 2}" text-anchor="middle" dominant-baseline="central">${seqEsc(seqTrunc(full, 22))}</text></g>`;
+    });
+    steps.forEach((s, k) => {
+      const y = TOP + k * ROWH + ROWH * 0.58;
+      const a = cx(idx[s.from]), b = cx(idx[s.to]), full = s.label || '';
+      o += `<text class="seq-num" x="7" y="${y - 7}">${k + 1}</text>`;
+      if (idx[s.from] === idx[s.to]) {
+        const w = 36, hg = 17;
+        o += `<path class="msg-line" d="M ${a} ${y - hg} h ${w} v ${hg} h ${-w}"/>`;
+        o += `<path class="msg-head" d="M ${a} ${y} l 8 -4 v 8 z"/>`;
+        o += `<text class="msg-label" x="${a + w + 7}" y="${y - hg / 2}" dominant-baseline="central"><title>${seqEsc(full)}</title>${seqEsc(seqTrunc(full, 40))}</text>`;
+      } else {
+        const dir = b > a ? 1 : -1, x2 = b - dir * 7;
+        o += `<line class="msg-line" x1="${a}" y1="${y}" x2="${x2}" y2="${y}"/>`;
+        o += `<path class="msg-head" d="M ${b} ${y} l ${-dir * 9} -4 v 8 z"/>`;
+        o += `<text class="msg-label" x="${(a + b) / 2}" y="${y - 7}" text-anchor="middle"><title>${seqEsc(full)}</title>${seqEsc(seqTrunc(full, 40))}</text>`;
+      }
+    });
+    return o + '</svg>';
+  }
+  for (const flow of flowsList.querySelectorAll('.flow')) {
+    flow.querySelector('.flow-header').addEventListener('click', () => flow.classList.toggle('open'));
+  }
+  for (const node of flowsList.querySelectorAll('[data-cmp]')) {
+    node.addEventListener('click', e => {
+      e.stopPropagation();
+      const cmpId = node.dataset.cmp;
+      const m = COMPONENT_BY_ID[cmpId];
+      if (!m) return;
+      switchTab('layers');
+      openLayer(m.layer.id);
+      setTimeout(() => {
+        const el = document.getElementById('cmp-' + cmpId);
+        if (el) { el.scrollIntoView({behavior:'smooth',block:'center'}); el.style.outline = '2px solid var(--accent)'; setTimeout(()=>el.style.outline='', 1500); }
+      }, 200);
+    });
+  }
+
+  // Endpoints
+  document.getElementById('endpoints-tbody').innerHTML = (DATA.endpoints || []).map(e => {
+    const paramLines = [];
+    if (e.params) for (const [k, v] of Object.entries(e.params)) paramLines.push(`${k}: ${v}`);
+    if (e.body) paramLines.push(typeof e.body === 'string' ? `body: ${e.body}` : 'body: ' + JSON.stringify(e.body));
+    if (e.shapes) paramLines.push('response shapes: ' + e.shapes.map(s => `kind:${s.kind} {${(s.fields || []).join(',')}}`).join(' | '));
+    if (e.guard) paramLines.push(`guard: ${e.guard}`);
+    return `<tr><td><span class="method ${e.method}">${e.method}</span></td><td class="path">${e.path}</td><td>${e.purpose}</td><td class="params">${paramLines.join('<br>') || '—'}</td></tr>`;
+  }).join('');
+
+  // Design
+  const design = DATA.design || {};
+  document.getElementById('principles-list').innerHTML = (design.principles || []).map(p => `<li>${p}</li>`).join('');
+  document.getElementById('constraints-list').innerHTML = (design.constraints || []).map(p => `<li>${p}</li>`).join('');
+  document.getElementById('tradeoffs-list').innerHTML = (design.tradeoffs || []).map(t => `
+    <div class="component" style="margin: 8px 0">
+      <div class="name">${t.decision}</div>
+      <p class="purpose" style="margin-top:6px">${t.rationale}</p>
+      <div class="extra">alternatives: ${(t.alternatives || []).map(a => `<span class="pill">${a}</span>`).join('')}</div>
+    </div>
+  `).join('');
+  document.getElementById('types-list').innerHTML = (DATA.types || []).map(t => `
+    <div class="component" style="margin: 8px 0">
+      <div><span class="name">${t.name}</span> <span class="kind">${t.kind || 'type'}</span></div>
+      <div class="files">${t.file}</div>
+      ${t.fields ? `<div class="extra">fields: ${t.fields.map(f => `<span class="pill">${f}</span>`).join('')}</div>` : ''}
+      ${t.values ? `<div class="extra">values: ${t.values.map(v => `<span class="pill">${v === null ? 'null' : v}</span>`).join('')}</div>` : ''}
+      ${t.variants ? `<div class="extra">variants: ${t.variants.map(v => `<span class="pill">kind:${v.kind} → {${(v.fields || []).join(', ')}}</span>`).join('')}</div>` : ''}
+    </div>
+  `).join('');
+
+  // Testing — each sub-block renders only if its data exists
+  const testing = DATA.testing || {};
+  const kvLine = (label, val) => (val == null || val === '') ? '' : `<dt>${label}</dt><dd>${val}</dd>`;
+  const renderUnit = () => {
+    const u = testing.unitSuite; if (!u) return '';
+    const cov = u.coverage ? [u.coverage.lines != null && `${u.coverage.lines}% lines`, u.coverage.branches != null && `${u.coverage.branches}% branches`].filter(Boolean).join(', ') : '';
+    const envs = u.environments && typeof u.environments === 'object'
+      ? Object.entries(u.environments).map(([k,v]) => kvLine(`${k} env`, v)).join('')
+      : '';
+    const rows = [
+      kvLine('Tool', u.tool || u.runner),
+      kvLine('Files', u.fileCount),
+      kvLine('Tests', u.testCount ?? u.count),
+      kvLine('Duration', u.duration),
+      envs,
+      kvLine('Coverage', cov),
+    ].filter(Boolean).join('');
+    return rows ? `<div class="component" style="margin: 10px 0"><div class="name">Unit suite</div><dl class="kv" style="margin-top:8px">${rows}</dl></div>` : '';
+  };
+  const renderE2E = () => {
+    const e = testing.e2eSuite; if (!e) return '';
+    const rows = [
+      kvLine('Tool', e.tool || e.runner),
+      kvLine('Browsers', Array.isArray(e.browsers) ? e.browsers.join(', ') : null),
+      kvLine('Visibility', e.visibilityMethod),
+      kvLine('Specs', Array.isArray(e.specs) ? e.specs.map(s => `<span class="pill">${String(s).split('/').pop()}</span>`).join('') : null),
+    ].filter(Boolean).join('');
+    return rows ? `<div class="component" style="margin: 10px 0"><div class="name">E2E suite</div><dl class="kv" style="margin-top:8px">${rows}</dl></div>` : '';
+  };
+  const renderApi = () => {
+    const a = testing.apiSuite; if (!a) return '';
+    const rows = [
+      kvLine('Tool', a.tool || a.runner),
+      kvLine('Folders', Array.isArray(a.folders) ? a.folders.map(f => `<span class="pill">${f}</span>`).join('') : a.folders),
+      kvLine('Command', a.command ? `<code>${a.command}</code>` : null),
+      kvLine('Environments', Array.isArray(a.envs) ? a.envs.join(', ') : null),
+    ].filter(Boolean).join('');
+    return rows ? `<div class="component" style="margin: 10px 0"><div class="name">API suite</div><dl class="kv" style="margin-top:8px">${rows}</dl></div>` : '';
+  };
+  const renderManual = () => {
+    const m = testing.manualMatrix; if (!m) return '';
+    const docLink = m.doc ? `<div class="extra">doc: <a href="${DATA.repository}/blob/${DATA.defaultBranch || 'main'}/${m.doc}" target="_blank" rel="noopener">${m.doc}</a></div>` : '';
+    const devices = Array.isArray(m.devices) && m.devices.length ? `<div class="extra">devices: ${m.devices.map(d => `<span class="pill">${d}</span>`).join('')}</div>` : '';
+    const rationale = m.rationale ? `<p class="purpose" style="margin-top:6px">${m.rationale}</p>` : '';
+    if (!rationale && !devices && !docLink) return '';
+    return `<div class="component" style="margin: 10px 0"><div class="name">Manual device matrix</div>${rationale}${devices}${docLink}</div>`;
+  };
+  const renderSummary = () => {
+    const x = testing.summary; if (!x) return '';
+    return `<div class="component" style="margin:10px 0"><div class="name">Overview</div><p class="purpose" style="margin-top:6px">${x}</p></div>`;
+  };
+  const renderSuites = () => {
+    const arr = Array.isArray(testing.suites) ? testing.suites : [];
+    if (!arr.length) return '';
+    const cards = arr.map(su => {
+      const rows = [
+        kvLine('Kind', su.kind ? `<span class="pill">${su.kind}</span>` : null),
+        kvLine('Files', su.files ? `<code>${su.files}</code>` : null),
+        kvLine('Tests', su.tests),
+        kvLine('Command', su.command ? `<code>${su.command}</code>` : null),
+      ].filter(Boolean).join('');
+      const purpose = su.purpose ? `<p class="purpose" style="margin-top:6px">${su.purpose}</p>` : '';
+      return `<div class="component" style="margin:10px 0"><div class="name">${su.name || 'Suite'}</div>${purpose}${rows ? `<dl class="kv" style="margin-top:8px">${rows}</dl>` : ''}</div>`;
+    }).join('');
+    return `<h3 style="margin:16px 0 4px">Test suites (${arr.length})</h3>${cards}`;
+  };
+  const renderInvariants = () => {
+    const arr = Array.isArray(testing.invariantChecks) ? testing.invariantChecks : [];
+    const rows = arr.map(c => kvLine(`<code>${c.name || ''}</code>`, c.purpose || '')).filter(Boolean).join('');
+    if (!rows) return '';
+    return `<div class="component" style="margin:10px 0"><div class="name">Invariant checks (${arr.length})</div><dl class="kv" style="margin-top:8px">${rows}</dl></div>`;
+  };
+  const renderDrift = () => {
+    const m = testing.driftMonitor; if (!m) return '';
+    const rows = [
+      kvLine('Installer', m.installer ? `<code>${m.installer}</code>` : null),
+      kvLine('LaunchAgent', m.label ? `<code>${m.label}</code>` : null),
+      kvLine('Schedule', m.schedule),
+      kvLine('Command', m.command ? `<code>${m.command}</code>` : null),
+      kvLine('Alert', m.alert),
+    ].filter(Boolean).join('');
+    return rows ? `<div class="component" style="margin:10px 0"><div class="name">Drift monitor</div><dl class="kv" style="margin-top:8px">${rows}</dl></div>` : '';
+  };
+  const renderCi = () => {
+    const gates = Array.isArray(testing.ciGates) ? testing.ciGates : [];
+    const gateRows = gates.map(g => kvLine(`<code>${g.name || ''}</code>`, g.purpose || '')).filter(Boolean).join('');
+    const note = testing.ciNote ? `<p class="purpose" style="margin-top:6px">${testing.ciNote}</p>` : '';
+    const cg = testing.commitGate;
+    const cgRows = cg ? [kvLine('Script', cg.script ? `<code>${cg.script}</code>` : null), kvLine('Checks', cg.checks)].filter(Boolean).join('') : '';
+    let html = '';
+    if (gateRows || note) html += `<div class="component" style="margin:10px 0"><div class="name">CI gates${gates.length ? ` (${gates.length})` : ''}</div>${note}${gateRows ? `<dl class="kv" style="margin-top:8px">${gateRows}</dl>` : ''}</div>`;
+    if (cgRows) html += `<div class="component" style="margin:10px 0"><div class="name">Commit gate</div><dl class="kv" style="margin-top:8px">${cgRows}</dl></div>`;
+    return html;
+  };
+  document.getElementById('testing-blocks').innerHTML = [renderSummary(), renderSuites(), renderInvariants(), renderDrift(), renderCi(), renderUnit(), renderApi(), renderE2E(), renderManual()].filter(Boolean).join('') || '<p style="color:var(--text-dim)">No testing data in architecture.json.</p>';
+
+  // Ops — layer is optional (project may not have one)
+  const opsLayer = LAYER_BY_ID['ops'];
+  document.getElementById('ops-components').innerHTML = opsLayer
+    ? (opsLayer.components || []).map(c => renderComponentCard(c)).join('')
+    : '<p style="color:var(--text-dim)">No ops layer defined.</p>';
+  // gitFlow — entirely optional
+  const gf = DATA.gitFlow;
+  if (gf) {
+    const entries = [];
+    if (gf.branches) for (const [k, v] of Object.entries(gf.branches)) entries.push([k, v]);
+    if (Array.isArray(gf.branchTypes)) for (const bt of gf.branchTypes) {
+      entries.push([bt.prefix + '*', `base: ${bt.baseFrom} → merges to: ${Array.isArray(bt.mergesTo) ? bt.mergesTo.join(', ') : bt.mergesTo}`]);
+    }
+    if (gf.preflight) entries.push(['preflight', gf.preflight]);
+    if (gf.plugin) entries.push(['plugin', gf.plugin]);
+    if (gf.currentVersion) entries.push(['version', gf.currentVersion]);
+    document.getElementById('gitflow-kv').innerHTML = entries.map(([k,v]) => `<dt>${k}</dt><dd>${v}</dd>`).join('');
+  } else {
+    document.getElementById('gitflow-kv').innerHTML = '<dt style="color:var(--text-dim)">no gitFlow section in architecture.json</dt>';
+  }
+
+  // Docs
+  document.getElementById('docs-list').innerHTML = (DATA.docs || []).map(d => `
+    <li><a href="${DATA.repository}/blob/${DATA.defaultBranch || 'main'}/${d.path}" target="_blank">${d.title}</a>${d.scope ? ` — <span style="color:var(--text-faint)">${d.scope}</span>` : ''}<br><code style="color:var(--text-faint);font-size:12px">${d.path}</code></li>
+  `).join('');
+
+  // JSON link: build from current page location so it survives any proxy prefix.
+  (() => {
+    const link = document.getElementById('json-link');
+    if (link) {
+      const base = location.pathname.replace(/[^/]*$/, '');
+      link.href = base + 'architecture.json';
+    }
+  })();
+
+  // Diagram (JSON-driven)
+  const dg = DATA.diagram;
+  if (dg) {
+    if (dg.intro) document.getElementById('diagram-intro').textContent = dg.intro;
+    const content = document.getElementById('diagram-content');
+    if (Array.isArray(dg.tiers) && dg.tiers.length) {
+      const renderNode = n => {
+        const style = [];
+        if (n.color) style.push(`--c: ${n.color}`);
+        if (n.bg) style.push(`background: ${n.bg}`);
+        else if (n.color) style.push(`background: linear-gradient(135deg, ${n.color}1a, transparent)`);
+        const cls = ['dnode']; if (n.full) cls.push('full');
+        const sub = n.sub ? `<span class="sub">${n.sub}</span>` : '';
+        return `<div class="${cls.join(' ')}" style="${style.join('; ')}"><div class="label">${n.label || ''}</div>${sub}</div>`;
+      };
+      const tierHtml = dg.tiers.map((tier, i) => {
+        const arrow = i > 0 && tier.arrowLabel
+          ? `<div class="arrow-down">↓<span class="lbl">${tier.arrowLabel}</span></div>`
+          : (i > 0 ? `<div class="arrow-down">↓</div>` : '');
+        const nodes = (tier.nodes || []).map(renderNode).join('');
+        return arrow + nodes;
+      }).join('');
+      content.innerHTML = `<div class="diagram">${tierHtml}</div>`;
+    } else if (dg.html) {
+      content.innerHTML = dg.html;
+    } else {
+      content.innerHTML = '<p style="color:var(--text-dim)">Diagram defined but has no tiers or html.</p>';
+    }
+    if (Array.isArray(dg.notes) && dg.notes.length) {
+      document.getElementById('diagram-notes').innerHTML = `
+        <div style="margin-top: 28px; padding: 16px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-elev)">
+          <div style="font-weight: 600; margin-bottom: 8px">Key invariants</div>
+          <ul style="margin: 0; padding-left: 22px; color: var(--text-dim); font-size: 13.5px; line-height: 1.7">
+            ${dg.notes.map(n => `<li>${n}</li>`).join('')}
+          </ul>
+        </div>`;
+    }
+  } else {
+    document.getElementById('diagram-content').innerHTML = '<p style="color:var(--text-dim)">No <code>diagram</code> field in architecture.json. Add one — see <code>references/json-schema.md</code>.</p>';
+  }
+
+    // Tabs
+  function switchTab(name) {
+    for (const b of document.querySelectorAll('nav.tabs button')) b.classList.toggle('active', b.dataset.tab === name);
+    for (const p of document.querySelectorAll('section.panel')) p.classList.toggle('active', p.id === 'panel-' + name);
+    window.scrollTo({top: 0, behavior: 'smooth'});
+    if (history.replaceState) history.replaceState(null, '', '#' + name);
+  }
+  for (const btn of document.querySelectorAll('nav.tabs button')) {
+    btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+  }
+  if (location.hash) {
+    const name = location.hash.slice(1);
+    if (document.getElementById('panel-' + name)) switchTab(name);
+  }
+})();
+</script>
+
+</body>
+</html>

--- a/docs/architecture/architecture.json
+++ b/docs/architecture/architecture.json
@@ -1,0 +1,395 @@
+{
+  "name": "obsidian-brain",
+  "displayName": "Obsidian Brain",
+  "version": "2.7.1",
+  "tagline": "A Claude Code plugin that turns an Obsidian vault into a persistent brain across sessions — auto-logging, curated knowledge capture, snapshot-on-compact, and fast cross-project recall, all via direct filesystem writes.",
+  "lastUpdated": "2026-06-12",
+  "repository": "https://github.com/abhattacherjee/obsidian-brain",
+  "defaultBranch": "main",
+  "techStack": {
+    "language": { "name": "Python", "version": "3.12", "strict": true, "notes": "stdlib only — no pip dependencies; deterministic hooks safe to run at session boundaries" },
+    "framework": { "name": "Claude Code Plugin", "version": "2.7.1", "router": "lifecycle hooks + prompt-based skills" },
+    "runtime": { "name": "Python", "minVersion": "3.12" },
+    "ui": { "library": "Obsidian Dataview", "version": "community plugin (JS + inline queries)", "notes": "dashboards only — the plugin itself requires no Obsidian plugin to write notes" },
+    "persistence": { "primary": "Markdown vault (filesystem)", "secondary": ["SQLite + FTS5 search index", "JSON config", "append-only telemetry logs"] },
+    "realtime": { "protocol": "none", "endpoint": "direct filesystem writes — no MCP server, no REST API, no daemon" },
+    "ai": { "provider": "Claude CLI (claude -p)", "model": "haiku default; escalates haiku to sonnet to opus on empty output (#165)", "notes": "summarization deferred from hooks to /recall" },
+    "vectorSearch": { "engine": "SQLite FTS5 (BM25) + 7-signal rerank; TF-IDF cosine themes with ACT-R activation and Free-Energy surprise" },
+    "tests": { "unit": { "runner": "pytest", "count": 64, "environments": ["python3.12"], "coverage": { "lines": 90 } } },
+    "packageManager": "none (stdlib only)"
+  },
+  "diagram": {
+    "intro": "Two execution modes feed one store. Auto-running Python hooks fire on Claude Code session-lifecycle events and write raw notes immediately (write-first); prompt-based skills run on demand to summarize, search, triage and repair. A shared stdlib core (obsidian_utils) is the spine; a SQLite+FTS5 index powers ranked recall. Everything is a direct, atomic filesystem write — it works even when Obsidian is closed.",
+    "tiers": [
+      { "arrowLabel": null, "nodes": [{ "label": "Claude Code", "sub": "session lifecycle", "color": "#7B61FF", "full": true }] },
+      { "arrowLabel": "SessionEnd · SessionStart · PreCompact", "nodes": [{ "label": "Lifecycle Hooks", "sub": "log · hint · snapshot · reaper", "color": "#7B61FF", "full": true }] },
+      { "arrowLabel": "shared spine (stdlib)", "nodes": [{ "label": "obsidian_utils", "sub": "config · session-ctx · summarize · atomic write · scrub", "color": "#22D3EE", "full": true }] },
+      { "arrowLabel": "persist (write-first, atomic, 0600)", "nodes": [
+        { "label": "Markdown Vault", "sub": "sessions / insights / snapshots", "color": "#F97316" },
+        { "label": "SQLite + FTS5", "sub": "7-signal rank · themes", "color": "#10B981" },
+        { "label": "Config + Telemetry", "sub": "~/.claude", "color": "#84CC16" }
+      ] },
+      { "arrowLabel": "on demand (18 skills)", "nodes": [
+        { "label": "Capture / Recall", "sub": "compress · recall · vault-ask · standup", "color": "#8B5CF6" },
+        { "label": "vault-doctor", "sub": "9 pluggable checks", "color": "#EC4899" },
+        { "label": "check-items", "sub": "AI triage pipeline", "color": "#F59E0B" }
+      ] }
+    ],
+    "notes": [
+      "Hooks never import vault_index — indexing is a deliberate skill-side concern, keeping hooks fast and deterministic (they must exit 0).",
+      "Summarization (claude -p haiku) is deferred from SessionEnd to /recall, because a SessionEnd subprocess is SIGKILLed when the session process-tree exits.",
+      "All vault writes are atomic temp+rename, mode 0600, path-contained via resolve()+is_relative_to() against the vault root.",
+      "A cross-plugin O_EXCL dedup lock (fail-open, 15s TTL) lets the monorepo and standalone installs coexist without double-writing."
+    ]
+  },
+  "layers": [
+    {
+      "id": "lifecycle-hooks",
+      "name": "Lifecycle Hooks (auto-running Python)",
+      "color": "#7B61FF",
+      "description": "Stdlib Python scripts registered in hooks/hooks.json, triggered by Claude Code session-lifecycle events. Each reads JSON from stdin (1 MB cap), always exits 0, and writes atomically. Implements the write-first pattern: raw notes saved immediately, AI summarization deferred to /recall.",
+      "components": [
+        { "id": "hook-session-log", "name": "obsidian_session_log.py", "kind": "module", "files": ["hooks/obsidian_session_log.py"], "purpose": "SessionEnd: writes the raw session note immediately. Discovers sibling snapshots (cross-midnight), applies message-count + duration thresholds (snapshot presence bypasses skips), dedup-claims before the expensive raw-body build, and logs a structured outcome line for every exit path." },
+        { "id": "hook-session-hint", "name": "obsidian_session_hint.py", "kind": "module", "files": ["hooks/obsidian_session_hint.py"], "purpose": "SessionStart (matcher startup|resume|clear|compact): refreshes the bootstrap sid-file atomically, invokes the orphan reaper, and injects a read-only last-session context hint via hookSpecificOutput.additionalContext." },
+        { "id": "hook-context-snapshot", "name": "obsidian_context_snapshot.py", "kind": "module", "files": ["hooks/obsidian_context_snapshot.py"], "purpose": "PreCompact: saves a context snapshot before compression. Gates on snapshot_on_compact/snapshot_on_clear, scrubs secrets, and writes a snapshot note backlinked to its parent session. Stderr-only telemetry (no hook-log line)." },
+        { "id": "hook-session-reaper", "name": "obsidian_session_reaper.py", "kind": "module", "files": ["hooks/obsidian_session_reaper.py"], "purpose": "Called by SessionStart: reconstructs session notes for orphaned JSONL transcripts where SessionEnd never fired (SIGKILL, worktree teardown). Watermark-bounded, 5s budget, permission-canary guarded; writes notes tagged claude/reconstructed." },
+        { "id": "hooks-registration", "name": "hooks.json", "kind": "registration", "files": ["hooks/hooks.json"], "purpose": "Registers SessionEnd to session_log, SessionStart to session_hint, PreCompact to context_snapshot. Commands invoke python3 with the plugin-root hook path." }
+      ]
+    },
+    {
+      "id": "shared-core",
+      "name": "Shared Core (obsidian_utils)",
+      "color": "#22D3EE",
+      "description": "The ~5.5k-line stdlib spine (4.3k code lines) imported by every hook and many skills: config + session resolution, transcript parsing, deferred summarization (shells out to claude -p), atomic vault writes, secret scrubbing, the cross-plugin dedup lock, and telemetry. Every function self-catches and logs to stderr.",
+      "components": [
+        { "id": "load-config", "name": "load_config()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Reads the machine-local config JSON over deepcopy(_DEFAULTS), session-scoped cached by cwd-derived SID. Side-effect: auto-chmods the config to 0600 if group/world bits are set." },
+        { "id": "session-context", "name": "get_session_context() / SID resolution", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Single source of truth for session id, 4-char hash, project, and session-note name. Layered SID chain: project-basename to bootstrap fast-path to slow JSONL glob to recent-bootstrap scan to unknown. SID filenames validated against a safe charset to block path traversal." },
+        { "id": "canonical-project-name", "name": "canonical_project_name()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Resolves the main-repo basename via the git common-dir so all worktrees of a repo collapse under one logical project; normalizes spaces/underscores to hyphens; one-shot stderr warning only on genuine git failure." },
+        { "id": "transcript-parser", "name": "read_transcript() / extract_*_messages()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Parses CC JSONL transcripts (nested message.content and flat shapes), extracting user/assistant messages and tool uses." },
+        { "id": "session-metadata", "name": "extract_session_metadata()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Derives project, project_path, git_branch, files_touched (<=60), errors (<=30), duration_minutes, and commits from a transcript." },
+        { "id": "summarizer", "name": "generate_summary() / generate_snapshot_summary()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Builds a structured prompt and runs the Claude CLI in print mode with timeout+retry. Two-layer open-item dedup, model escalation on empty output, and conservative summary recovery (_normalize_summary). Returns (text, reason)." },
+        { "id": "write-vault-note", "name": "write_vault_note()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "The single atomic-write primitive: path-traversal check (resolve + is_relative_to vault root) BEFORE any side effect, then mkstemp + chmod 0600 + os.rename. Returns None on success or a non-empty error string." },
+        { "id": "scrub-secrets", "name": "scrub_secrets() / escape_wikilinks()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "Best-effort redaction of GitHub/AWS tokens, password/secret/api_key assignments, PEM headers and Bearer values before any user content reaches the vault; escapes double-brackets so bash test brackets do not create phantom Obsidian links." },
+        { "id": "hook-dedup-lock", "name": "claim_hook_run() / release_hook_run()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "O_CREAT|O_EXCL lock files under the secure working dir (15s TTL, fail-open, PID-checked release) coordinating the double-install (monorepo + standalone) case so a hook never fires twice." },
+        { "id": "gather-evidence", "name": "gather_session_evidence()", "kind": "function", "files": ["hooks/obsidian_utils.py"], "purpose": "For /retro: collects all snapshots + insights/decisions/error-fixes whose frontmatter source_session matches the active session, with discovery_errors captured rather than raised." },
+        { "id": "telemetry-log", "name": "_append_sessionend_log() / _append_reaper_log()", "kind": "ops", "files": ["hooks/obsidian_utils.py"], "purpose": "Writes one-line key=value outcome records to the hook telemetry log, rotating at 100 KB, 0600, sanitizing newlines/tabs. Primary diagnostic surface for sessions that did not produce a vault note." }
+      ]
+    },
+    {
+      "id": "search-index",
+      "name": "Search & Index (SQLite + FTS5)",
+      "color": "#10B981",
+      "description": "A local SQLite database (WAL mode, FTS5) that enables fast full-text and ranked recall across the vault. Lazy mtime-incremental sync, a 7-signal reranker, ACT-R activation from an access log, and TF-IDF cosine themes with a Free-Energy surprise signal. Hooks never touch this — it is skill-side only.",
+      "components": [
+        { "id": "ensure-index", "name": "ensure_index() / _sync()", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Create-or-update the DB: schema init statement-by-statement (FTS5 IF NOT EXISTS), column migrations, mtime-incremental sync inside BEGIN IMMEDIATE, and corruption recovery that deletes+recreates db/-wal/-shm.", "overrideEnv": "OBSIDIAN_BRAIN_DB" },
+        { "id": "search-vault", "name": "search_vault()", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Sanitizes the query to AND-mode FTS5 (hyphens to spaces), runs bm25 with title 10x and tags 5x weighting, OR-fallback when AND is empty, reranks, batch-logs access, strips body before returning." },
+        { "id": "rerank", "name": "rerank_results() — 7-signal scorer", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Weighted sum: proximity 0.25, bm25 0.20, activation 0.20, type 0.10, recency 0.10, importance 0.10, density 0.05. Type score is context-adaptive (debugging/standup/emerge/search/general)." },
+        { "id": "access-log", "name": "log_access() / batch_activations()", "kind": "datastore-client", "files": ["hooks/vault_index.py"], "purpose": "Records access events (cascading snapshot accesses to the parent session) and computes ACT-R base-level activation, reserving 0.0 for notes with no history." },
+        { "id": "themes", "name": "assign_to_theme() / detect_surprise()", "kind": "module", "files": ["hooks/vault_index.py"], "purpose": "TF-IDF (smoothed IDF, sparse top-50) cosine clustering into running-average centroids (threshold 0.3); Free-Energy surprise = negation-proximity over top shared terms. term_df maintained via ON CONFLICT DO UPDATE, never blind REPLACE." },
+        { "id": "rebuild-index", "name": "rebuild_index() — Friston-preserving", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Default non-destructive rebuild preserves access_log, themes and theme_members (activation/centroid/surprise), with an absolute-path safety guard that skips orphan-prune on path-format drift. full=True is the legacy total wipe for corrupt schema." },
+        { "id": "upsert-note", "name": "_upsert_note() — DELETE-then-INSERT", "kind": "function", "files": ["hooks/vault_index.py"], "purpose": "Deliberately avoids INSERT OR REPLACE: explicit DELETE+INSERT preserving the prior importance value, and issuing the contentless-FTS5 delete op with old column values so the FTS index never accumulates orphans." },
+        { "id": "vault-stats-compute", "name": "compute_stats()", "kind": "function", "files": ["hooks/vault_stats.py"], "purpose": "Read-only aggregation for /vault-stats: signal coverage (per-note activation + importance), access-by-context, top-accessed, importance distribution, and snapshot integrity metrics (orphans, broken backlinks, summarized fraction)." }
+      ]
+    },
+    {
+      "id": "triage-pipeline",
+      "name": "Triage Pipeline (check-items / emerge / standup-deep)",
+      "color": "#F59E0B",
+      "description": "The Python support layer behind /check-items, /standup deep and /emerge. A staged pipeline — L1 cache to token grouping to semantic merge to evidence gather to L2 deterministic prefilter to chunked LLM classification to partition to dashboard — with tight false-positive guards and a heuristic fallback.",
+      "components": [
+        { "id": "check-items-args", "name": "check_items_args.py", "kind": "module", "files": ["hooks/check_items_args.py"], "purpose": "Order-independent Scope parsing: mode (current/vault/project), Nd window, --show-all/--dry-run/--no-cache, and project detection against known workspace dirs." },
+        { "id": "check-items-prefilter", "name": "check_items_prefilter.py", "kind": "module", "files": ["hooks/check_items_prefilter.py"], "purpose": "L2 deterministic triage: classifies items with no plausible completion evidence without dispatching a sub-agent. Distinctiveness gate (snake_case / len>=8 / interior mixed-case) is the key false-positive guard against generic short words.", "overrideEnv": "CHECK_ITEMS_PREFILTER" },
+        { "id": "check-items-cache", "name": "check_items_cache.py", "kind": "module", "files": ["hooks/check_items_cache.py"], "purpose": "Persistent classification cache keyed by a 16-hex canonical content hash. Invalidation: force to new to head_changed to mtime_changed to ttl_expired (DONE/STALE 24h, ACTIVE 7d). Atomic 0600 store." },
+        { "id": "check-items-cli", "name": "check_items_cli.py", "kind": "module", "files": ["hooks/check_items_cli.py"], "purpose": "Holds the semantic-merge and classifier prompts and the Claude CLI dispatch. Solves the timeout problem by chunking to <=25 groups/call (well under the 300s ceiling) so chunks stay on Haiku; strips json fences and validates the 6-field payload.", "overrideEnv": "CHECK_ITEMS_CLASSIFIER_CHUNK_SIZE" },
+        { "id": "check-items-report", "name": "check_items_report.py", "kind": "module", "files": ["hooks/check_items_report.py"], "purpose": "Writes the per-scope dashboard note (Done/Needs-Action/Stale/Active sections + classifier-mode frontmatter), always written even on --dry-run, path-contained and atomic." },
+        { "id": "open-item-dedup", "name": "open_item_dedup.py", "kind": "module", "files": ["hooks/open_item_dedup.py"], "purpose": "Cross-note open-item dedup (exact to distinctive-token to fuzzy set-intersection), cascade-checkoff with verify-before-edit, the heuristic fallback classifier (distinctive token AND completion phrase within +/-120 chars), and the deep_analysis_pipeline evidence engine." },
+        { "id": "compress-guard", "name": "compress_guard.py", "kind": "module", "files": ["hooks/compress_guard.py"], "purpose": "is_high_confidence_match() predicate for /compress dedup: absolute-strength gate (top rank <= -5.0) AND rank-delta gate (top minus runner-up > 0.25), tuned against compress_rank_gap_corpus.json." },
+        { "id": "deep-cli", "name": "deep_cli.py", "kind": "module", "files": ["hooks/deep_cli.py"], "purpose": "Thin CLI backing /standup deep: runs the deep pipeline, renders the presentation, and applies path-contained batch edits with a 24h acted-on store so items are not re-recommended." },
+        { "id": "emerge-cli", "name": "emerge_cli.py", "kind": "module", "files": ["hooks/emerge_cli.py"], "purpose": "Thin CLI backing /emerge: collects a vault corpus over a window (snapshots excluded by default), re-collects post-upgrade, and assembles the claude-emerge note with source_notes wikilinks." },
+        { "id": "summarizer-metrics", "name": "summarizer_metrics.py", "kind": "ops", "files": ["hooks/summarizer_metrics.py"], "purpose": "Append-only JSONL telemetry for upgrade_batch() runs; rotates at 100 KB; never raises (best-effort stderr warn only)." }
+      ]
+    },
+    {
+      "id": "vault-doctor",
+      "name": "Vault Doctor (pluggable repair engine)",
+      "color": "#EC4899",
+      "description": "A dispatcher plus an auto-discovered registry of repair checks. Each check implements scan() to list[Issue] and apply() to list[Result]. Dry-run by default; per-check crash containment; a --min-confidence filter that is override-safe because apply() raises on any non-canonical signal_class. Exit-code 2 escalates even at 0 issues when a check crashes.",
+      "components": [
+        { "id": "doctor-dispatcher", "name": "vault_doctor.py", "kind": "module", "files": ["scripts/vault_doctor.py"], "purpose": "CLI dispatcher: config resolution (CLI > env > file, bypassing the session cache), flag forwarding via EXTRA_SCAN_FLAGS, per-check scan/apply crash containment with crashed_checks, the confidence filter with dropped_per_signal_class attribution, timestamped backup root, and the 0/1/2/3 exit-code contract." },
+        { "id": "check-registry", "name": "vault_doctor_checks/__init__.py", "kind": "registration", "files": ["scripts/vault_doctor_checks/__init__.py"], "purpose": "Auto-discovers checks via pkgutil; defines the Issue/Result dataclasses and the scan/apply module contract; all_checks() excludes OPT_IN=True checks; broken modules are warned-and-skipped, never fatal." },
+        { "id": "check-source-sessions", "name": "source-sessions", "kind": "module", "files": ["scripts/vault_doctor_checks/source_sessions.py"], "purpose": "UUID-first stale source_session backlink detector across insights/decisions/error-fixes/retros. Skips imported notes; preserves mtime on repair so fixed notes do not re-enter the window; apply() raises on non uuid-basename-stale signal_class (conf 0.99)." },
+        { "id": "check-session-coverage", "name": "session-coverage (opt-in)", "kind": "module", "files": ["scripts/vault_doctor_checks/session_coverage.py"], "purpose": "Detects JSONL transcripts with no session note (SessionEnd missed), replicating hook thresholds + snapshot-anchor bypass. --reconstruct shells out to replay-sessionend.py to write the note (conf 0.9); replay-JSON shape-guarded." },
+        { "id": "check-snapshot-integrity", "name": "snapshot-integrity", "kind": "module", "files": ["scripts/vault_doctor_checks/snapshot_integrity.py"], "purpose": "Five sub-checks: orphan snapshots, broken backlinks, stale/missing session snapshot-lists, and summary-status mismatch. Project-blind sid-collision detection routes colliding sids to unresolved before any parent-based fix." },
+        { "id": "check-snapshot-migration", "name": "snapshot-migration", "kind": "module", "files": ["scripts/vault_doctor_checks/snapshot_migration.py"], "purpose": "Ordered legacy-format migrations (filename HHMMSS, missing status/backlink, session snapshot-list). Tracks renamed paths/stems, re-checks collisions before os.rename, and rolls back a rename only if zero vault-wide wikilink rewrites succeeded." },
+        { "id": "check-project-canonicalization", "name": "project-name-canonicalization (opt-in)", "kind": "module", "files": ["scripts/vault_doctor_checks/project_name_canonicalization.py"], "purpose": "Backfills the canonical main-repo project name vs worktree slug via git rev-parse, with a GIT_DIR env scrub so ambient vars cannot certify one bogus name vault-wide; strict UTF-8 decode in apply (defers to encoding-corruption)." },
+        { "id": "check-project-normalization", "name": "project-name-normalization", "kind": "module", "files": ["scripts/vault_doctor_checks/project_name_normalization.py"], "purpose": "Detects underscores in project frontmatter (personal_ws to personal-ws) and the matching project tag; frontmatter-only regex; conf 1.0." },
+        { "id": "check-spurious-wikilinks", "name": "spurious-wikilinks", "kind": "module", "files": ["scripts/vault_doctor_checks/spurious_wikilinks.py"], "purpose": "Escapes unescaped double-brackets in conversation/tool-usage lines (bash test brackets parsed by Obsidian as phantom wikilinks); session folder only; conf 1.0." },
+        { "id": "check-encoding-corruption", "name": "encoding-corruption", "kind": "module", "files": ["scripts/vault_doctor_checks/encoding_corruption.py"], "purpose": "Detects invalid UTF-8 bytes (grep Binary file matches); re-encodes with errors=replace; backs up raw original bytes before the atomic rewrite." },
+        { "id": "check-audit-historic", "name": "audit-historic-repairs (opt-in)", "kind": "module", "files": ["scripts/vault_doctor_checks/audit_historic_repairs.py"], "purpose": "One-shot audit of prior doctor backups: classifies each note A (restore mtime-drift corruption) / B (keep) / C (ambiguous) / D (both-wrong); only category A auto-applies, restoring the oldest backup backlink. Loud no-op if the backup root is missing.", "overrideEnv": "OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT" }
+      ]
+    },
+    {
+      "id": "skills",
+      "name": "Skills (prompt-based procedures)",
+      "color": "#8B5CF6",
+      "description": "18 SKILL.md prompt procedures (no code files) that Claude Code follows step-by-step, reaching the backing Python via a cache glob. Grouped by lifecycle: SETUP, CAPTURE, RECALL/QUERY, MAINTENANCE, TRIAGE. Some fan out to sub-agents; most run inline.",
+      "components": [
+        { "id": "sk-obsidian-setup", "name": "/obsidian-setup", "kind": "module", "files": ["skills/obsidian-setup/SKILL.md"], "purpose": "SETUP. First-run/upgrade config: vault path, folders, dashboards install, optional deps; writes the config JSON and rebuilds the index." },
+        { "id": "sk-vault-config", "name": "/vault-config", "kind": "module", "files": ["skills/vault-config/SKILL.md"], "purpose": "SETUP. Interactive numbered-menu editor for config (toggles, thresholds, snapshot flags) with atomic config rewrite." },
+        { "id": "sk-compress", "name": "/compress", "kind": "module", "files": ["skills/compress/SKILL.md"], "purpose": "CAPTURE. Saves curated session insights (multi-pick or single-topic, with update-existing path); dedups against the index via compress_guard." },
+        { "id": "sk-decide", "name": "/decide", "kind": "module", "files": ["skills/decide/SKILL.md"], "purpose": "CAPTURE. Writes ADR-lite decision notes (context/options/decision/rationale/consequences) with active/superseded status." },
+        { "id": "sk-error-log", "name": "/error-log", "kind": "module", "files": ["skills/error-log/SKILL.md"], "purpose": "CAPTURE. Structured error to root-cause to fix to prevention notes." },
+        { "id": "sk-retro", "name": "/retro", "kind": "module", "files": ["skills/retro/SKILL.md"], "purpose": "CAPTURE. Honest session retrospective pulling prior-session snapshots/insights as first-class evidence via gather_session_evidence." },
+        { "id": "sk-recall", "name": "/recall", "kind": "module", "files": ["skills/recall/SKILL.md"], "purpose": "RECALL. Read-only context resume: upgrades unsummarized notes (ThreadPool Haiku pipeline, per-note sub-agent fallback) and presents a context brief." },
+        { "id": "sk-vault-ask", "name": "/vault-ask", "kind": "module", "files": ["skills/vault-ask/SKILL.md"], "purpose": "RECALL. Synthesized, source-cited answer grounded in vault notes; FTS fast-path + 3 parallel Grep agents + per-file context-shield sub-agents + snapshot summaries." },
+        { "id": "sk-vault-search", "name": "/vault-search", "kind": "module", "files": ["skills/vault-search/SKILL.md"], "purpose": "RECALL. Ranked keyword/tag/structured search with snippets and snapshot markers via ensure_index + search_vault." },
+        { "id": "sk-standup", "name": "/standup", "kind": "module", "files": ["skills/standup/SKILL.md"], "purpose": "RECALL. Daily/weekly cross-project standup; deep mode adds the AI item-classification + cascade-checkoff pipeline via deep_cli." },
+        { "id": "sk-link", "name": "/link", "kind": "module", "files": ["skills/link/SKILL.md"], "purpose": "RECALL. Bidirectional wikilink cross-referencing in Related sections (model-driven ranking, parallel Grep)." },
+        { "id": "sk-vault-doctor", "name": "/vault-doctor", "kind": "module", "files": ["skills/vault-doctor/SKILL.md"], "purpose": "MAINTENANCE. Orchestrates scripts/vault_doctor.py; dry-run unless fix; documents the exit-code/crashed_checks contract and the crash-vs-apply-error remediation branch." },
+        { "id": "sk-vault-reindex", "name": "/vault-reindex", "kind": "module", "files": ["skills/vault-reindex/SKILL.md"], "purpose": "MAINTENANCE. Rebuild the FTS5 index; non-destructive by default, --full wipes the Friston tables." },
+        { "id": "sk-vault-import", "name": "/vault-import", "kind": "module", "files": ["skills/vault-import/SKILL.md"], "purpose": "MAINTENANCE. Backfills historical sessions from the CC projects JSONLs (up to 5 parallel context-shield sub-agents)." },
+        { "id": "sk-vault-stats", "name": "/vault-stats", "kind": "module", "files": ["skills/vault-stats/SKILL.md"], "purpose": "MAINTENANCE. Vault health + access/importance analytics; saves a trend-tracking note via compute_stats." },
+        { "id": "sk-dev-test", "name": "/dev-test", "kind": "module", "files": ["skills/dev-test/SKILL.md"], "purpose": "MAINTENANCE. Install/restore/status the dev plugin into the cache for local testing via scripts/test-dev-skill.sh." },
+        { "id": "sk-check-items", "name": "/check-items", "kind": "module", "files": ["skills/check-items/SKILL.md"], "purpose": "TRIAGE. Two-pass AI triage of open items: auto-checks PR-shipped items, cache-backed, cascades sibling checkoffs. Owns partition() and classifier dispatch over the triage-pipeline modules." },
+        { "id": "sk-emerge", "name": "/emerge", "kind": "module", "files": ["skills/emerge/SKILL.md"], "purpose": "TRIAGE. Surfaces unnamed cross-note patterns over a window via a synthesis Agent over emerge_cli corpus." }
+      ]
+    },
+    {
+      "id": "note-schema",
+      "name": "Note Schema & Dashboards",
+      "color": "#06B6D4",
+      "description": "Markdown templates define every note type frontmatter and body; the universal claude/ tag prefix and type discriminator are the coupling between writers (templates) and readers (Dataview dashboards).",
+      "components": [
+        { "id": "note-templates", "name": "Note templates", "kind": "module", "files": ["templates/session.md", "templates/snapshot.md", "templates/insight.md", "templates/decision.md", "templates/error-fix.md", "templates/imported-session.md"], "purpose": "Mustache-style templates. Curated notes (insight/decision/error-fix) carry created_at/source_session/source_session_note/project; runtime notes (session/snapshot/imported) carry session_id/git_branch/duration/status. Decision is the only curated type with a status field." },
+        { "id": "tag-convention", "name": "claude/ tag convention", "kind": "module-inline", "files": ["CLAUDE.md"], "purpose": "Every frontmatter tag uses the claude/ prefix: type tag (claude/session, claude/insight), claude/project/<name>, claude/topic/<topic>, claude/auto, claude/imported, claude/reconstructed, claude/retro, claude/standup. Dashboards filter exclusively on these." },
+        { "id": "dataview-dashboards", "name": "Dataview dashboards", "kind": "module", "files": ["dashboards/sessions-overview.md", "dashboards/open-items.md", "dashboards/decision-timeline.md", "dashboards/learning-velocity.md", "dashboards/project-index.md", "dashboards/weekly-review.md"], "purpose": "Six Dataview/dataviewjs dashboards over claude-sessions + claude-insights: recent sessions, open items by project, decision timeline, topic/error-pattern velocity, project index, and a 7-day weekly review. Require the Obsidian Dataview plugin." }
+      ]
+    },
+    {
+      "id": "storage-telemetry",
+      "name": "Storage & Telemetry (datastores)",
+      "color": "#F97316",
+      "description": "Where state lives. One markdown vault (the product), one SQLite index (derived, rebuildable), a machine-local JSON config, a 0700 secure working directory for locks/cache/bootstrap/watermark, and append-only telemetry logs.",
+      "components": [
+        { "id": "db-vault", "name": "Markdown Vault", "kind": "datastore", "files": [], "purpose": "The Obsidian vault (live config: a local claude-code-vault folder). Folders claude-sessions/, claude-insights/, claude-check-items/, claude-dashboards/. The source of truth; works when Obsidian is closed." },
+        { "id": "db-index", "name": "SQLite + FTS5 index", "kind": "datastore", "files": ["hooks/vault_index.py"], "purpose": "The vault index DB (WAL, 0600, ~33 MB). Tables: notes, notes_fts (contentless FTS5), access_log, themes, theme_members, term_df. Derived and fully rebuildable from the vault.", "overrideEnv": "OBSIDIAN_BRAIN_DB" },
+        { "id": "db-config", "name": "Config file", "kind": "datastore", "files": [], "purpose": "Machine-local config JSON (0600, auto-chmodded). vault_path, folder names, min_messages/min_duration thresholds, summary_model, and feature flags (auto_log_enabled, snapshot_on_compact/clear, log_raw_messages)." },
+        { "id": "db-secure-workdir", "name": "Secure working dir", "kind": "datastore", "files": [], "purpose": "The 0700 secure working dir: locks/ (O_EXCL hook-dedup), cache-<sid>.json, sid-<project> bootstrap files, reaper-watermark-<project>, and triage/pipeline temp + cache JSON. Replaces /tmp to prevent symlink/cache-poisoning." },
+        { "id": "db-hook-log", "name": "Hook telemetry log", "kind": "datastore", "files": [], "purpose": "The hook telemetry log (0600, rotates at 100 KB). One key=value line per SessionEnd/SessionStart/Reaper event; the primary diagnostic for sessions that produced no note." },
+        { "id": "db-summarizer-metrics", "name": "Summarizer metrics JSONL", "kind": "datastore", "files": ["hooks/summarizer_metrics.py"], "purpose": "Append-only summarizer metrics JSONL (0600, rotates at 100 KB). One record per upgrade_batch() run." }
+      ]
+    },
+    {
+      "id": "build-release",
+      "name": "Build, Release & CI",
+      "color": "#84CC16",
+      "description": "No build step (pure Python + Markdown). Validation is the pytest suite + a layered preflight + CI. Distribution is a standalone marketplace from this repo, with plugin.json and marketplace.json version-bumped in lockstep.",
+      "components": [
+        { "id": "ops-bump-version", "name": "bump-version.sh", "kind": "ops", "files": ["scripts/bump-version.sh"], "purpose": "Bumps plugin.json + marketplace.json in lockstep (major|minor|patch|X.Y.Z) with pre-bump validation, atomic marketplace write, and all-or-nothing rollback if the second write fails." },
+        { "id": "ops-commit-preflight", "name": "commit-preflight.sh", "kind": "ops", "files": ["scripts/commit-preflight.sh"], "purpose": "Creates a 5-minute token consumed by the require-preflight hook. Enforces (always-on) manifest version sync, then secret scan, then pytest with cov-fail-under 90. Flags: --docs-only, --skip-tests, --auto." },
+        { "id": "ops-ci", "name": "CI workflow", "kind": "ops", "files": [".github/workflows/ci.yml"], "purpose": "Adaptive cost-optimized CI: secret-scan, changelog-check (PRs to main), python-tests (3.12, cov>=90), no-default-db AST guard, security-tests, and an advisory detect-release-merge check." },
+        { "id": "ops-no-default-db", "name": "no-default-db.py", "kind": "ops", "files": ["scripts/ci-checks/no-default-db.py"], "purpose": "AST guard (GH #46): every ensure_index/rebuild_index/deep_analysis_pipeline call in tests/ must pass explicit db_path= so tests cannot pollute the live vault DB." },
+        { "id": "ops-pytest", "name": "pytest suite", "kind": "ops", "files": ["tests/"], "purpose": "64 test files, coverage source=hooks, fail_under=90. Hook simulation pattern pipes synthetic JSON into installed hooks; import-time state-dir constants isolated via autouse conftest monkeypatch." },
+        { "id": "ops-security-tests", "name": "test-security.sh", "kind": "ops", "files": ["scripts/test-security.sh"], "purpose": "Runs the security regression suite (path containment, secret scrub, temp-path safety) with OB_HOOKS_DIR=hooks." }
+      ]
+    }
+  ],
+  "flows": [
+    {
+      "id": "session-end-autolog",
+      "name": "SessionEnd auto-log (write-first)",
+      "description": "When a Claude Code session ends, the raw note is written immediately; AI summarization is deferred to /recall.",
+      "steps": [
+        { "from": "hooks-registration", "to": "hook-session-log", "label": "SessionEnd JSON via stdin (1 MB cap)" },
+        { "from": "hook-session-log", "to": "transcript-parser", "label": "read JSONL transcript" },
+        { "from": "transcript-parser", "to": "session-metadata", "label": "extract project/branch/files/errors" },
+        { "from": "session-metadata", "to": "hook-dedup-lock", "label": "claim SessionEnd before raw-body build" },
+        { "from": "hook-session-log", "to": "write-vault-note", "label": "raw note (status: auto-logged)" },
+        { "from": "write-vault-note", "to": "db-vault", "label": "atomic temp+rename, 0600" },
+        { "from": "hook-session-log", "to": "telemetry-log", "label": "outcome=OK_RAW_NOTE_ONLY / SKIPPED / WRITE_FAILED" }
+      ]
+    },
+    {
+      "id": "session-start-hint",
+      "name": "SessionStart hint + reaper",
+      "description": "On session start, refresh the bootstrap sid-file, sweep orphaned transcripts, and inject a last-session context hint.",
+      "steps": [
+        { "from": "hooks-registration", "to": "hook-session-hint", "label": "SessionStart (startup|resume|clear|compact)" },
+        { "from": "hook-session-hint", "to": "db-secure-workdir", "label": "atomic bootstrap sid-<project> write" },
+        { "from": "hook-session-hint", "to": "hook-session-reaper", "label": "invoke (if reaper_enabled)" },
+        { "from": "hook-session-hint", "to": "db-vault", "label": "find latest session note" },
+        { "from": "hook-session-hint", "to": "telemetry-log", "label": "bootstrap_updated=true|false" }
+      ]
+    },
+    {
+      "id": "precompact-snapshot",
+      "name": "PreCompact context snapshot",
+      "description": "Before context compression, persist a scrubbed snapshot backlinked to the parent session.",
+      "steps": [
+        { "from": "hooks-registration", "to": "hook-context-snapshot", "label": "PreCompact (source: compact|clear|auto)" },
+        { "from": "hook-context-snapshot", "to": "transcript-parser", "label": "read transcript" },
+        { "from": "hook-context-snapshot", "to": "scrub-secrets", "label": "scrub secrets (redact)" },
+        { "from": "hook-context-snapshot", "to": "write-vault-note", "label": "snapshot note -snapshot-HHMMSS" },
+        { "from": "write-vault-note", "to": "db-vault", "label": "atomic write, backlink to parent" }
+      ]
+    },
+    {
+      "id": "orphan-reaper",
+      "name": "Orphan transcript reaper",
+      "description": "Reconstruct notes for sessions where SessionEnd never fired (SIGKILL, worktree teardown).",
+      "steps": [
+        { "from": "hook-session-reaper", "to": "canonical-project-name", "label": "collapse worktrees to one project" },
+        { "from": "hook-session-reaper", "to": "transcript-parser", "label": "read orphaned JSONL (mtime > watermark)" },
+        { "from": "hook-session-reaper", "to": "write-vault-note", "label": "reconstructed note (claude/reconstructed)" },
+        { "from": "write-vault-note", "to": "db-vault", "label": "atomic write" },
+        { "from": "hook-session-reaper", "to": "db-secure-workdir", "label": "advance reaper-watermark" }
+      ]
+    },
+    {
+      "id": "recall-deferred-summarize",
+      "name": "/recall deferred summarization",
+      "description": "On demand, upgrade raw notes to AI summaries — the deferred half of the write-first pattern.",
+      "steps": [
+        { "from": "sk-recall", "to": "summarizer", "label": "generate_summary (Claude CLI haiku, escalate)" },
+        { "from": "summarizer", "to": "db-vault", "label": "flip status: auto-logged to summarized" },
+        { "from": "sk-recall", "to": "search-vault", "label": "build context brief from ranked notes" }
+      ]
+    },
+    {
+      "id": "search-and-rank",
+      "name": "Search & 7-signal rank",
+      "description": "FTS5 BM25 candidate retrieval reranked by 7 signals, with access logged for ACT-R activation.",
+      "steps": [
+        { "from": "sk-vault-search", "to": "ensure-index", "label": "lazy mtime-incremental sync" },
+        { "from": "ensure-index", "to": "db-index", "label": "upsert changed notes (DELETE-then-INSERT)" },
+        { "from": "sk-vault-search", "to": "search-vault", "label": "AND-mode FTS5 query" },
+        { "from": "search-vault", "to": "rerank", "label": "proximity/bm25/activation/type/recency/importance/density" },
+        { "from": "rerank", "to": "access-log", "label": "batch-log access to activation" },
+        { "from": "access-log", "to": "db-index", "label": "insert access rows (cascade snapshot to session)" }
+      ]
+    },
+    {
+      "id": "check-items-triage",
+      "name": "/check-items AI triage",
+      "description": "Stage open items through cache to prefilter to chunked LLM classification to partition to dashboard.",
+      "steps": [
+        { "from": "sk-check-items", "to": "check-items-args", "label": "parse scope/window/flags" },
+        { "from": "check-items-args", "to": "check-items-cache", "label": "partition known vs needs-classify (hash + TTL)" },
+        { "from": "check-items-cache", "to": "check-items-prefilter", "label": "L2 deterministic no-evidence triage" },
+        { "from": "check-items-prefilter", "to": "check-items-cli", "label": "classify <=25/chunk (under 300s, stay on Haiku)" },
+        { "from": "check-items-cli", "to": "open-item-dedup", "label": "cascade sibling checkoffs (verify-before-edit)" },
+        { "from": "open-item-dedup", "to": "check-items-report", "label": "partition Done/Needs-Action/Stale/Active" },
+        { "from": "check-items-report", "to": "db-vault", "label": "write per-scope dashboard note" }
+      ]
+    },
+    {
+      "id": "vault-doctor-repair",
+      "name": "/vault-doctor scan & repair",
+      "description": "Dispatch registered checks; dry-run by default; apply() raises on non-canonical signal_class so --min-confidence is override-safe.",
+      "steps": [
+        { "from": "sk-vault-doctor", "to": "doctor-dispatcher", "label": "resolve config (CLI>env>file), select checks" },
+        { "from": "doctor-dispatcher", "to": "check-registry", "label": "auto-discover checks (exclude OPT_IN)" },
+        { "from": "check-registry", "to": "check-source-sessions", "label": "scan() to list[Issue] (crash-contained)" },
+        { "from": "doctor-dispatcher", "to": "check-source-sessions", "label": "apply() under timestamped backup root" },
+        { "from": "check-source-sessions", "to": "db-vault", "label": "atomic rewrite, mtime preserved" }
+      ]
+    },
+    {
+      "id": "compress-dedup",
+      "name": "/compress insight dedup",
+      "description": "Before saving a curated insight, check the index for a high-confidence existing match to offer update-vs-create.",
+      "steps": [
+        { "from": "sk-compress", "to": "search-vault", "label": "FTS5 search for the topic" },
+        { "from": "search-vault", "to": "compress-guard", "label": "strength gate (<=-5.0) AND rank-delta gate (>0.25)" },
+        { "from": "compress-guard", "to": "write-vault-note", "label": "create new OR append Update section" },
+        { "from": "write-vault-note", "to": "db-vault", "label": "atomic write" }
+      ]
+    },
+    {
+      "id": "release-lockstep",
+      "name": "Git Flow release (version lockstep)",
+      "description": "A release branch from develop, then bump manifests in lockstep, then preflight, then CI, then merge into main with a back-merge to develop.",
+      "steps": [
+        { "from": "ops-bump-version", "to": "ops-commit-preflight", "label": "plugin.json + marketplace.json in lockstep" },
+        { "from": "ops-commit-preflight", "to": "ops-pytest", "label": "manifest-sync + secret-scan + pytest cov>=90" },
+        { "from": "ops-pytest", "to": "ops-ci", "label": "PR validation gate" },
+        { "from": "ops-ci", "to": "ops-no-default-db", "label": "AST guard: no live-DB pollution in tests" }
+      ]
+    }
+  ],
+  "types": [
+    { "name": "Issue", "file": "scripts/vault_doctor_checks/__init__.py", "kind": "type", "fields": ["check", "note_path", "project", "current_source", "proposed_source", "reason", "confidence", "extra"] },
+    { "name": "Result", "file": "scripts/vault_doctor_checks/__init__.py", "kind": "type", "fields": ["check", "note_path", "status", "backup_path", "error"], "values": ["applied", "skipped", "error", "unresolved"] },
+    { "name": "Scope", "file": "hooks/check_items_args.py", "kind": "type", "fields": ["mode", "project", "window_days", "show_all", "dry_run", "no_cache"], "values": ["current", "vault", "project"] },
+    { "name": "ReaperOutcome", "file": "hooks/obsidian_session_reaper.py", "kind": "type", "fields": ["reaped", "skipped_existing", "skipped_below", "canary_blocked", "timeout", "wall_ms"] },
+    { "name": "NoteType (frontmatter discriminator)", "file": "templates/", "kind": "enum", "values": ["claude-session", "claude-snapshot", "claude-insight", "claude-decision", "claude-error-fix", "claude-check-items-report", "claude-stats", "claude-retro", "claude-emerge", "imported(claude-session)"] }
+  ],
+  "environment": [
+    { "name": "CLAUDE_PLUGIN_ROOT", "default": "(set by Claude Code)", "purpose": "Base path the hook registration uses to invoke the plugin hook scripts." },
+    { "name": "CLAUDE_PROJECT_DIR", "default": "(set by Claude Code)", "purpose": "Project anchor used as a fallback in the SID resolution chain and statusline anchoring." },
+    { "name": "OBSIDIAN_BRAIN_DB", "default": "the vault index DB under ~/.claude", "purpose": "Override the SQLite index path (#192); also used by tests to avoid polluting the live DB." },
+    { "name": "OBSIDIAN_BRAIN_VAULT", "default": "(config file)", "purpose": "vault-doctor config override (with _SESSIONS_FOLDER / _INSIGHTS_FOLDER); takes precedence over the config file." },
+    { "name": "OBSIDIAN_BRAIN_DOCTOR_BACKUP_ROOT", "default": "the doctor backup dir under ~/.claude", "purpose": "Scan root for the audit-historic-repairs check (apply always writes under the dispatcher backup root)." },
+    { "name": "CHECK_ITEMS_PREFILTER", "default": "on", "purpose": "Set to off to disable the L2 deterministic prefilter and send all items to the LLM classifier." },
+    { "name": "CHECK_ITEMS_SUBAGENT_TIMEOUT_SEC", "default": "300", "purpose": "Inner per-call timeout for the classifier/semantic-merge sub-agents; chunking keeps each call well under it." },
+    { "name": "CHECK_ITEMS_CLASSIFIER_CHUNK_SIZE", "default": "25", "purpose": "Max groups per classifier sub-agent call — sized to stay on Haiku and under the timeout." }
+  ],
+  "design": {
+    "principles": [
+      "Write-first, summarize-later: hooks always persist a raw note immediately; AI summarization is deferred to /recall.",
+      "Direct filesystem writes only — no MCP server, no REST API, no daemon; the vault works even when Obsidian is closed.",
+      "Hooks are pure stdlib, deterministic, and always exit 0; they never import the index (indexing is a skill-side concern).",
+      "Everything is recoverable: the SQLite index is derived and fully rebuildable from the markdown vault.",
+      "Defense in depth on writes: path containment, atomic temp+rename, 0600/0700 perms, secret scrubbing, 1 MB stdin caps."
+    ],
+    "constraints": [
+      "Python stdlib only — no pip dependencies (hooks run at session boundaries where install state is unknown).",
+      "All hooks must exit 0 regardless of outcome (a non-zero hook would disrupt the host session).",
+      "All vault writes use temp file + rename — never sed -i or in-place overwrite.",
+      "User-data files are 0600, working dirs 0700; no predictable /tmp paths.",
+      "Test coverage gate: cov-fail-under 90 on hooks; tests must pass explicit db_path= (no live-DB pollution).",
+      "Dashboards require the Obsidian Dataview community plugin (JavaScript + inline queries)."
+    ],
+    "tradeoffs": [
+      { "decision": "Defer Claude CLI summarization from SessionEnd to /recall (write-first).", "alternatives": ["Summarize synchronously in the SessionEnd hook", "Background daemon to summarize"], "rationale": "A SessionEnd subprocess is SIGKILLed when the session process-tree exits, so synchronous summarization is unreliable. Writing the raw note first guarantees no session is ever lost; /recall upgrades on demand." },
+      { "decision": "DELETE-then-INSERT in the index instead of INSERT OR REPLACE.", "alternatives": ["INSERT OR REPLACE", "UPSERT via ON CONFLICT for the whole row"], "rationale": "REPLACE would drop the learned importance value and orphan rows in the contentless FTS5 table. Explicit delete+insert preserves importance and issues the FTS delete op with old values so the index never accumulates orphans." },
+      { "decision": "Friston-preserving non-destructive rebuild as the default.", "alternatives": ["Always full wipe + rebuild"], "rationale": "access_log activation, theme centroids and Free-Energy surprise are expensive learned signals with no source of truth outside the DB. A blind wipe would discard them; full=True is reserved for corrupt/incompatible schema." },
+      { "decision": "canonical_project_name() collapses worktrees via the git common-dir.", "alternatives": ["Use the cwd basename verbatim"], "rationale": "Worktrees have distinct cwd basenames but are one logical project; collapsing them keeps a feature branch notes grouped with the main repo and prevents fragmented project scopes." },
+      { "decision": "Snapshot-anchor bypass: log below-threshold sessions if they have sibling snapshots.", "alternatives": ["Apply message/duration thresholds uniformly"], "rationale": "A short session that nonetheless produced a PreCompact snapshot needs a parent note to anchor that snapshot backlink; dropping it would orphan real captured context." },
+      { "decision": "vault-doctor apply() raises on any non-canonical signal_class.", "alternatives": ["Apply whatever scan() returned"], "rationale": "Makes the --min-confidence filter override-safe: a low-confidence WARN can never be force-applied, because apply() refuses to act on anything but the one resolvable signal_class it was designed to fix." },
+      { "decision": "Escalate exit code to 2 when a check crashes, even at 0 issues.", "alternatives": ["Return 0 on a crashed-but-no-issues run"], "rationale": "Automation must not read an incomplete sweep as a clean bill of health; a crash means coverage was partial, so the run is flagged distinctly from a genuine all-clear." },
+      { "decision": "L2 deterministic prefilter with a distinctiveness gate before the LLM classifier.", "alternatives": ["Send every open item to the classifier"], "rationale": "Most open items have no plausible completion evidence and can be triaged for free; the distinctiveness gate (snake_case / len>=8 / interior mixed-case) stops generic short words like add/fix from accidentally matching unrelated shipped features." },
+      { "decision": "Classifier chunking at <=25 groups per sub-agent call.", "alternatives": ["One sub-agent call for the whole payload", "Raise the timeout ceiling"], "rationale": "A single large payload risks exceeding the 300s timeout and forces the slower Sonnet tier; chunking keeps each call fast, on Haiku, and recoverable on partial failure." },
+      { "decision": "Cross-plugin O_EXCL dedup lock that fails open.", "alternatives": ["Assume a single install", "A fail-closed lock"], "rationale": "The monorepo and standalone marketplace copies can both be installed; the lock prevents double-writes, but fails open (empty session_id or any FS error to proceed) so it can never silently swallow a legitimate hook." }
+    ]
+  },
+  "testing": {
+    "unitSuite": { "tool": "pytest", "fileCount": 64, "duration": "fast (stdlib, no network)", "environments": { "python": "3.12" }, "coverage": { "lines": 90, "source": "hooks", "omits": ["obsidian_utils.py (I/O monolith)", "emerge_cli.py", "deep_cli.py"] } },
+    "manualMatrix": { "doc": "CLAUDE.md (Development Commands)", "devices": ["hook simulation: pipe synthetic SessionEnd/SessionStart/PreCompact JSON into installed hooks", "json.load validation of hooks.json and plugin.json"], "rationale": "No build/test framework for the prompt-based skills; hooks are validated by feeding synthetic lifecycle JSON and asserting vault writes + telemetry outcomes." }
+  },
+  "scripts": [
+    { "name": "bump-version.sh", "command": "bump plugin.json + marketplace.json in lockstep (major|minor|patch|X.Y.Z) with rollback" },
+    { "name": "commit-preflight.sh", "command": "preflight gate: manifest-sync + secret-scan + pytest cov>=90; mints the require-preflight token" },
+    { "name": "pre-commit.sh", "command": "secret detection on staged + lines; blocks .env and credential filenames" },
+    { "name": "git-flow-finish.sh", "command": "complete a release/hotfix: merge to main + develop, tag, dev-cycle bump" },
+    { "name": "ci-checks/no-default-db.py", "command": "AST guard: tests must pass explicit db_path= (GH #46)" },
+    { "name": "test-dev-skill.sh", "command": "/dev-test install — copy the working tree into the plugin cache for local testing" },
+    { "name": "test-security.sh", "command": "security regression suite (path containment, scrub, temp-path safety)" },
+    { "name": "verify-hooks.sh", "command": "validate hooks.json / plugin.json structure" }
+  ],
+  "gitFlow": {
+    "branches": { "main": "production releases (tagged)", "develop": "integration branch" },
+    "branchTypes": [
+      { "prefix": "feature/", "baseFrom": "develop", "mergesTo": "develop" },
+      { "prefix": "release/", "baseFrom": "develop", "mergesTo": ["main", "develop"] },
+      { "prefix": "hotfix/", "baseFrom": "main", "mergesTo": ["main", "develop"] }
+    ],
+    "preflight": "./scripts/commit-preflight.sh — manifest-sync (always-on) + secret-scan + pytest cov>=90; required before every commit",
+    "plugin": "abhattacherjee/git-flow",
+    "currentVersion": "2.7.1"
+  },
+  "docs": [
+    { "title": "Standalone Marketplace Distribution (plan)", "path": "docs/superpowers/plans/2026-06-01-standalone-marketplace-distribution.md", "scope": "Migration to a standalone marketplace served from this repo (no monorepo sync)." },
+    { "title": "Standalone Marketplace Design (spec)", "path": "docs/superpowers/specs/2026-06-01-obsidian-brain-standalone-marketplace-design.md", "scope": "Design for the self-authoritative marketplace.json (source: ./) and release flow." }
+  ]
+}


### PR DESCRIPTION
Closes #218

## What
- **`docs/architecture/architecture.json`** — canonical, machine-readable architecture: 9 layers, 10 named data flows, key types, env vars, and design tradeoffs. Generated via the `architecture-page` skill, grounded in live source.
- **`docs/architecture/architecture.html`** — self-contained viewer (tabs, search, click-through). The **Data flows** tab renders each flow as an inline-SVG **sequence diagram** (lifelines, numbered messages, self-message loops, layer-colored participants).
- **`docs/.nojekyll`** — fixes the chronically-failing GitHub Pages legacy-Jekyll build on `develop` (Pages source `develop:/docs` holds internal specs, not a Jekyll site); also lets the static page serve verbatim.
- **`CLAUDE.md`** — new "Keeping the architecture page current" rule: any change that adds/removes/renames a hook, skill, vault-doctor check, CLI module, datastore, env var, or alters a data flow must update the architecture artifacts (edit JSON → re-render → smoke-test) in the same PR, grounded in live source.

## Verification
- Headless smoke test passes for both the real and the sparse torture JSON (zero JS errors, all tabs switch).
- Architecture claims adversarially verified against real `hooks/`/`scripts/`/`skills/` source (multi-agent review): structural integrity clean (every flow→component ref resolves, every `files[]` path exists); 4 metadata discrepancies (two `overrideEnv` values, a stale line count, one flow label) found and fixed.

## Notes
- Docs/infra only — no plugin code or hook behavior changes; preflight ran in docs-only mode (manifest in sync).
- Base is `develop`; `Closes #218` will cross-reference (issue auto-closes only on default-branch merges), so the issue is closed + board-moved manually on merge.