### PR TITLE
feat(consolidate): soft size-guard for oversized themes + distinct self-merge message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `/consolidate stats` now flags themes whose size exceeds a soft cap (`consolidate_max_theme_size`, default 120) and suggests `/consolidate split <id>`. Clustering output is unchanged. (#238)
+
+### Fixed
+- `/consolidate merge <a> <a>` (self-merge) now reports a distinct `cannot merge a theme with itself` error instead of the misleading `theme(s) not found` message. (#239)
+
 ## [3.0.0] - 2026-06-15
 
 ### Added

--- a/hooks/consolidate_cli.py
+++ b/hooks/consolidate_cli.py
@@ -126,12 +126,22 @@ def run_stats() -> None:
         nudge = int(config.get("consolidate_unassigned_threshold", 50))
         if st["unassigned"] > nudge:
             print(f"NUDGE unassigned={st['unassigned']} exceeds {nudge}; run /consolidate")
+        # Oversized themes are by definition among the largest, so top-5 coverage
+        # is complete for any realistic cap; no additional DB query needed.
+        max_size = int(config.get("consolidate_max_theme_size", 120))
+        for t in st["largest"]:
+            if t["note_count"] > max_size:
+                print(f"WARN theme id={t['id']} has {t['note_count']} members (>{max_size} soft cap)")
+                print(f"  -> consider: /consolidate split {t['id']}")
     except (sqlite3.Error, RuntimeError, ValueError, TypeError) as exc:
         print(f"ERROR {exc}", file=sys.stderr)
         sys.exit(1)
 
 
 def run_merge(a: int, b: int) -> None:
+    if a == b:
+        print(f"ERROR cannot merge a theme with itself a={a}")
+        return
     db = _default_db_path()
     try:
         ok = themes.merge_themes(db, a, b, _now_iso())

--- a/hooks/consolidate_cli.py
+++ b/hooks/consolidate_cli.py
@@ -126,8 +126,10 @@ def run_stats() -> None:
         nudge = int(config.get("consolidate_unassigned_threshold", 50))
         if st["unassigned"] > nudge:
             print(f"NUDGE unassigned={st['unassigned']} exceeds {nudge}; run /consolidate")
-        # Oversized themes are by definition among the largest, so top-5 coverage
-        # is complete for any realistic cap; no additional DB query needed.
+        # Oversized themes are by definition among the largest, so the top-5 `largest`
+        # list covers them unless more than five themes simultaneously exceed the cap,
+        # in which case the rest surface on the next `stats` run after splitting. No
+        # extra DB query needed.
         max_size = int(config.get("consolidate_max_theme_size", 120))
         for t in st["largest"]:
             if t["note_count"] > max_size:

--- a/hooks/obsidian_utils.py
+++ b/hooks/obsidian_utils.py
@@ -1209,6 +1209,7 @@ _DEFAULTS: dict = {
     "consolidate_cluster_threshold": 0.5,  # cosine sim for single-linkage edge in /consolidate
     "consolidate_min_cluster_size": 3,  # smallest cluster that becomes a theme
     "consolidate_unassigned_threshold": 50,  # /consolidate stats nudge when unassigned exceeds this
+    "consolidate_max_theme_size": 120,  # /consolidate stats flags themes larger than this + suggests split
     "aged_summarize_threshold_days": 90,  # #168: notes whose file mtime is older than this AND have no inbound vault links AND no pin tag are deferred (skipped) by /recall
     "summary_pin_tags": ["claude/keep", "claude/permanent"],  # #168: notes carrying any of these frontmatter tags are never deferred
     "auto_log_enabled": True,

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -290,3 +290,77 @@ def test_split_noop_when_cohesive(db, capsys):
     assert conn.execute("SELECT COUNT(*) FROM themes WHERE id=1").fetchone()[0] == 1  # unchanged
     conn.close()
     assert "NO_SPLIT" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# T1: run_stats WARN line fires when note_count STRICTLY exceeds cap
+# ---------------------------------------------------------------------------
+
+def test_stats_flags_oversized_theme(tmp_vault, monkeypatch, capsys):
+    """WARN + split suggestion printed when a theme has note_count > cap."""
+    import vault_index as _vi
+    p = str(tmp_vault / "c.db")
+    _vi.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
+    monkeypatch.setenv("OBSIDIAN_BRAIN_DB", p)
+    monkeypatch.setattr(
+        consolidate_cli, "load_config",
+        lambda: {"vault_path": str(tmp_vault), "consolidate_max_theme_size": 5},
+    )
+    conn = sqlite3.connect(p)
+    conn.execute(
+        "INSERT INTO themes (id,name,summary,centroid,note_count,created_date,updated_date,project) "
+        "VALUES (1,'BigTheme','s','{}',6,'d','d','proj')"
+    )
+    conn.commit(); conn.close()
+    consolidate_cli.run_stats()
+    out = capsys.readouterr().out
+    assert "WARN theme id=1 has 6 members" in out
+    assert "/consolidate split 1" in out
+
+
+# ---------------------------------------------------------------------------
+# T2: run_stats stays silent when note_count == cap (strict > boundary)
+# ---------------------------------------------------------------------------
+
+def test_stats_silent_at_cap_boundary(tmp_vault, monkeypatch, capsys):
+    """No WARN when note_count is exactly at the cap — boundary is strict >."""
+    import vault_index as _vi
+    p = str(tmp_vault / "c.db")
+    _vi.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
+    monkeypatch.setenv("OBSIDIAN_BRAIN_DB", p)
+    monkeypatch.setattr(
+        consolidate_cli, "load_config",
+        lambda: {"vault_path": str(tmp_vault), "consolidate_max_theme_size": 5},
+    )
+    conn = sqlite3.connect(p)
+    conn.execute(
+        "INSERT INTO themes (id,name,summary,centroid,note_count,created_date,updated_date,project) "
+        "VALUES (1,'ExactCap','s','{}',5,'d','d','proj')"
+    )
+    conn.commit(); conn.close()
+    consolidate_cli.run_stats()
+    out = capsys.readouterr().out
+    assert "WARN" not in out
+
+
+# ---------------------------------------------------------------------------
+# T3: run_merge(a, a) emits the DISTINCT self-merge message, not not-found
+# ---------------------------------------------------------------------------
+
+def test_merge_self_emits_distinct_message(db, capsys):
+    """run_merge(1, 1) must say 'cannot merge a theme with itself', NOT 'not found'."""
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO themes (id,name,summary,centroid,note_count,created_date,updated_date,project) "
+        "VALUES (1,'Solo','s','{\"x\":1.0}',1,'d','d','proj')"
+    )
+    conn.execute(
+        "INSERT INTO notes (path,type,project,title,body,mtime,tfidf_vector) "
+        "VALUES ('m1.md','session','proj','t','b',1.0,'{\"x\":1.0}')"
+    )
+    conn.execute("INSERT INTO theme_members VALUES (1,'m1.md',0.9,0.0,'d')")
+    conn.commit(); conn.close()
+    consolidate_cli.run_merge(1, 1)
+    out = capsys.readouterr().out
+    assert "cannot merge a theme with itself" in out
+    assert "theme(s) not found" not in out

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -344,6 +344,38 @@ def test_stats_silent_at_cap_boundary(tmp_vault, monkeypatch, capsys):
 
 
 # ---------------------------------------------------------------------------
+# T2b: run_stats WARN loop iterates ALL oversized themes, not just the first
+# ---------------------------------------------------------------------------
+
+def test_stats_flags_multiple_oversized_themes(tmp_vault, monkeypatch, capsys):
+    """WARN is printed for every oversized theme, not just the first one found."""
+    import vault_index as _vi
+    p = str(tmp_vault / "c.db")
+    _vi.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
+    monkeypatch.setenv("OBSIDIAN_BRAIN_DB", p)
+    monkeypatch.setattr(
+        consolidate_cli, "load_config",
+        lambda: {"vault_path": str(tmp_vault), "consolidate_max_theme_size": 5},
+    )
+    conn = sqlite3.connect(p)
+    conn.execute(
+        "INSERT INTO themes (id,name,summary,centroid,note_count,created_date,updated_date,project) "
+        "VALUES (1,'BigA','s','{}',6,'d','d','proj')"
+    )
+    conn.execute(
+        "INSERT INTO themes (id,name,summary,centroid,note_count,created_date,updated_date,project) "
+        "VALUES (2,'BigB','s','{}',7,'d','d','proj')"
+    )
+    conn.commit(); conn.close()
+    consolidate_cli.run_stats()
+    out = capsys.readouterr().out
+    assert "WARN theme id=1 has 6 members" in out
+    assert "WARN theme id=2 has 7 members" in out
+    assert "/consolidate split 1" in out
+    assert "/consolidate split 2" in out
+
+
+# ---------------------------------------------------------------------------
 # T3: run_merge(a, a) emits the DISTINCT self-merge message, not not-found
 # ---------------------------------------------------------------------------
 

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -298,9 +298,8 @@ def test_split_noop_when_cohesive(db, capsys):
 
 def test_stats_flags_oversized_theme(tmp_vault, monkeypatch, capsys):
     """WARN + split suggestion printed when a theme has note_count > cap."""
-    import vault_index as _vi
     p = str(tmp_vault / "c.db")
-    _vi.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
+    vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
     monkeypatch.setenv("OBSIDIAN_BRAIN_DB", p)
     monkeypatch.setattr(
         consolidate_cli, "load_config",
@@ -324,9 +323,8 @@ def test_stats_flags_oversized_theme(tmp_vault, monkeypatch, capsys):
 
 def test_stats_silent_at_cap_boundary(tmp_vault, monkeypatch, capsys):
     """No WARN when note_count is exactly at the cap — boundary is strict >."""
-    import vault_index as _vi
     p = str(tmp_vault / "c.db")
-    _vi.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
+    vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
     monkeypatch.setenv("OBSIDIAN_BRAIN_DB", p)
     monkeypatch.setattr(
         consolidate_cli, "load_config",
@@ -349,9 +347,8 @@ def test_stats_silent_at_cap_boundary(tmp_vault, monkeypatch, capsys):
 
 def test_stats_flags_multiple_oversized_themes(tmp_vault, monkeypatch, capsys):
     """WARN is printed for every oversized theme, not just the first one found."""
-    import vault_index as _vi
     p = str(tmp_vault / "c.db")
-    _vi.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
+    vault_index.ensure_index(str(tmp_vault), ["claude-sessions"], db_path=p)
     monkeypatch.setenv("OBSIDIAN_BRAIN_DB", p)
     monkeypatch.setattr(
         consolidate_cli, "load_config",


### PR DESCRIPTION
## Summary

Consolidate-CLI polish bundle surfaced during the #53 full-epic dogfood (PR #237). Two low-priority fixes, same subsystem:

### #238 — soft size-guard for oversized themes
`/consolidate --full` could produce one oversized theme via single-linkage chaining (a 190-note theme in the dogfood). This adds a **non-destructive soft guard**: `/consolidate stats` now flags any theme whose `note_count` **strictly exceeds** `consolidate_max_theme_size` (new `_DEFAULTS` key, default `120`) and suggests `/consolidate split <id>`.

- Reuses the existing top-5 `largest` list — oversized themes are by definition the largest, so coverage is complete for any realistic cap. **No new DB query.**
- **Clustering output is unchanged.** Single-linkage is retained; `split` remains the mitigation. Threshold/linkage changes were deliberately deferred (they'd change clustering globally and need full re-validation).

### #239 — distinct self-merge message
`/consolidate merge <a> <a>` previously printed `ERROR theme(s) not found` — the same message as genuinely missing IDs. `run_merge` now emits `ERROR cannot merge a theme with itself a=N`. The behavior was already correct (`merge_themes`' own `a==b` guard protects the theme); only the wording was wrong. That guard stays as defense-in-depth.

## Tests
- `test_stats_flags_oversized_theme` — WARN + split suggestion fire when `note_count > cap`.
- `test_stats_silent_at_cap_boundary` — silent when `note_count == cap` (pins the strict `>` boundary).
- `test_merge_self_emits_distinct_message` — self-merge message is distinct from not-found.
- Full suite: 1622 passed; coverage 90.78% (>=90 gate).

## Notes
- No `architecture.json` change: adds a config default + behavior inside the existing `consolidate-cli` component — no hook/skill/component/flow added or renamed.

Closes #238
Closes #239
