### PR TITLE
fix(retro): force per-snapshot mining + relevance verdict so pre-compact snapshots aren't dropped (#261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **`/retro` now force-mines current-session pre-compact snapshots (#261):** Step 3 gains a mandatory, visible per-snapshot pre-pass that emits a digest and a `RELEVANT` / `EARLIER-ARC/UNRELATED` verdict for every snapshot in the evidence bundle (default-to-`RELEVANT`), so pre-compact decision points and dead ends are no longer skimmed in favor of the vivid post-compact buffer. `## Evidence Consulted` now lists only `RELEVANT` snapshots and requires an explicit no-findings acknowledgment, which also stops earlier-`/ship`-arc snapshots from contaminating a multi-arc session's retro.
+- **`/retro` now force-mines current-session pre-compact snapshots (#261):** Step 3 gains a mandatory, visible per-snapshot pre-pass that emits a digest and a `RELEVANT` / `EARLIER-ARC/UNRELATED` verdict for every snapshot in the evidence bundle (default-to-`RELEVANT`), so pre-compact decision points and dead ends are no longer skimmed in favor of the vivid post-compact buffer. `## Evidence Consulted` now lists `RELEVANT` snapshots (with an explicit no-findings acknowledgment for any that yielded nothing) and separately records `EARLIER-ARC/UNRELATED` snapshots with their exclusion reason — so earlier-`/ship`-arc snapshots stop contaminating a multi-arc retro without silently vanishing from the saved note.
 
 ## [3.2.0] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **`/retro` now force-mines current-session pre-compact snapshots (#261):** Step 3 gains a mandatory, visible per-snapshot pre-pass that emits a digest and a `RELEVANT` / `EARLIER-ARC/UNRELATED` verdict for every snapshot in the evidence bundle (default-to-`RELEVANT`), so pre-compact decision points and dead ends are no longer skimmed in favour of the vivid post-compact buffer. `## Evidence Consulted` now lists only `RELEVANT` snapshots and requires an explicit no-findings acknowledgment, which also stops earlier-`/ship`-arc snapshots from contaminating a multi-arc session's retro.
+- **`/retro` now force-mines current-session pre-compact snapshots (#261):** Step 3 gains a mandatory, visible per-snapshot pre-pass that emits a digest and a `RELEVANT` / `EARLIER-ARC/UNRELATED` verdict for every snapshot in the evidence bundle (default-to-`RELEVANT`), so pre-compact decision points and dead ends are no longer skimmed in favor of the vivid post-compact buffer. `## Evidence Consulted` now lists only `RELEVANT` snapshots and requires an explicit no-findings acknowledgment, which also stops earlier-`/ship`-arc snapshots from contaminating a multi-arc session's retro.
 
 ## [3.2.0] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`/retro` now force-mines current-session pre-compact snapshots (#261):** Step 3 gains a mandatory, visible per-snapshot pre-pass that emits a digest and a `RELEVANT` / `EARLIER-ARC/UNRELATED` verdict for every snapshot in the evidence bundle (default-to-`RELEVANT`), so pre-compact decision points and dead ends are no longer skimmed in favour of the vivid post-compact buffer. `## Evidence Consulted` now lists only `RELEVANT` snapshots and requires an explicit no-findings acknowledgment, which also stops earlier-`/ship`-arc snapshots from contaminating a multi-arc session's retro.
+
 ## [3.2.0] - 2026-06-21
 
 > **Upgrade note:** This release improves the `/compress` topic-match cosine gate, which relies on per-note TF-IDF vectors. Notes indexed before the vector-storage migration (~26% of a typical vault) have no vector. Run `/vault-reindex` once after updating to backfill them (non-destructive — preserves Friston activation data); until you do, the cosine gate fail-opens on those notes via the AND-path.

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -124,7 +124,29 @@ Then proceed with whatever evidence was collected (possibly none).
 
 Review the full current conversation. Be **candid**, not defensive or self-congratulatory.
 
-**When the bundle from Step 3a is non-empty:** treat its snapshot bodies and insight/decision/error-fix bodies as **first-class evidence**, not background context. Pre-compact arcs in snapshot files almost always contain more decision points and dead ends than the post-compact half — surface specific corrections and abandoned approaches from there. The "What Didn't Work" section in particular should reflect the relative duration and decision density of both halves; if the pre-compact half ran 6 hours and the post-compact half ran 90 minutes, the analysis should weight accordingly.
+**When the bundle from Step 3a is non-empty, mine the snapshots BEFORE analyzing the live conversation.** The pre-compact snapshot arcs almost always hold more decision points and dead ends than the vivid post-compact buffer, and are the evidence most easily skimmed. The pre-pass below is **mandatory** — running it first is what gives snapshots equal-or-higher priority than the live buffer.
+
+#### 3.0 — Mine each snapshot FIRST (MANDATORY)
+
+For **each** entry in `bundle["snapshots"]`, emit a short **visible** digest so the pass leaves an auditable trace — do not silently "consider" snapshots; print the digest:
+
+```
+Snapshot [<hhmmss>] <stem> — verdict: RELEVANT | EARLIER-ARC/UNRELATED
+  (if RELEVANT)
+    - decision points: ...
+    - abandoned approaches / dead ends: ...
+    - user corrections / redirects: ...
+    - anything the post-compact buffer alone would not reveal: ...
+  (if EARLIER-ARC/UNRELATED)
+    - reason (e.g. "distinct earlier /ship arc for #NN, not part of this retro")
+```
+
+**Verdict rules:**
+- **Default to `RELEVANT`.** Only mark a snapshot `EARLIER-ARC/UNRELATED` when it is *unmistakably* about a different, self-contained earlier task that is not part of the work this retrospective covers. This bias keeps the exclusion path from becoming a new way to drop content.
+- Judge relevance by topical continuity with what this retro is about (the live buffer's focus + the most recent arc). A long session can span several `/ship` arcs that each already got their own retro — earlier arcs' snapshots are `EARLIER-ARC`.
+- If `bundle["snapshots"]` is empty, emit one line — `No current-session snapshots — active-conversation-only retro.` — and skip this pre-pass.
+
+Then weight the analysis by the two halves' decision density: if the pre-compact half ran 6 hours and the post-compact half ran 90 minutes, "What Didn't Work" should reflect that. Treat every `RELEVANT` snapshot body and the insight/decision/error-fix bodies as **first-class evidence**, not background context — every `RELEVANT` snapshot's findings must surface in the sections below.
 
 The **"What Didn't Work"** section is the MOST valuable part of this retrospective — invest the most analysis there.
 
@@ -143,7 +165,7 @@ Draft the note body using this exact structure:
 ```markdown
 ## Evidence Consulted
 - Active conversation: <N> messages (post-compact buffer)
-- Snapshots: <K> file(s)
+- Snapshots (RELEVANT only): <K> file(s)
   - [[<stem-1>]] (<hhmmss>, <trigger>)
   - [[<stem-2>]] (<hhmmss>, <trigger>)
 - Insights: <K> file(s)
@@ -169,6 +191,8 @@ Draft the note body using this exact structure:
 ```
 
 **Rules for `## Evidence Consulted`:**
+- List **only snapshots marked `RELEVANT`** in the Step 3.0 pre-pass. `EARLIER-ARC/UNRELATED` snapshots are excluded here — their exclusion rationale already lives in the 3.0 digest.
+- **Coverage:** every `RELEVANT` snapshot must be represented in the analysis. If a `RELEVANT` snapshot genuinely yielded no distinct dead-ends beyond the live buffer, say so explicitly in "What Didn't Work" (e.g. `- [[stem]]: no distinct dead-ends beyond the live buffer`) rather than silently omitting it.
 - Omit any list line whose count is 0 (no `Snapshots: 0 file(s)` noise).
 - Omit the entire `## Evidence Consulted` section if the empty-bundle fallback fired in Step 3a.
 - Wikilinks (`[[stem]]`) preserve Obsidian backlinks and round-trip through the FTS index.

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -143,7 +143,7 @@ Snapshot [<hhmmss>] <stem> — verdict: RELEVANT | EARLIER-ARC/UNRELATED
 
 **Verdict rules:**
 - **Default to `RELEVANT`.** Only mark a snapshot `EARLIER-ARC/UNRELATED` when it is *unmistakably* about a different, self-contained earlier task that is not part of the work this retrospective covers. This bias keeps the exclusion path from becoming a new way to drop content.
-- Judge relevance by topical continuity with what this retro is about (the live buffer's focus + the most recent arc). A long session can span several `/ship` arcs that each already got their own retro — earlier arcs' snapshots are `EARLIER-ARC/UNRELATED`. This topical-continuity check is a default-case guide only — it never overrides the default-to-`RELEVANT` bias above (e.g. if `/retro` is invoked to reflect on an earlier arc, that arc's snapshots are `RELEVANT`).
+- Judge relevance by topical continuity with what this retro is about. `/retro` takes no arc argument — it reflects on the current session as a whole — so infer the focus from the live buffer and the most recent arc, and treat `most recent arc` as a heuristic, not a hard boundary. Only a clearly-concluded earlier `/ship` arc that already got its own retro is `EARLIER-ARC/UNRELATED`; when in any doubt, mark `RELEVANT` (the default-to-`RELEVANT` bias above governs). Every excluded snapshot is still recorded in `## Evidence Consulted` (Step 4), so a wrong exclusion stays visible to the user in the Step 6 preview rather than being silently lost.
 - If `bundle["snapshots"]` is empty, skip this pre-pass; emit `No current-session snapshots — skipping the snapshot pre-pass.` only if Step 3a did not already print its no-evidence fallback notice (do not print a duplicate).
 
 Then weight the analysis by the two halves' decision density: if the pre-compact half ran 6 hours and the post-compact half ran 90 minutes, "What Didn't Work" should reflect that. Estimate this weighting only from `RELEVANT` snapshots — exclude the time span covered by any `EARLIER-ARC/UNRELATED` snapshot from both the duration estimate and the resulting weight. Treat every `RELEVANT` snapshot body and the insight/decision/error-fix bodies as **first-class evidence**, not background context — every `RELEVANT` snapshot's findings must surface in the sections below.
@@ -165,9 +165,11 @@ Draft the note body using this exact structure:
 ```markdown
 ## Evidence Consulted
 - Active conversation: <N> messages (post-compact buffer)
-- Snapshots (RELEVANT only): <K> file(s)
+- Snapshots — RELEVANT: <K> file(s)
   - [[<stem-1>]] (<hhmmss>, <trigger>)
   - [[<stem-2>]] (<hhmmss>, <trigger>)
+- Snapshots — excluded as earlier-arc: <M> file(s)
+  - [[<stem-x>]] (<hhmmss>) — <one-line exclusion reason from the 3.0 digest>
 - Insights: <K> file(s)
   - [[<stem-1>]] — <title>
 - Decisions: <K> file(s)
@@ -191,9 +193,9 @@ Draft the note body using this exact structure:
 ```
 
 **Rules for `## Evidence Consulted`:**
-- List **only snapshots marked `RELEVANT`** in the Step 3.0 pre-pass. `EARLIER-ARC/UNRELATED` snapshots are excluded here — their exclusion rationale already lives in the 3.0 digest.
+- Under `Snapshots — RELEVANT`, list the snapshots marked `RELEVANT` in the Step 3.0 pre-pass. Under `Snapshots — excluded as earlier-arc`, list every `EARLIER-ARC/UNRELATED` snapshot with its one-line reason. The 3.0 digest is console-only, so persisting excluded snapshots here is what keeps an exclusion auditable in the saved note (and catchable by the user in the Step 6 preview) — never rely on the digest alone.
 - **Coverage:** every `RELEVANT` snapshot must be represented in the analysis. If a `RELEVANT` snapshot genuinely yielded no distinct dead-ends beyond the live buffer, say so explicitly in "What Didn't Work" (e.g. `- [[stem]]: no distinct dead-ends beyond the live buffer`) rather than silently omitting it.
-- Omit any list line whose count is 0 (no `... : 0 file(s)` zero-count noise).
+- Omit any list line whose count is 0 (no `... : 0 file(s)` zero-count noise) — **except** the two `Snapshots —` lines: whenever `bundle["snapshots"]` was non-empty, render BOTH lines even at count 0, so an all-excluded session is never indistinguishable from a no-snapshot one.
 - Omit the entire `## Evidence Consulted` section if the empty-bundle fallback fired in Step 3a.
 - Wikilinks (`[[stem]]`) preserve Obsidian backlinks and round-trip through the FTS index.
 - Active-conversation message count is approximate — the count visible to the model when /retro fires; an order-of-magnitude figure is fine.

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -2,7 +2,7 @@
 name: retro
 description: "Generates honest session retrospectives analyzing what worked, what didn't, key learnings, and actionable process improvements. Use when: (1) /retro command at end of session, (2) user wants to reflect on session quality and outcomes."
 metadata:
-  version: 1.2.0
+  version: 1.3.0
 ---
 
 # Retro — Generate Honest Session Retrospective
@@ -122,7 +122,7 @@ Then proceed with whatever evidence was collected (possibly none).
 
 ### Step 3 — Analyze the session honestly
 
-Review the full current conversation. Be **candid**, not defensive or self-congratulatory.
+Be **candid**, not defensive or self-congratulatory. This retro draws on two sources: the current session's pre-compact snapshots (the Step 3a bundle) and the live post-compact conversation. Work them in that order — mine the snapshots first (3.0 below), then review the live conversation.
 
 **When the bundle from Step 3a is non-empty, mine the snapshots BEFORE analyzing the live conversation.** The pre-compact snapshot arcs almost always hold more decision points and dead ends than the vivid post-compact buffer, and are the evidence most easily skimmed. The pre-pass below is **mandatory** — running it first is what gives snapshots equal-or-higher priority than the live buffer.
 
@@ -143,8 +143,8 @@ Snapshot [<hhmmss>] <stem> — verdict: RELEVANT | EARLIER-ARC/UNRELATED
 
 **Verdict rules:**
 - **Default to `RELEVANT`.** Only mark a snapshot `EARLIER-ARC/UNRELATED` when it is *unmistakably* about a different, self-contained earlier task that is not part of the work this retrospective covers. This bias keeps the exclusion path from becoming a new way to drop content.
-- Judge relevance by topical continuity with what this retro is about (the live buffer's focus + the most recent arc). A long session can span several `/ship` arcs that each already got their own retro — earlier arcs' snapshots are `EARLIER-ARC`.
-- If `bundle["snapshots"]` is empty, emit one line — `No current-session snapshots — active-conversation-only retro.` — and skip this pre-pass.
+- Judge relevance by topical continuity with what this retro is about (the live buffer's focus + the most recent arc). A long session can span several `/ship` arcs that each already got their own retro — earlier arcs' snapshots are `EARLIER-ARC/UNRELATED`.
+- If `bundle["snapshots"]` is empty, skip this pre-pass; emit `No current-session snapshots — active-conversation-only retro.` only if Step 3a did not already print its no-evidence fallback notice (do not print a duplicate).
 
 Then weight the analysis by the two halves' decision density: if the pre-compact half ran 6 hours and the post-compact half ran 90 minutes, "What Didn't Work" should reflect that. Treat every `RELEVANT` snapshot body and the insight/decision/error-fix bodies as **first-class evidence**, not background context — every `RELEVANT` snapshot's findings must surface in the sections below.
 
@@ -193,7 +193,7 @@ Draft the note body using this exact structure:
 **Rules for `## Evidence Consulted`:**
 - List **only snapshots marked `RELEVANT`** in the Step 3.0 pre-pass. `EARLIER-ARC/UNRELATED` snapshots are excluded here — their exclusion rationale already lives in the 3.0 digest.
 - **Coverage:** every `RELEVANT` snapshot must be represented in the analysis. If a `RELEVANT` snapshot genuinely yielded no distinct dead-ends beyond the live buffer, say so explicitly in "What Didn't Work" (e.g. `- [[stem]]: no distinct dead-ends beyond the live buffer`) rather than silently omitting it.
-- Omit any list line whose count is 0 (no `Snapshots: 0 file(s)` noise).
+- Omit any list line whose count is 0 (no `... : 0 file(s)` zero-count noise).
 - Omit the entire `## Evidence Consulted` section if the empty-bundle fallback fired in Step 3a.
 - Wikilinks (`[[stem]]`) preserve Obsidian backlinks and round-trip through the FTS index.
 - Active-conversation message count is approximate — the count visible to the model when /retro fires; an order-of-magnitude figure is fine.

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -143,10 +143,10 @@ Snapshot [<hhmmss>] <stem> — verdict: RELEVANT | EARLIER-ARC/UNRELATED
 
 **Verdict rules:**
 - **Default to `RELEVANT`.** Only mark a snapshot `EARLIER-ARC/UNRELATED` when it is *unmistakably* about a different, self-contained earlier task that is not part of the work this retrospective covers. This bias keeps the exclusion path from becoming a new way to drop content.
-- Judge relevance by topical continuity with what this retro is about (the live buffer's focus + the most recent arc). A long session can span several `/ship` arcs that each already got their own retro — earlier arcs' snapshots are `EARLIER-ARC/UNRELATED`.
+- Judge relevance by topical continuity with what this retro is about (the live buffer's focus + the most recent arc). A long session can span several `/ship` arcs that each already got their own retro — earlier arcs' snapshots are `EARLIER-ARC/UNRELATED`. This topical-continuity check is a default-case guide only — it never overrides the default-to-`RELEVANT` bias above (e.g. if `/retro` is invoked to reflect on an earlier arc, that arc's snapshots are `RELEVANT`).
 - If `bundle["snapshots"]` is empty, skip this pre-pass; emit `No current-session snapshots — skipping the snapshot pre-pass.` only if Step 3a did not already print its no-evidence fallback notice (do not print a duplicate).
 
-Then weight the analysis by the two halves' decision density: if the pre-compact half ran 6 hours and the post-compact half ran 90 minutes, "What Didn't Work" should reflect that. Treat every `RELEVANT` snapshot body and the insight/decision/error-fix bodies as **first-class evidence**, not background context — every `RELEVANT` snapshot's findings must surface in the sections below.
+Then weight the analysis by the two halves' decision density: if the pre-compact half ran 6 hours and the post-compact half ran 90 minutes, "What Didn't Work" should reflect that. Estimate this weighting only from `RELEVANT` snapshots — exclude the time span covered by any `EARLIER-ARC/UNRELATED` snapshot from both the duration estimate and the resulting weight. Treat every `RELEVANT` snapshot body and the insight/decision/error-fix bodies as **first-class evidence**, not background context — every `RELEVANT` snapshot's findings must surface in the sections below.
 
 The **"What Didn't Work"** section is the MOST valuable part of this retrospective — invest the most analysis there.
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -122,7 +122,7 @@ Then proceed with whatever evidence was collected (possibly none).
 
 ### Step 3 — Analyze the session honestly
 
-Be **candid**, not defensive or self-congratulatory. This retro draws on two sources: the current session's pre-compact snapshots (the Step 3a bundle) and the live post-compact conversation. Work them in that order — mine the snapshots first (3.0 below), then review the live conversation.
+Be **candid**, not defensive or self-congratulatory. This retro draws on the current session's pre-compact evidence (the Step 3a bundle — snapshots plus insights/decisions/error-fixes) and the live post-compact conversation. Work the bundle first — mine the snapshots in 3.0 below — then review the live conversation.
 
 **When the bundle from Step 3a is non-empty, mine the snapshots BEFORE analyzing the live conversation.** The pre-compact snapshot arcs almost always hold more decision points and dead ends than the vivid post-compact buffer, and are the evidence most easily skimmed. The pre-pass below is **mandatory** — running it first is what gives snapshots equal-or-higher priority than the live buffer.
 

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -144,7 +144,7 @@ Snapshot [<hhmmss>] <stem> — verdict: RELEVANT | EARLIER-ARC/UNRELATED
 **Verdict rules:**
 - **Default to `RELEVANT`.** Only mark a snapshot `EARLIER-ARC/UNRELATED` when it is *unmistakably* about a different, self-contained earlier task that is not part of the work this retrospective covers. This bias keeps the exclusion path from becoming a new way to drop content.
 - Judge relevance by topical continuity with what this retro is about (the live buffer's focus + the most recent arc). A long session can span several `/ship` arcs that each already got their own retro — earlier arcs' snapshots are `EARLIER-ARC/UNRELATED`.
-- If `bundle["snapshots"]` is empty, skip this pre-pass; emit `No current-session snapshots — active-conversation-only retro.` only if Step 3a did not already print its no-evidence fallback notice (do not print a duplicate).
+- If `bundle["snapshots"]` is empty, skip this pre-pass; emit `No current-session snapshots — skipping the snapshot pre-pass.` only if Step 3a did not already print its no-evidence fallback notice (do not print a duplicate).
 
 Then weight the analysis by the two halves' decision density: if the pre-compact half ran 6 hours and the post-compact half ran 90 minutes, "What Didn't Work" should reflect that. Treat every `RELEVANT` snapshot body and the insight/decision/error-fix bodies as **first-class evidence**, not background context — every `RELEVANT` snapshot's findings must surface in the sections below.
 


### PR DESCRIPTION
## Summary

Turns `/retro` Step 3's advisory *"treat snapshots as first-class evidence"* prose into a **mandatory, visible per-snapshot mining pass**, so key information from the current session's pre-compact snapshots is no longer skimmed in favor of the vivid post-compact buffer.

Root cause (verified in source): the data layer is fine — `gather_session_evidence()` already returns full, untruncated snapshot bodies matched by exact `session_id`. The loss was **prompt-side** in Step 3, whose only instruction was advisory. Empirical calibration on the live vault also surfaced a distinct **cross-arc contamination** issue (multi-`/ship`-arc sessions carry earlier arcs' snapshots into a later retro's Evidence Consulted). Both are fixed by the same lever.

## Changes (prompt-only — no code/hook changes)

1. **New mandatory `3.0` pre-pass** at the top of Step 3: for each `bundle["snapshots"]` entry, emit a visible digest + a `RELEVANT` / `EARLIER-ARC/UNRELATED` verdict. **Default-to-`RELEVANT`** so the exclusion path can't become a new content-dropping mechanism. Runs *before* the live-buffer analysis to enforce equal/higher priority.
2. **Step 4 `## Evidence Consulted`** lists only `RELEVANT` snapshots; a `RELEVANT` snapshot with no distinct findings must be explicitly acknowledged (not silently dropped) — which also excludes earlier-arc snapshots from multi-arc retros.
3. Skill `version` bumped `1.2.0 → 1.3.0`; CHANGELOG `[Unreleased]` entry.

## Validation (manual — repo has no skill-prompt test runner)

- **Single-arc no-regress** (618a-style, 4 on-topic snapshots): all `RELEVANT`; Evidence Consulted still lists all 4; exclusion path dormant. ✓
- **Multi-arc exclusion** (5-snapshot multi-`/ship` session): earlier-arc snapshots markable `EARLIER-ARC/UNRELATED`; Evidence Consulted shrinks to the on-topic subset. ✓
- **Empty bundle**: 3.0 emits the skip notice (deduped against Step 3a's fallback) and skips; Step 4 omits Evidence Consulted. ✓

## Review

Two task-level reviews (SPEC ✅, QUALITY approved after 5 fixes) + one whole-branch review (MERGE-READY) via subagent-driven development. Architecture artifacts unchanged (data flow and `sk-retro` files/purpose unaffected).

Closes #261
