### PR TITLE
fix(dev-test): sync hooks.json + manifests into cache on install (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `scripts/test-dev-skill.sh install` now also syncs `hooks/hooks.json` (and the `.claude-plugin/` manifests) into the plugin cache. Previously only `hooks/*.py` and skill dirs were copied, so a newly **registered** hook (e.g. a new `Stop` event) had its script copied but was never registered — it silently never fired after `/dev-test install`. Closes #227.
+
 ## [2.7.1] - 2026-06-12
 
 ### Added

--- a/scripts/test-dev-skill.sh
+++ b/scripts/test-dev-skill.sh
@@ -56,9 +56,25 @@ case "$cmd" in
 
         echo "Installing dev versions..."
 
-        # Copy hooks (Python files)
+        # Copy hooks (Python files + registration manifest)
         cp "$REPO_ROOT/hooks/"*.py "$CACHE_DIR/hooks/"
         echo "  hooks/*.py -> cache"
+        if [[ -f "$REPO_ROOT/hooks/hooks.json" ]]; then
+            cp "$REPO_ROOT/hooks/hooks.json" "$CACHE_DIR/hooks/"
+            echo "  hooks/hooks.json -> cache"
+        fi
+
+        # Copy plugin manifests so version/metadata changes propagate
+        if [[ -d "$CACHE_DIR/.claude-plugin" ]]; then
+            if [[ -f "$REPO_ROOT/.claude-plugin/plugin.json" ]]; then
+                cp "$REPO_ROOT/.claude-plugin/plugin.json" "$CACHE_DIR/.claude-plugin/"
+                echo "  .claude-plugin/plugin.json -> cache"
+            fi
+            if [[ -f "$REPO_ROOT/.claude-plugin/marketplace.json" ]]; then
+                cp "$REPO_ROOT/.claude-plugin/marketplace.json" "$CACHE_DIR/.claude-plugin/"
+                echo "  .claude-plugin/marketplace.json -> cache"
+            fi
+        fi
 
         # Copy skills
         for skill_dir in "$REPO_ROOT/skills/"*/; do

--- a/tests/test_dev_skill_install.py
+++ b/tests/test_dev_skill_install.py
@@ -30,6 +30,7 @@ def _stage_repo(tmp_path: Path) -> Path:
     repo = tmp_path / "repo"
     (repo / "hooks").mkdir(parents=True)
     (repo / "hooks" / "obsidian_utils.py").write_text("# fake hook\n")
+    (repo / "hooks" / "hooks.json").write_text('{"hooks": {"SessionEnd": []}}\n')
 
     (repo / "skills" / "test-skill").mkdir(parents=True)
     (repo / "skills" / "test-skill" / "SKILL.md").write_text("# fake skill\n")
@@ -163,3 +164,25 @@ def test_install_refuses_when_backup_already_exists(tmp_path: Path) -> None:
     assert "Backup already exists" in proc.stdout
     # Existing backup untouched
     assert (backup / "marker").read_text() == "pre-existing"
+
+
+def test_install_copies_hooks_json(tmp_path: Path) -> None:
+    """Regression (#227): hooks/hooks.json must be synced to the cache on install."""
+    proc = _run_install(tmp_path)
+    assert proc.returncode == 0, f"install failed: {proc.stderr}"
+    cache_hooks_json = (
+        tmp_path
+        / "home"
+        / ".claude"
+        / "plugins"
+        / "cache"
+        / "claude-code-skills"
+        / "obsidian-brain"
+        / "2.3.0"
+        / "hooks"
+        / "hooks.json"
+    )
+    assert cache_hooks_json.is_file(), "hooks/hooks.json was not copied to cache"
+    import json
+    cached = json.loads(cache_hooks_json.read_text(encoding="utf-8"))
+    assert cached == {"hooks": {"SessionEnd": []}}


### PR DESCRIPTION
Fixes the dev-test installer so newly **registered** hooks actually activate.

`scripts/test-dev-skill.sh install` copied `hooks/*.py` and skill dirs but **not `hooks/hooks.json`** — so a new hook entry (e.g. the v2.7.1 `Stop` gate) had its script copied yet was never registered, silently never firing after `/dev-test install`. Now also syncs `hooks/hooks.json` and the `.claude-plugin/` manifests, each guarded by an existence check so minimal repos / the test fixture don't abort under `set -e`.

**Test:** the fake-repo fixture now stages a `hooks/hooks.json`; new `test_install_copies_hooks_json` asserts it lands in the cache (regression guard). Full suite green.

Discovered while dogfooding the v2.7.1 retro Stop hook on this machine.

Closes #227