### PR TITLE
docs: Pages root redirects + README link to the architecture page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **GitHub Pages** — add `docs/.nojekyll` so the legacy Jekyll build stops failing on every `develop` push (the `docs/` tree holds internal specs/plans, not a Jekyll site) and so the static architecture page serves verbatim.
+- **GitHub Pages** — add `docs/index.html` and `docs/architecture/index.html` redirects so the Pages site root and `/architecture/` directory resolve to the architecture page (previously returned 404).
 
 ## [2.7.0] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Deep architecture reference page** (`docs/architecture/architecture.json` + self-contained `docs/architecture/architecture.html`) — layer/flow/design views with data flows rendered as inline-SVG sequence diagrams. Generated via the `architecture-page` skill and verified against live source.
+- README links to the live [interactive architecture page](https://abhattacherjee.github.io/obsidian-brain/architecture/architecture.html) on GitHub Pages.
 
 ### Fixed
 - **GitHub Pages** — add `docs/.nojekyll` so the legacy Jekyll build stops failing on every `develop` push (the `docs/` tree holds internal specs/plans, not a Jekyll site) and so the static architecture page serves verbatim.

--- a/README.md
+++ b/README.md
@@ -332,6 +332,8 @@ Replace `/Users/you` with your actual home directory (run `echo $HOME` to find i
 
 ## Architecture
 
+📐 **[Interactive architecture page](https://abhattacherjee.github.io/obsidian-brain/architecture/architecture.html)** — explore the layers, named data flows (as sequence diagrams), key types, and design tradeoffs in your browser (served via GitHub Pages).
+
 - **Integration pattern:** Direct filesystem writes (no MCP, no REST API, no Obsidian plugins needed)
 - **Hook scripts:** Pure Python (stdlib only), deterministic behavior
 - **Summarization:** Best-effort at SessionEnd, deferred to `/recall` for reliable upgrade

--- a/docs/architecture/index.html
+++ b/docs/architecture/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta http-equiv="refresh" content="0; url=./architecture.html" />
+<link rel="canonical" href="./architecture.html" />
+<title>Obsidian Brain — Architecture</title>
+</head>
+<body>
+<p>Redirecting to the <a href="./architecture.html">architecture page</a>…</p>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta http-equiv="refresh" content="0; url=./architecture/architecture.html" />
+<link rel="canonical" href="./architecture/architecture.html" />
+<title>Obsidian Brain — Architecture</title>
+</head>
+<body>
+<p>Redirecting to the <a href="./architecture/architecture.html">Obsidian Brain architecture page</a>…</p>
+</body>
+</html>


### PR DESCRIPTION
Closes #221

## What
Make the GitHub Pages architecture page discoverable and resolvable at friendly URLs.

- **`docs/index.html`** — meta-refresh redirect → `architecture/architecture.html` (site root no longer 404s)
- **`docs/architecture/index.html`** — meta-refresh redirect → `architecture.html` (directory URL works)
- **`README.md`** — links the `## Architecture` section to the live [interactive architecture page](https://abhattacherjee.github.io/obsidian-brain/architecture/architecture.html) on GitHub Pages.

After merge, `https://abhattacherjee.github.io/obsidian-brain/` resolves straight to the architecture page, and the README points readers to it.

Follow-up to #218 (architecture page + `.nojekyll`). Docs-only; preflight ran in docs mode. Base `develop`; `Closes #221` cross-references (manual close + board move on merge).